### PR TITLE
[feat] 로그인 페이지 및 인증 흐름 구현, 로고 기반 CSS 색상 단순화

### DIFF
--- a/.claude/vite-dev.mjs
+++ b/.claude/vite-dev.mjs
@@ -1,0 +1,10 @@
+import { fileURLToPath } from 'url'
+import { createRequire } from 'module'
+import { resolve } from 'path'
+
+const MAIN = 'C:/Users/jyt66/Desktop/yanus-groupware'
+const ROOT = 'C:/Users/jyt66/Desktop/yanus-groupware/.claude/worktrees/awesome-nash'
+process.chdir(ROOT)
+process.argv[1] = resolve(MAIN, 'node_modules/vite/bin/vite.js')
+
+await import('file:///' + MAIN.replace(/\\/g, '/') + '/node_modules/vite/bin/vite.js')

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
-import { AppProvider } from './context/AppContext'
+import { AppProvider, useApp } from './context/AppContext'
 import { TasksProvider } from './context/TasksContext'
 import { EventsProvider } from './context/EventsContext'
 import { ChatProvider } from './context/ChatContext'
@@ -12,6 +12,34 @@ import { Drive } from './pages/Drive'
 import { AIChat } from './pages/AIChat'
 import { Members } from './pages/Members'
 import { Settings } from './pages/Settings'
+import { Login } from './pages/Login'
+
+function AuthGuard({ children }: { children: React.ReactNode }) {
+  const { isLoggedIn } = useApp()
+  return isLoggedIn ? <>{children}</> : <Navigate to="/login" replace />
+}
+
+function AppRoutes() {
+  const { isLoggedIn } = useApp()
+  return (
+    <Routes>
+      <Route path="/login" element={isLoggedIn ? <Navigate to="/" replace /> : <Login />} />
+      <Route path="/signup" element={isLoggedIn ? <Navigate to="/" replace /> : <Login />} />
+      <Route path="/" element={<AuthGuard><Layout /></AuthGuard>}>
+        <Route index element={<Dashboard />} />
+        <Route path="chat" element={<Chat />} />
+        <Route path="calendar" element={<Calendar />} />
+        <Route path="tasks" element={<Navigate to="/calendar" replace />} />
+        <Route path="attendance" element={<Attendance />} />
+        <Route path="drive" element={<Drive />} />
+        <Route path="ai" element={<AIChat />} />
+        <Route path="members" element={<Members />} />
+        <Route path="settings" element={<Settings />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Route>
+    </Routes>
+  )
+}
 
 function App() {
   return (
@@ -20,20 +48,7 @@ function App() {
         <EventsProvider>
         <ChatProvider>
         <BrowserRouter>
-          <Routes>
-          <Route path="/" element={<Layout />}>
-            <Route index element={<Dashboard />} />
-            <Route path="chat" element={<Chat />} />
-            <Route path="calendar" element={<Calendar />} />
-            <Route path="tasks" element={<Navigate to="/calendar" replace />} />
-            <Route path="attendance" element={<Attendance />} />
-            <Route path="drive" element={<Drive />} />
-            <Route path="ai" element={<AIChat />} />
-            <Route path="members" element={<Members />} />
-            <Route path="settings" element={<Settings />} />
-            <Route path="*" element={<Navigate to="/" replace />} />
-            </Route>
-          </Routes>
+          <AppRoutes />
         </BrowserRouter>
         </ChatProvider>
         </EventsProvider>

--- a/src/components/AnimatedClockRing.tsx
+++ b/src/components/AnimatedClockRing.tsx
@@ -63,18 +63,19 @@ export function AnimatedClockRing({ status, clockIn, clockOut, now, variant = 'd
 
   const shouldRotate = variant === 'default' && status !== 'done'
 
+  // 로고 색상 기반: 파랑 #72b8e8, 보라 #9680cc, 핑크 #d44a99
   const [c0, c1, c2] = isStart
-    ? ['#22c55e', '#4ade80', '#bbf7d0'] // 출근 버튼 - 그린 톤
+    ? ['#3db87a', '#5ed4a0', '#3db87a'] // 출근 - 그린
     : isLeave
-    ? ['#f97373', '#fb7185', '#fecaca'] // 퇴근 버튼 - 레드 톤
-    : ['#9B5CFF', '#4DA3FF', '#6C7CFF'] // 기본 퍼플-블루 그라데이션
+    ? ['#e05050', '#e87070', '#e05050'] // 퇴근 - 레드
+    : ['#9680cc', '#72b8e8', '#9680cc'] // 기본 - 로고 보라→파랑
 
   const workingStops =
     variant === 'default' && status === 'working'
       ? {
-          s0: ['#9B5CFF', '#4DA3FF', '#6C7CFF', '#9B5CFF'],
-          s1: ['#4DA3FF', '#6C7CFF', '#9B5CFF', '#4DA3FF'],
-          s2: ['#6C7CFF', '#9B5CFF', '#4DA3FF', '#6C7CFF'],
+          s0: ['#9680cc', '#72b8e8', '#d44a99', '#9680cc'],
+          s1: ['#72b8e8', '#d44a99', '#9680cc', '#72b8e8'],
+          s2: ['#d44a99', '#9680cc', '#72b8e8', '#d44a99'],
         }
       : null
 

--- a/src/components/Layout.css
+++ b/src/components/Layout.css
@@ -5,8 +5,8 @@
 
 .sidebar {
   width: 200px;
-  background: #12121a;
-  border-right: 1px solid rgba(255, 255, 255, 0.06);
+  background: var(--bg-sidebar);
+  border-right: 1px solid var(--border-color);
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
@@ -71,16 +71,98 @@
 
 .nav-item:hover {
   color: var(--text-primary);
-  background: rgba(124, 58, 237, 0.15);
+  background: rgba(150, 128, 204, 0.12);
 }
 
 .nav-item.active {
-  color: var(--text-primary);
-  background: var(--accent-purple) !important;
+  color: #fff;
+  background: var(--purple) !important;
 }
 
 .nav-item.active svg {
   color: inherit;
+}
+
+.sidebar-bottom {
+  padding: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sidebar-user {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: rgba(124, 58, 237, 0.08);
+  margin-bottom: 4px;
+}
+
+.sidebar-user-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--accent-purple);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #fff;
+  flex-shrink: 0;
+}
+
+.sidebar-user-info {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.sidebar-user-name {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sidebar-user-role {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  text-transform: capitalize;
+}
+
+.sidebar-auth-btn {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background 0.2s, color 0.2s;
+  font-family: inherit;
+  width: 100%;
+  text-align: left;
+}
+
+.sidebar-auth-btn:hover {
+  background: rgba(124, 58, 237, 0.12);
+  color: var(--text-primary);
+}
+
+.sidebar-auth-btn.logout-btn:hover {
+  background: rgba(239, 68, 68, 0.1);
+  color: #ef4444;
 }
 
 .main-content {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,6 @@
-import { Home, MessageSquare, Calendar, RotateCw, FolderUp, Bot, Users, Settings } from 'lucide-react'
-import { NavLink, Outlet } from 'react-router-dom'
+import { Home, MessageSquare, Calendar, RotateCw, FolderUp, Bot, Users, Settings, LogOut, LogIn, UserPlus } from 'lucide-react'
+import { NavLink, Outlet, Link } from 'react-router-dom'
+import { useApp } from '../context/AppContext'
 import logoImg from '../assets/logo.png'
 import './Layout.css'
 
@@ -15,6 +16,8 @@ const navItems = [
 ]
 
 export function Layout() {
+  const { state, isLoggedIn, logout } = useApp()
+
   return (
     <div className="layout">
       <aside className="sidebar">
@@ -34,6 +37,34 @@ export function Layout() {
             </NavLink>
           ))}
         </nav>
+        <div className="sidebar-bottom">
+          {isLoggedIn ? (
+            <>
+              <div className="sidebar-user">
+                <span className="sidebar-user-avatar">{state.currentUser.name[0]}</span>
+                <div className="sidebar-user-info">
+                  <span className="sidebar-user-name">{state.currentUser.name}</span>
+                  <span className="sidebar-user-role">{state.currentUser.team}</span>
+                </div>
+              </div>
+              <button className="sidebar-auth-btn logout-btn" onClick={logout} title="로그아웃">
+                <LogOut size={16} />
+                <span>로그아웃</span>
+              </button>
+            </>
+          ) : (
+            <>
+              <Link to="/login" className="sidebar-auth-btn">
+                <LogIn size={16} />
+                <span>로그인</span>
+              </Link>
+              <Link to="/signup" className="sidebar-auth-btn">
+                <UserPlus size={16} />
+                <span>회원가입</span>
+              </Link>
+            </>
+          )}
+        </div>
       </aside>
       <main className="main-content">
         <Outlet />

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from 'react'
+import { createContext, useContext, useState, useEffect } from 'react'
 import type { ReactNode } from 'react'
 
 export type UserRole = 'member' | 'team_lead' | 'leader'
@@ -43,6 +43,9 @@ const AppContext = createContext<{
   personalSchedule: PersonalWorkSchedule
   setPersonalSchedule: (s: PersonalWorkSchedule) => void
   isAdmin: boolean
+  isLoggedIn: boolean
+  login: (email: string, password: string) => boolean
+  logout: () => void
 } | null>(null)
 
 export function AppProvider({ children }: { children: ReactNode }) {
@@ -51,10 +54,26 @@ export function AppProvider({ children }: { children: ReactNode }) {
     users: mockUsers,
   })
   const [personalSchedule, setPersonalSchedule] = useState<PersonalWorkSchedule>(defaultSchedule)
+  const [isLoggedIn, setIsLoggedIn] = useState(() => {
+    return localStorage.getItem('yanus-logged-in') === 'true'
+  })
   const isAdmin = state.currentUser.role === 'leader' || state.currentUser.role === 'team_lead'
 
+  useEffect(() => {
+    localStorage.setItem('yanus-logged-in', String(isLoggedIn))
+  }, [isLoggedIn])
+
+  const login = (_email: string, _password: string): boolean => {
+    setIsLoggedIn(true)
+    return true
+  }
+
+  const logout = () => {
+    setIsLoggedIn(false)
+  }
+
   return (
-    <AppContext.Provider value={{ state, personalSchedule, setPersonalSchedule, isAdmin }}>
+    <AppContext.Provider value={{ state, personalSchedule, setPersonalSchedule, isAdmin, isLoggedIn, login, logout }}>
       {children}
     </AppContext.Provider>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -1,26 +1,38 @@
 :root {
-  --bg-dark: #0d0d14;
-  --bg-darker: #08080c;
-  --bg-card: rgba(20, 18, 32, 0.85);
-  --bg-card-solid: rgba(25, 23, 40, 0.95);
-  --bg-sidebar: rgba(15, 13, 28, 0.98);
-  --text-primary: #f1f5f9;
-  --text-secondary: #94a3b8;
-  --text-muted: #64748b;
-  --accent-purple: #7c3aed;
-  --accent-purple-light: #a78bfa;
-  --accent-purple-dark: #5b21b6;
-  --accent-blue: #3b82f6;
-  --accent-cyan: #06b6d4;
-  --accent-pink: #ec4899;
-  --gradient-purple: linear-gradient(135deg, #7c3aed 0%, #a78bfa 50%, #ec4899 100%);
-  --gradient-purple-blue: linear-gradient(135deg, #7c3aed 0%, #3b82f6 100%);
-  --border-color: rgba(148, 163, 184, 0.12);
-  --success: #22c55e;
-  --warning: #eab308;
-  --error: #ef4444;
-  --sidebar-width: 240px;
-  --sidebar-narrow: 64px;
+  /* 로고 기반 핵심 색상: 하늘파랑 → 보라 → 핑크 */
+  --blue: #72b8e8;
+  --purple: #9680cc;
+  --pink: #d44a99;
+
+  /* 배경 */
+  --bg-dark: #111118;
+  --bg-card: rgba(22, 20, 34, 0.82);
+  --bg-sidebar: #0e0d16;
+
+  /* 텍스트 */
+  --text-primary: #eef0f6;
+  --text-secondary: #8e97b2;
+  --text-muted: #5a6280;
+
+  /* 액센트 (구버전 이름 호환) */
+  --accent-purple: var(--purple);
+  --accent-purple-light: #b09de0;
+  --accent-purple-dark: #7056a8;
+  --accent-blue: var(--blue);
+  --accent-cyan: #60c8e0;
+  --accent-pink: var(--pink);
+
+  /* 그라데이션 - 로고색 기반, 최소화 */
+  --gradient-logo: linear-gradient(135deg, var(--blue) 0%, var(--purple) 50%, var(--pink) 100%);
+  --gradient-purple: var(--gradient-logo);
+  --gradient-purple-blue: linear-gradient(135deg, var(--purple) 0%, var(--blue) 100%);
+
+  /* 기타 */
+  --border-color: rgba(150, 160, 200, 0.1);
+  --success: #3db87a;
+  --warning: #d4a020;
+  --error: #e05050;
+  --sidebar-width: 200px;
 }
 
 * {
@@ -40,10 +52,7 @@ body::before {
   content: '';
   position: fixed;
   inset: 0;
-  background: 
-    linear-gradient(180deg, rgba(30, 25, 55, 0.6) 0%, transparent 50%),
-    radial-gradient(ellipse 80% 50% at 50% -20%, rgba(124, 58, 237, 0.18), transparent),
-    radial-gradient(ellipse 60% 40% at 100% 100%, rgba(59, 130, 246, 0.12), transparent);
+  background: radial-gradient(ellipse 70% 40% at 50% -10%, rgba(150, 128, 204, 0.1), transparent);
   pointer-events: none;
   z-index: 0;
 }

--- a/src/pages/Dashboard.css
+++ b/src/pages/Dashboard.css
@@ -28,7 +28,7 @@
 
 .clock-card-link:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 32px rgba(124, 58, 237, 0.2);
+  box-shadow: 0 8px 24px rgba(150, 128, 204, 0.15);
 }
 
 .clock-outer {
@@ -43,7 +43,6 @@
 .clock-ring-svg {
   position: absolute;
   inset: 0;
-  filter: drop-shadow(0 0 24px rgba(124, 58, 237, 0.35));
 }
 
 .clock-inner {
@@ -110,15 +109,18 @@
 }
 
 .schedule-item.purple {
-  background: linear-gradient(90deg, rgba(124, 58, 237, 0.3) 0%, transparent 100%);
+  background: rgba(150, 128, 204, 0.12);
+  border-left: 3px solid var(--purple);
 }
 
 .schedule-item.blue {
-  background: linear-gradient(90deg, rgba(59, 130, 246, 0.25) 0%, transparent 100%);
+  background: rgba(114, 184, 232, 0.1);
+  border-left: 3px solid var(--blue);
 }
 
 .schedule-item.grey {
-  background: rgba(148, 163, 184, 0.06);
+  background: rgba(150, 160, 200, 0.05);
+  border-left: 3px solid var(--border-color);
 }
 
 .schedule-icon {
@@ -194,12 +196,13 @@
   width: 40px;
   height: 40px;
   border-radius: 50%;
-  background: var(--gradient-purple);
+  background: var(--purple);
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 0.85rem;
   font-weight: 600;
+  color: #fff;
   flex-shrink: 0;
 }
 
@@ -245,9 +248,19 @@
 
 .attendance-progress {
   margin-top: 12px;
-  height: 6px;
+  height: 5px;
   border-radius: 3px;
-  background: linear-gradient(90deg, var(--accent-purple) 0%, var(--accent-blue) 92%, transparent 92%);
+  background: rgba(150, 160, 200, 0.1);
+  overflow: hidden;
+}
+
+.attendance-progress::after {
+  content: '';
+  display: block;
+  width: 92%;
+  height: 100%;
+  background: var(--purple);
+  border-radius: 3px;
 }
 
 /* Active Members: bottom-right right */

--- a/src/pages/Login.css
+++ b/src/pages/Login.css
@@ -1,0 +1,164 @@
+.login-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.login-card {
+  width: 100%;
+  max-width: 380px;
+  padding: 40px 36px;
+  border-radius: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.login-logo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
+.login-logo-img {
+  height: 52px;
+  width: auto;
+  object-fit: contain;
+}
+
+.login-title {
+  font-size: 1.5rem;
+  font-weight: 800;
+  background: var(--gradient-purple);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin: 0;
+  line-height: 1.2;
+}
+
+.login-subtitle {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.login-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.login-field label {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.login-field input {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 11px 14px;
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  font-family: inherit;
+  width: 100%;
+  transition: border-color 0.2s;
+  outline: none;
+}
+
+.login-field input:focus {
+  border-color: var(--accent-purple);
+  background: rgba(124, 58, 237, 0.06);
+}
+
+.login-field input::placeholder {
+  color: var(--text-muted);
+}
+
+.password-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.password-wrap input {
+  padding-right: 44px;
+}
+
+.pw-toggle {
+  position: absolute;
+  right: 12px;
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  padding: 0;
+  transition: color 0.2s;
+}
+
+.pw-toggle:hover {
+  color: var(--text-secondary);
+}
+
+.login-error {
+  font-size: 0.8rem;
+  color: var(--error);
+  margin: 0;
+  padding: 8px 12px;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  border-radius: 8px;
+}
+
+.login-btn {
+  background: var(--purple);
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 12px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.1s;
+  margin-top: 4px;
+  letter-spacing: 0.03em;
+}
+
+.login-btn:hover {
+  background: var(--accent-purple-dark);
+}
+
+.login-btn:active {
+  transform: scale(0.98);
+}
+
+.signup-hint {
+  text-align: center;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.signup-link {
+  color: var(--accent-purple-light);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.signup-link:hover {
+  text-decoration: underline;
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react'
+import { useNavigate, Link } from 'react-router-dom'
+import { Eye, EyeOff } from 'lucide-react'
+import { useApp } from '../context/AppContext'
+import logoImg from '../assets/logo.png'
+import './Login.css'
+
+export function Login() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+  const [error, setError] = useState('')
+  const { login } = useApp()
+  const navigate = useNavigate()
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!email.trim() || !password.trim()) {
+      setError('이메일과 비밀번호를 입력해 주세요.')
+      return
+    }
+    login(email, password)
+    navigate('/')
+  }
+
+  return (
+    <div className="login-page">
+      <div className="login-card glass">
+        <div className="login-logo">
+          <img src={logoImg} alt="yANUs" className="login-logo-img" />
+          <h1 className="login-title">yANUs</h1>
+          <p className="login-subtitle">동아리 그룹웨어</p>
+        </div>
+
+        <form className="login-form" onSubmit={handleSubmit}>
+          <div className="login-field">
+            <label>이메일</label>
+            <input
+              type="email"
+              placeholder="name@example.com"
+              value={email}
+              onChange={(e) => { setEmail(e.target.value); setError('') }}
+            />
+          </div>
+
+          <div className="login-field">
+            <label>비밀번호</label>
+            <div className="password-wrap">
+              <input
+                type={showPassword ? 'text' : 'password'}
+                placeholder="비밀번호를 입력하세요"
+                value={password}
+                onChange={(e) => { setPassword(e.target.value); setError('') }}
+              />
+              <button
+                type="button"
+                className="pw-toggle"
+                onClick={() => setShowPassword((v) => !v)}
+                tabIndex={-1}
+              >
+                {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+              </button>
+            </div>
+          </div>
+
+          {error && <p className="login-error">{error}</p>}
+
+          <button type="submit" className="login-btn">로그인</button>
+        </form>
+
+        <p className="signup-hint">
+          아직 계정이 없으신가요?{' '}
+          <Link to="/signup" className="signup-link">회원가입</Link>
+        </p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **로그인 페이지** (`Login.tsx` / `Login.css`): 이메일·비밀번호 입력, 비밀번호 표시 토글, 로그인 후 대시보드 이동
- **인증 흐름** (`AppContext`, `App.tsx`): `isLoggedIn` 상태 + localStorage 연동, 미로그인 시 `/login` 자동 리다이렉트, AuthGuard 적용
- **Layout 사이드바** (`Layout.tsx` / `Layout.css`): 하단에 유저 프로필(이름·팀) + 로그아웃 버튼 추가
- **CSS 색상 단순화** (`index.css`, `Dashboard.css`, `AnimatedClockRing.tsx`): 로고 3색(파랑 `#72b8e8` · 보라 `#9680cc` · 핑크 `#d44a99`) 기반으로 변수 정리, 과도한 그라데이션 제거, 스케줄 아이템을 단색 좌측 보더 스타일로 변경
- **Dev 서버 설정** (`.claude/vite-dev.mjs`): worktree 경로를 올바르게 서빙하도록 수정

## Test plan

- [ ] `/login` 접근 시 로그인 폼 표시 확인
- [ ] 이메일·비밀번호 입력 후 로그인 → `/` 대시보드 이동 확인
- [ ] 미로그인 상태에서 `/` 접근 시 `/login` 리다이렉트 확인
- [ ] 로그아웃 버튼 클릭 → `/login` 이동 확인
- [ ] 사이드바 하단 유저 정보(이름·팀) 표시 확인
- [ ] 대시보드 색상이 로고 기반 단순 팔레트로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)