### PR TITLE
fix(dashboard): 더미 데이터 제거 및 실제 API 연동, 출근 버튼 UX 개선

### DIFF
--- a/src/pages/dashboard/__tests__/Dashboard.test.tsx
+++ b/src/pages/dashboard/__tests__/Dashboard.test.tsx
@@ -9,18 +9,42 @@ vi.mock('../../../features/attendance/model/useWorkSession', () => ({
     clockIn: null,
     clockOut: null,
     handleClockClick: vi.fn(),
-  }),
-}))
-
-vi.mock('../../../features/auth/model', () => ({
-  useApp: () => ({
-    state: { currentUser: { id: '1', name: '홍길동', role: 'member' }, users: [] },
-    isAdmin: false,
+    errorMessage: null,
+    toastType: 'info',
+    clearError: vi.fn(),
+    isLoading: false,
   }),
 }))
 
 vi.mock('../../../features/attendance/ui', () => ({
-  AnimatedClockRing: ({ children }: { children: React.ReactNode }) => <div data-testid="clock-ring">{children}</div>,
+  AnimatedClockRing: () => <div data-testid="clock-ring" />,
+}))
+
+vi.mock('../../../features/calendar/model/EventsProvider', () => ({
+  useEvents: () => ({
+    getEventsByDate: () => [],
+    events: [],
+  }),
+}))
+
+vi.mock('../../../features/chat/model/ChatProvider', () => ({
+  useChat: () => ({
+    channels: [{ id: '1', name: '일반' }],
+    activeChannelId: '1',
+    getMessagesByChannel: () => [],
+  }),
+}))
+
+vi.mock('../../../features/tasks/model/TasksProvider', () => ({
+  useTasks: () => ({
+    getTasksByDate: () => [],
+    tasks: [],
+    isLoading: false,
+  }),
+}))
+
+vi.mock('../../../shared/lib/date', () => ({
+  getTodayStr: () => '2026-03-23',
 }))
 
 describe('Dashboard 페이지', () => {
@@ -46,13 +70,40 @@ describe('Dashboard 페이지', () => {
     expect(screen.getByText('출근')).toBeInTheDocument()
   })
 
-  it('스케줄 카드와 팀 채팅 카드가 렌더링된다', () => {
+  it('오늘 일정 카드가 렌더링된다', () => {
     render(
       <MemoryRouter>
         <Dashboard />
       </MemoryRouter>
     )
-    expect(screen.getByText("Today's Schedule")).toBeInTheDocument()
-    expect(screen.getByText('Team Chat')).toBeInTheDocument()
+    expect(screen.getByText('오늘 일정')).toBeInTheDocument()
+  })
+
+  it('일정이 없을 때 빈 상태 메시지를 표시한다', () => {
+    render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>
+    )
+    expect(screen.getByText('오늘 등록된 일정이 없습니다')).toBeInTheDocument()
+  })
+
+  it('오늘 할 일 카드가 렌더링된다', () => {
+    render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>
+    )
+    expect(screen.getByText('오늘 할 일')).toBeInTheDocument()
+  })
+
+  it('채팅 미리보기 카드가 렌더링된다', () => {
+    render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>
+    )
+    // activeChannel name이 표시되거나 채팅 열기 링크가 있어야 함
+    expect(screen.getByText('채팅 열기')).toBeInTheDocument()
   })
 })

--- a/src/pages/dashboard/dashboard.css
+++ b/src/pages/dashboard/dashboard.css
@@ -2,33 +2,41 @@
   max-width: 1200px;
 }
 
+/* ── 그리드: 3칸 2줄 ── */
 .dashboard-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: 260px 1fr 1fr;
   grid-template-rows: auto auto;
   gap: 20px;
 }
 
-/* Clock-In: top-left */
+/* 클락 카드: 1열 전체 높이 */
 .clock-card {
   grid-column: 1;
-  grid-row: 1;
+  grid-row: 1 / 3;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: 260px;
+  gap: 12px;
+  min-height: 380px;
 }
 
 .clock-card-link {
   text-decoration: none;
   color: inherit;
   transition: transform 0.2s, box-shadow 0.2s;
+  cursor: pointer;
 }
 
-.clock-card-link:hover {
+.clock-card-link:hover:not(:disabled) {
   transform: translateY(-2px);
-  box-shadow: 0 8px 24px rgba(150, 128, 204, 0.15);
+  box-shadow: 0 8px 24px rgba(150, 128, 204, 0.18);
+}
+
+.clock-card-loading {
+  cursor: default;
+  opacity: 0.85;
 }
 
 .clock-outer {
@@ -64,63 +72,105 @@
 }
 
 .clock-time-start {
-  font-size: 1.4rem;
+  font-size: 1.3rem;
   color: var(--success);
 }
 
 .clock-time-leave {
+  font-size: 1.3rem;
+  color: #e05050;
+}
+
+.clock-time-done {
+  font-size: 1.2rem;
+  color: var(--text-secondary);
+}
+
+.clock-time-loading {
+  font-size: 1.5rem;
+  color: var(--text-secondary);
+}
+
+.clock-duration {
   font-size: 1.4rem;
-  color: var(--error);
-}
-
-.clock-label {
-  margin-top: 14px;
+  font-weight: 600;
   color: var(--text-primary);
-  font-size: 0.95rem;
+  letter-spacing: 2px;
+  font-variant-numeric: tabular-nums;
 }
 
+.clock-hint {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+/* 오늘 일정: 2열 1행 */
+.schedule-card {
+  grid-column: 2 / 4;
+  grid-row: 1;
+}
+
+/* 채팅: 2열 2행 */
+.chat-preview {
+  grid-column: 2;
+  grid-row: 2;
+}
+
+/* 할 일: 3열 2행 */
+.tasks-card {
+  grid-column: 3;
+  grid-row: 2;
+}
+
+/* ── 공통 카드 ── */
 .card {
   padding: 24px;
 }
 
-.schedule-card h3,
-.chat-preview h3,
-.stats-card h3,
-.members-card h3 {
-  font-size: 1rem;
+.card h3 {
+  font-size: 0.95rem;
   font-weight: 600;
   margin-bottom: 16px;
   color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
+/* ── 빈 상태 ── */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 20px 0;
+}
+
+.empty-state p {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+/* ── 일정 목록 ── */
 .schedule-card ul {
   list-style: none;
   padding: 0;
   margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .schedule-item {
   display: flex;
-  gap: 14px;
+  gap: 12px;
   align-items: flex-start;
-  padding: 12px 14px;
+  padding: 10px 14px;
   border-radius: 8px;
-  margin-bottom: 6px;
 }
 
 .schedule-item.purple {
-  background: rgba(150, 128, 204, 0.12);
-  border-left: 3px solid var(--purple);
-}
-
-.schedule-item.blue {
-  background: rgba(114, 184, 232, 0.1);
-  border-left: 3px solid var(--blue);
-}
-
-.schedule-item.grey {
-  background: rgba(150, 160, 200, 0.05);
-  border-left: 3px solid var(--border-color);
+  background: rgba(150, 128, 204, 0.1);
+  border-left: 3px solid var(--accent-purple);
 }
 
 .schedule-icon {
@@ -137,20 +187,15 @@
 
 .schedule-time {
   color: var(--text-secondary);
-  font-size: 0.82rem;
+  font-size: 0.78rem;
 }
 
 .schedule-title {
-  font-size: 0.95rem;
+  font-size: 0.92rem;
   color: var(--text-primary);
 }
 
-/* Team Chat: bottom-left */
-.chat-preview {
-  grid-column: 1;
-  grid-row: 2;
-}
-
+/* ── 채팅 미리보기 ── */
 .chat-preview ul {
   list-style: none;
   padding: 0;
@@ -159,8 +204,8 @@
 
 .chat-preview li {
   display: flex;
-  gap: 14px;
-  padding: 12px 0;
+  gap: 12px;
+  padding: 10px 0;
   border-bottom: 1px solid var(--border-color);
   font-size: 0.9rem;
 }
@@ -174,33 +219,40 @@
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  gap: 8px;
+  gap: 6px;
+  min-width: 0;
 }
 
 .chat-msg-content strong {
-  margin-right: 4px;
+  font-size: 0.88rem;
+  flex-shrink: 0;
 }
 
 .msg-text {
   flex: 1;
   color: var(--text-secondary);
+  font-size: 0.88rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
 }
 
 .ts {
   color: var(--text-muted);
-  font-size: 0.8rem;
-  margin-left: auto;
+  font-size: 0.75rem;
+  flex-shrink: 0;
 }
 
 .avatar {
-  width: 40px;
-  height: 40px;
+  width: 36px;
+  height: 36px;
   border-radius: 50%;
-  background: var(--purple);
+  background: var(--accent-purple);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.85rem;
+  font-size: 0.82rem;
   font-weight: 600;
   color: #fff;
   flex-shrink: 0;
@@ -208,112 +260,79 @@
 
 .view-all {
   display: block;
-  margin-top: 16px;
-  text-align: center;
-  color: var(--accent-purple-light);
-  font-size: 0.9rem;
+  margin-top: 14px;
+  color: var(--accent-purple-light, #b39ddb);
+  font-size: 0.85rem;
+  text-decoration: none;
+  transition: color 0.2s;
 }
 
-/* Attendance Rate: bottom-center */
-.stats-card {
-  grid-column: 2;
-  grid-row: 2;
-}
-
-
-.big-stat {
-  font-size: 2.5rem;
-  font-weight: 700;
+.view-all:hover {
   color: var(--text-primary);
 }
 
-.stats-card .big-stat {
-  margin-bottom: 12px;
-}
-
-.stat-tabs {
+/* ── 할 일 목록 ── */
+.tasks-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
   display: flex;
-  gap: 16px;
+  flex-direction: column;
+  gap: 10px;
 }
 
-.stat-tabs span {
+.task-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+}
+
+.task-item.done .task-title {
+  text-decoration: line-through;
   color: var(--text-secondary);
-  font-size: 0.875rem;
 }
 
-.stat-tabs span.active {
-  color: var(--accent-purple-light);
-  font-weight: 600;
+.task-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 
-.attendance-progress {
-  margin-top: 12px;
-  height: 5px;
-  border-radius: 3px;
-  background: rgba(150, 160, 200, 0.1);
+.task-title {
+  flex: 1;
+  white-space: nowrap;
   overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.attendance-progress::after {
-  content: '';
-  display: block;
-  width: 92%;
-  height: 100%;
-  background: var(--purple);
-  border-radius: 3px;
-}
-
-/* Active Members: bottom-right right */
-.members-card {
-  grid-column: 2;
-  grid-row: 2;
-}
-
-.schedule-card {
-  grid-column: 2 / 4;
-  grid-row: 1;
-}
-
-.members-card {
-  grid-column: 3;
-  grid-row: 2;
-}
-
-.members-card .up {
+.task-done-badge {
+  font-size: 0.72rem;
   color: var(--success);
-  font-size: 0.9rem;
-  margin-left: 4px;
+  border: 1px solid var(--success);
+  border-radius: 4px;
+  padding: 1px 6px;
+  flex-shrink: 0;
 }
 
-.members-card .increase {
-  font-size: 0.85rem;
-  color: var(--success);
-  margin-left: 2px;
-}
-
-.members-card p {
-  color: var(--text-secondary);
-  font-size: 0.9rem;
-  margin-top: 4px;
-}
-
-.members-card .total {
-  color: var(--text-muted);
-  font-size: 0.85rem;
-}
-
+/* ── 반응형 ── */
 @media (max-width: 900px) {
   .dashboard-grid {
     grid-template-columns: 1fr;
     grid-template-rows: auto;
   }
 
-  .schedule-card,
   .clock-card,
+  .schedule-card,
   .chat-preview,
-  .stats-card,
-  .members-card {
+  .tasks-card {
     grid-column: 1;
     grid-row: auto;
+  }
+
+  .clock-card {
+    min-height: 280px;
   }
 }

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -1,8 +1,12 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { Calendar, Clock, Users, User } from 'lucide-react'
+import { Calendar, CheckSquare } from 'lucide-react'
 import { AnimatedClockRing } from '../../features/attendance/ui'
 import { useWorkSession } from '../../features/attendance/model/useWorkSession'
+import { useEvents } from '../../features/calendar/model/EventsProvider'
+import { useChat } from '../../features/chat/model/ChatProvider'
+import { useTasks } from '../../features/tasks/model/TasksProvider'
+import { getTodayStr } from '../../shared/lib/date'
 import { Toast } from '../../shared/ui/Toast'
 import './dashboard.css'
 
@@ -14,34 +18,71 @@ function formatDuration(ms: number) {
   return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`
 }
 
+function formatTime(t: string) {
+  // "HH:mm" → "오전/오후 H:mm"
+  const [h, m] = t.split(':').map(Number)
+  const period = h >= 12 ? '오후' : '오전'
+  const h12 = h % 12 || 12
+  return `${period} ${h12}:${String(m).padStart(2, '0')}`
+}
+
+function formatMsgTime(date: Date) {
+  const h = date.getHours()
+  const m = date.getMinutes()
+  const period = h >= 12 ? '오후' : '오전'
+  const h12 = h % 12 || 12
+  return `${period} ${h12}:${String(m).padStart(2, '0')}`
+}
+
+const priorityColors: Record<string, string> = {
+  high: 'var(--error)',
+  medium: 'var(--accent-purple)',
+  low: 'var(--text-secondary)',
+}
+
 export function Dashboard() {
   const [now, setNow] = useState(() => new Date())
-  const [hover, setHover] = useState(false)
-  const { status, clockIn, clockOut, handleClockClick, errorMessage, toastType, clearError } = useWorkSession()
+  const { status, clockIn, clockOut, handleClockClick, errorMessage, toastType, clearError, isLoading } =
+    useWorkSession()
+  const { getEventsByDate } = useEvents()
+  const { channels, getMessagesByChannel, activeChannelId } = useChat()
+  const { getTasksByDate } = useTasks()
+
+  const today = getTodayStr()
+  const todayEvents = getEventsByDate(today)
+  const recentMessages = getMessagesByChannel(activeChannelId).slice(-3)
+  const todayTasks = getTasksByDate(today)
+  const activeChannel = channels.find((c) => c.id === activeChannelId)
 
   useEffect(() => {
     const id = setInterval(() => setNow(new Date()), 1000)
     return () => clearInterval(id)
   }, [])
 
+  // 클락 카드 중앙 텍스트
   let centerText = ''
   let centerClass = 'clock-time'
 
-  if (status === 'idle') {
+  if (isLoading) {
+    centerText = '...'
+    centerClass += ' clock-time-loading'
+  } else if (status === 'idle') {
     centerText = '출근'
     centerClass += ' clock-time-start'
   } else if (status === 'working') {
-    if (hover) {
-      centerText = '퇴근'
-      centerClass += ' clock-time-leave'
-    } else {
-      const base = clockIn ? now.getTime() - clockIn.getTime() : 0
-      centerText = formatDuration(base)
-    }
+    centerText = '퇴근'
+    centerClass += ' clock-time-leave'
   } else {
-    const base = clockIn && clockOut ? clockOut.getTime() - clockIn.getTime() : 0
-    centerText = formatDuration(base)
+    centerText = '완료'
+    centerClass += ' clock-time-done'
   }
+
+  const workedDuration =
+    status === 'working' && clockIn
+      ? formatDuration(now.getTime() - clockIn.getTime())
+      : status === 'done' && clockIn && clockOut
+      ? formatDuration(clockOut.getTime() - clockIn.getTime())
+      : null
 
   return (
     <div className="dashboard">
@@ -49,12 +90,12 @@ export function Dashboard() {
         <Toast message={errorMessage} type={toastType} onClose={clearError} />
       )}
       <div className="dashboard-grid">
+        {/* 출퇴근 버튼 */}
         <button
           type="button"
-          className="card clock-card glass clock-card-link"
-          onClick={handleClockClick}
-          onMouseEnter={() => setHover(true)}
-          onMouseLeave={() => setHover(false)}
+          className={`card clock-card glass clock-card-link ${isLoading ? 'clock-card-loading' : ''}`}
+          onClick={isLoading ? undefined : handleClockClick}
+          disabled={isLoading}
         >
           <div className="clock-outer">
             <AnimatedClockRing
@@ -62,100 +103,110 @@ export function Dashboard() {
               clockIn={clockIn}
               clockOut={clockOut}
               now={now}
-              variant={status === 'idle' ? 'start' : status === 'working' && hover ? 'leave' : 'default'}
+              variant={
+                isLoading ? 'default'
+                : status === 'idle' ? 'start'
+                : status === 'working' ? 'leave'
+                : 'default'
+              }
             />
             <div className="clock-inner">
               <span className={centerClass}>{centerText}</span>
             </div>
           </div>
+          {workedDuration && (
+            <span className="clock-duration">{workedDuration}</span>
+          )}
+          {!isLoading && status === 'idle' && (
+            <span className="clock-hint">클릭하여 출근</span>
+          )}
         </button>
 
+        {/* 오늘 일정 */}
         <div className="card schedule-card glass">
-          <h3>Today's Schedule</h3>
-          <ul>
-            <li className="schedule-item purple">
-              <Calendar size={18} className="schedule-icon" />
-              <div>
-                <span className="schedule-time">10:00 AM</span>
-                <span className="schedule-title">Club Meeting</span>
-              </div>
-            </li>
-            <li className="schedule-item grey">
-              <Clock size={18} className="schedule-icon" />
-              <div>
-                <span className="schedule-time">12:00 PM</span>
-                <span className="schedule-title">Lunch Break</span>
-              </div>
-            </li>
-            <li className="schedule-item blue">
-              <Users size={18} className="schedule-icon" />
-              <div>
-                <span className="schedule-time">02:00 PM</span>
-                <span className="schedule-title">Project Sync</span>
-              </div>
-            </li>
-            <li className="schedule-item purple">
-              <User size={18} className="schedule-icon" />
-              <div>
-                <span className="schedule-time">04:30 PM</span>
-                <span className="schedule-title">Design Review</span>
-              </div>
-            </li>
-          </ul>
+          <h3>
+            <Calendar size={16} />
+            오늘 일정
+          </h3>
+          {todayEvents.length === 0 ? (
+            <div className="empty-state">
+              <p>오늘 등록된 일정이 없습니다</p>
+              <Link to="/calendar" className="view-all">캘린더 보기</Link>
+            </div>
+          ) : (
+            <ul>
+              {todayEvents.slice(0, 4).map((ev) => (
+                <li key={ev.id} className="schedule-item purple">
+                  <Calendar size={16} className="schedule-icon" />
+                  <div>
+                    <span className="schedule-time">
+                      {formatTime(ev.startTime)} – {formatTime(ev.endTime)}
+                    </span>
+                    <span className="schedule-title">{ev.title}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+          {todayEvents.length > 4 && (
+            <Link to="/calendar" className="view-all">+{todayEvents.length - 4}개 더 보기</Link>
+          )}
         </div>
 
+        {/* 채팅 미리보기 */}
         <div className="card chat-preview glass">
-          <h3>Team Chat</h3>
-          <ul>
-            <li>
-              <span className="avatar">S</span>
-              <div className="chat-msg-content">
-                <strong>Sarah Chen</strong>
-                <span className="msg-text">Can we review the proposal?</span>
-                <span className="ts">09:05 AM</span>
-              </div>
-            </li>
-            <li>
-              <span className="avatar">A</span>
-              <div className="chat-msg-content">
-                <strong>Alex Johnson</strong>
-                <span className="msg-text">Shared the latest files.</span>
-                <span className="ts">08:50 AM</span>
-              </div>
-            </li>
-            <li>
-              <span className="avatar">D</span>
-              <div className="chat-msg-content">
-                <strong>David Lee</strong>
-                <span className="msg-text">Good morning everyone!</span>
-                <span className="ts">08:45 AM</span>
-              </div>
-            </li>
-          </ul>
-          <Link to="/chat" className="view-all">
-            View All
-          </Link>
+          <h3>
+            {activeChannel ? `# ${activeChannel.name}` : '팀 채팅'}
+          </h3>
+          {recentMessages.length === 0 ? (
+            <div className="empty-state">
+              <p>최근 메시지가 없습니다</p>
+            </div>
+          ) : (
+            <ul>
+              {recentMessages.map((msg) => (
+                <li key={msg.id}>
+                  <span className="avatar">{msg.userName[0]}</span>
+                  <div className="chat-msg-content">
+                    <strong>{msg.userName}</strong>
+                    <span className="msg-text">{msg.content ?? '(파일)'}</span>
+                    <span className="ts">{formatMsgTime(msg.timestamp)}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+          <Link to="/chat" className="view-all">채팅 열기</Link>
         </div>
 
-        <div className="card stats-card glass">
-          <h3>Attendance Rate</h3>
-          <div className="big-stat">92%</div>
-          <div className="stat-tabs">
-            <span className="active">Today</span>
-            <span>Last Week</span>
-          </div>
-          <div className="attendance-progress" />
-        </div>
-
-        <div className="card members-card glass">
-          <h3>Active Members</h3>
-          <div className="big-stat">
-            45
-            <span className="up">↑</span>
-            <span className="increase">7</span>
-          </div>
-          <p>45 Online</p>
-          <p className="total">108 Total</p>
+        {/* 오늘 할 일 */}
+        <div className="card tasks-card glass">
+          <h3>
+            <CheckSquare size={16} />
+            오늘 할 일
+          </h3>
+          {todayTasks.length === 0 ? (
+            <div className="empty-state">
+              <p>오늘 등록된 할 일이 없습니다</p>
+              <Link to="/calendar" className="view-all">할 일 보기</Link>
+            </div>
+          ) : (
+            <ul className="tasks-list">
+              {todayTasks.slice(0, 5).map((task) => (
+                <li key={task.id} className={`task-item ${task.done ? 'done' : ''}`}>
+                  <span
+                    className="task-dot"
+                    style={{ background: priorityColors[task.priority] }}
+                  />
+                  <span className="task-title">{task.title}</span>
+                  {task.done && <span className="task-done-badge">완료</span>}
+                </li>
+              ))}
+            </ul>
+          )}
+          {todayTasks.length > 5 && (
+            <Link to="/calendar" className="view-all">+{todayTasks.length - 5}개 더 보기</Link>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 변경 내용

### 더미 데이터 제거 및 실제 데이터 연동

| 카드 | 변경 전 | 변경 후 |
|------|---------|---------|
| 오늘 일정 | 하드코딩 4개 항목 | `useEvents()` → 오늘 날짜 이벤트 |
| 팀 채팅 | 하드코딩 3개 메시지 | `useChat()` → 활성 채널 최근 메시지 |
| 출석률 카드 (92%) | 제거 | — |
| 활성 멤버 카드 (45/108) | 제거 | → 오늘 할 일 카드 (`useTasks()`) |

### 출근 버튼 UX 개선

- `isLoading` 상태 활용: API 처리 중 버튼 비활성화 + "..." 표시
- working 상태: 중앙 텍스트를 타이머("00:00") → **"퇴근"** (항상 표시)
- 근무 시간 타이머는 링 아래 별도 표시 (`clock-duration`)
- done 상태: "완료" 텍스트 + 총 근무 시간 표시

### 그리드 레이아웃 변경

```
이전: clock | schedule(2칸) / chat | stats | members
이후: clock(2행) | schedule(2칸) / chat | tasks
```

## 테스트

- [x] 6개 대시보드 테스트 통과