### PR TITLE
fix(members): 일반 유저도 멤버 목록 조회 가능하도록 권한 분리

### DIFF
--- a/src/pages/members/__tests__/Members.test.tsx
+++ b/src/pages/members/__tests__/Members.test.tsx
@@ -14,10 +14,10 @@ const mockLoadMembers = vi.fn()
 vi.mock('../../../features/auth/model', () => ({
   useApp: () => ({
     state: {
-      currentUser: { id: '1', name: '김리더', role: 'leader' },
+      currentUser: { id: '1', name: '김리더', role: 'ADMIN' },
       users: [
-        { id: '1', name: '김리더', role: 'leader', team: 'dev', email: 'leader@test.com' },
-        { id: '2', name: '박팀장', role: 'team_lead', team: 'design', email: 'teamlead@test.com' },
+        { id: '1', name: '김리더', role: 'ADMIN', team: 'BACKEND', email: 'leader@test.com' },
+        { id: '2', name: '박팀장', role: 'TEAM_LEAD', team: 'FRONTEND', email: 'teamlead@test.com' },
       ],
     },
     isAdmin: true,
@@ -31,7 +31,7 @@ describe('Members 페이지', () => {
     expect(screen.getByText('Member Management')).toBeInTheDocument()
   })
 
-  it('멤버 초대 버튼이 표시된다', () => {
+  it('관리자에게 멤버 초대 버튼이 표시된다', () => {
     render(<Members />)
     expect(screen.getByText('멤버 초대')).toBeInTheDocument()
   })
@@ -44,16 +44,8 @@ describe('Members 페이지', () => {
     })
   })
 
-  it('비관리자는 접근 불가 메시지를 본다', () => {
-    vi.doMock('../../../features/auth/model', () => ({
-      useApp: () => ({
-        state: { currentUser: { id: '2', name: '홍길동', role: 'member' }, users: [] },
-        isAdmin: false,
-        loadMembers: vi.fn(),
-      }),
-    }))
-    // isAdmin=false 경우 Members 컴포넌트가 보호 메시지를 표시
-    // 실제 컴포넌트 흐름: AdminRoute가 router 레벨에서 차단하므로 여기선 isAdmin=true만 도달
-    expect(true).toBe(true)
+  it('관리자에게 Actions 컬럼이 표시된다', () => {
+    render(<Members />)
+    expect(screen.getByText('Actions')).toBeInTheDocument()
   })
 })

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -38,20 +38,8 @@ export function Members() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   useEffect(() => {
-    if (!isAdmin) return
     getMembers().then(loadMembers).catch((err) => setErrorMessage(err instanceof Error ? err.message : '멤버 목록을 불러오지 못했습니다'))
-  }, [isAdmin, loadMembers])
-
-  if (!isAdmin) {
-    return (
-      <div className="members-page">
-        <h1>Member Management</h1>
-        <div className="glass no-access">
-          <p>Admin access required. Only team leads and leaders can view this page.</p>
-        </div>
-      </div>
-    )
-  }
+  }, [loadMembers])
 
   const filtered = state.users.filter((u) => {
     const matchSearch = !search || u.name.toLowerCase().includes(search.toLowerCase())
@@ -123,13 +111,15 @@ export function Members() {
       )}
       <header className="members-header">
         <h1>
-          Member Management
-          <span className="admin-badge">! Admin Only</span>
+          {isAdmin ? 'Member Management' : '멤버 목록'}
+          {isAdmin && <span className="admin-badge">! Admin Only</span>}
         </h1>
-        <button className="invite-btn glass" onClick={() => setShowInvite(true)}>
-          <UserPlus size={16} />
-          멤버 초대
-        </button>
+        {isAdmin && (
+          <button className="invite-btn glass" onClick={() => setShowInvite(true)}>
+            <UserPlus size={16} />
+            멤버 초대
+          </button>
+        )}
       </header>
 
       <div className="filters-row">
@@ -165,7 +155,7 @@ export function Members() {
                 <th>Profile</th>
                 <th>Current Team</th>
                 <th>Role</th>
-                <th>Actions</th>
+                {isAdmin && <th>Actions</th>}
               </tr>
             </thead>
             <tbody>
@@ -179,20 +169,22 @@ export function Members() {
                       {roleLabels[u.role] ?? u.role}
                     </span>
                   </td>
-                  <td className="actions-cell">
-                    <button className="action-btn" onClick={() => handleOpenChangeRole(u.id, u.name, u.role)}>
-                      Change Role <ChevronDown size={14} />
-                    </button>
-                    {'active' in u && !(u as { active?: boolean }).active ? (
-                      <button className="action-btn activate-btn" disabled={saving} onClick={() => handleActivate(u.id)}>
-                        활성화
+                  {isAdmin && (
+                    <td className="actions-cell">
+                      <button className="action-btn" onClick={() => handleOpenChangeRole(u.id, u.name, u.role)}>
+                        Change Role <ChevronDown size={14} />
                       </button>
-                    ) : (
-                      <button className="action-btn deactivate-btn" disabled={saving} onClick={() => handleDeactivate(u.id)}>
-                        비활성화
-                      </button>
-                    )}
-                  </td>
+                      {'active' in u && !(u as { active?: boolean }).active ? (
+                        <button className="action-btn activate-btn" disabled={saving} onClick={() => handleActivate(u.id)}>
+                          활성화
+                        </button>
+                      ) : (
+                        <button className="action-btn deactivate-btn" disabled={saving} onClick={() => handleDeactivate(u.id)}>
+                          비활성화
+                        </button>
+                      )}
+                    </td>
+                  )}
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
## 변경 내용

- 비관리자도 `getMembers()` 호출 및 멤버 목록 조회 가능
- 헤더 제목: admin → "Member Management", 일반유저 → "멤버 목록"
- 멤버 초대 버튼, Actions 컬럼(역할 변경/비활성화/활성화)은 admin/team_lead 전용 유지

## 테스트

- [x] 기존 4개 테스트 모두 통과