### PR TITLE
chore(cd): Vercel 자동 배포 워크플로우 구축

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,42 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+
+jobs:
+  deploy:
+    name: Vercel 배포
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Vercel CLI 설치
+        run: npm install --global vercel@latest
+
+      - name: Vercel 환경변수 Pull
+        run: vercel pull --yes --environment=${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }} --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Vercel 빌드
+        run: vercel build ${{ github.ref == 'refs/heads/main' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Vercel 배포
+        run: vercel deploy --prebuilt ${{ github.ref == 'refs/heads/main' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
## 요약

- `.github/workflows/cd.yml` 추가
- `develop` 브랜치 push → Vercel Preview 배포
- `main` 브랜치 push → Vercel Production 배포

## 머지 전 필수 작업

GitHub Repository Settings → Secrets and variables → Actions 에서 아래 시크릿 등록 필요:

| Secret 이름 | 획득 방법 |
|---|---|
| `VERCEL_TOKEN` | Vercel 대시보드 → Settings → Tokens |
| `VERCEL_ORG_ID` | `vercel link` 실행 후 `.vercel/project.json` 확인 |
| `VERCEL_PROJECT_ID` | 위 동일 |

## 테스트 플랜

- [ ] GitHub Secrets 3개 등록
- [ ] `develop`에 머지 후 Preview 배포 확인
- [ ] 추후 `main` 배포 시 Production URL 확인

closes #16