### PR TITLE
fix(attendance): 비관리자 근무 일정 카드 레이아웃 및 시간 입력 표시 개선

### DIFF
--- a/src/features/attendance/ui/SetWorkDaysPersonal.css
+++ b/src/features/attendance/ui/SetWorkDaysPersonal.css
@@ -132,8 +132,8 @@
   background: rgba(15, 15, 26, 0.5);
   color: var(--text-primary);
   font-size: 0.85rem;
-  width: 115px;
-  min-width: 100px;
+  width: 150px;
+  color-scheme: dark;
   transition: border-color 0.2s;
 }
 

--- a/src/pages/attendance/attendance.css
+++ b/src/pages/attendance/attendance.css
@@ -68,7 +68,7 @@
 
 .two-cards-row.single {
   grid-template-columns: 1fr;
-  max-width: 500px;
+  max-width: 700px;
 }
 
 .set-work-days-section {


### PR DESCRIPTION
## 수정 내용

- **근무 일정 카드 너비 확장**: 비관리자 유저의 근무 일정 설정 카드가 `max-width: 500px`으로 제한되어 우측에 빈 공간이 생기는 문제 수정 → `max-width: 700px`으로 확대
- **시간 입력 표시 개선**: `input[type="time"]` 너비를 115px → 150px으로 확대하고 `color-scheme: dark` 추가하여 macOS/Chrome 한국어 로케일에서 "오전 HH:MM" 전체가 잘리지 않고 표시되도록 수정

## 테스트 계획

- [ ] 일반 유저로 출퇴근 페이지 접속 후 근무 일정 설정 카드가 넓게 표시되는지 확인
- [ ] 시간 입력에서 "오전 09:00", "오후 06:00" 형식으로 분까지 표시되는지 확인

관련 이슈: 출퇴근 페이지 UI 개선