### PR TITLE
fix(ui): 홈 빈 공간, 출퇴근 가로 배치, 멤버 필터, 페이지 제목 한국어

### DIFF
--- a/src/features/attendance/ui/SetWorkDaysPersonal.css
+++ b/src/features/attendance/ui/SetWorkDaysPersonal.css
@@ -1,37 +1,50 @@
+.set-work-days-personal {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.schedule-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
 .set-work-days-personal h3 {
   font-size: 1.1rem;
-  margin-bottom: 6px;
+  margin-bottom: 4px;
 }
 
 .set-work-days-personal .desc {
   color: var(--text-secondary);
   font-size: 0.85rem;
-  margin-bottom: 16px;
 }
 
 .member-info {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 20px;
+  gap: 8px;
+  flex-shrink: 0;
 }
 
 .member-avatar {
-  width: 36px;
-  height: 36px;
+  width: 32px;
+  height: 32px;
   border-radius: 50%;
   background: var(--gradient-purple);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.85rem;
+  font-size: 0.82rem;
   font-weight: 600;
   flex-shrink: 0;
 }
 
 .member-name {
   font-weight: 500;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
 }
 
 .schedule-loading {
@@ -40,43 +53,58 @@
   padding: 12px 0;
 }
 
-.day-schedule-list {
-  display: flex;
-  flex-direction: column;
+/* ── 가로 배치 그리드 ── */
+.day-schedule-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
   gap: 10px;
+  overflow-x: auto;
 }
 
-.day-schedule-row {
+.day-col {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 12px;
-  padding: 10px 12px;
-  border-radius: 10px;
+  gap: 10px;
+  padding: 14px 8px;
+  border-radius: 12px;
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid transparent;
   transition: border-color 0.2s, background 0.2s;
+  min-width: 80px;
 }
 
-.day-schedule-row.active {
+.day-col.active {
   background: rgba(139, 92, 246, 0.08);
   border-color: rgba(139, 92, 246, 0.2);
 }
 
+.day-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.day-col.active .day-label {
+  color: var(--text-primary);
+}
+
 .toggle {
-  width: 40px;
-  height: 22px;
-  border-radius: 11px;
+  width: 36px;
+  height: 20px;
+  border-radius: 10px;
   background: rgba(148, 163, 184, 0.3);
   position: relative;
   transition: background 0.2s;
   flex-shrink: 0;
+  cursor: pointer;
 }
 
 .toggle::after {
   content: '';
   position: absolute;
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   border-radius: 50%;
   background: var(--text-primary);
   top: 3px;
@@ -90,50 +118,41 @@
 }
 
 .toggle.on::after {
-  transform: translateX(18px);
+  transform: translateX(16px);
 }
 
-.day-label {
-  font-size: 0.8rem;
-  font-weight: 500;
-  color: var(--text-secondary);
-  width: 28px;
-  flex-shrink: 0;
-}
-
-.day-schedule-row.active .day-label {
-  color: var(--text-primary);
-}
-
+/* 시간 필드 — 세로 정렬 */
 .day-times {
   display: flex;
-  gap: 16px;
-  flex: 1;
-  justify-content: flex-end;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
 }
 
 .time-field {
   display: flex;
+  flex-direction: column;
+  gap: 3px;
   align-items: center;
-  gap: 6px;
 }
 
 .time-field label {
-  font-size: 0.75rem;
+  font-size: 0.68rem;
   color: var(--text-secondary);
   white-space: nowrap;
-  min-width: 24px;
 }
 
 .time-field input {
-  padding: 6px 8px;
+  padding: 5px 6px;
   border-radius: 6px;
   border: 1px solid var(--border-color);
   background: rgba(15, 15, 26, 0.5);
   color: var(--text-primary);
-  font-size: 0.85rem;
-  width: 150px;
+  font-size: 0.78rem;
+  width: 100%;
+  min-width: 70px;
   color-scheme: dark;
+  text-align: center;
   transition: border-color 0.2s;
 }
 
@@ -142,14 +161,20 @@
   outline: none;
 }
 
+.day-off-label {
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+  opacity: 0.5;
+  margin-top: 4px;
+}
+
 .schedule-error {
   color: #f87171;
   font-size: 0.85rem;
-  margin-top: 10px;
 }
 
 .save-btn {
-  margin-top: 20px;
+  align-self: flex-start;
   padding: 10px 28px;
   background: var(--gradient-purple);
   color: var(--text-primary);
@@ -166,4 +191,16 @@
 
 .save-btn:hover:not(:disabled) {
   opacity: 0.85;
+}
+
+@media (max-width: 900px) {
+  .day-schedule-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .day-schedule-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }

--- a/src/features/attendance/ui/SetWorkDaysPersonal.tsx
+++ b/src/features/attendance/ui/SetWorkDaysPersonal.tsx
@@ -11,29 +11,30 @@ export function SetWorkDaysPersonal() {
 
   return (
     <div className="set-work-days-personal">
-      <h3>근무 일정 설정</h3>
-      <p className="desc">
-        요일별로 출퇴근 시간을 개별 설정할 수 있습니다.
-      </p>
-
-      <div className="member-info">
-        <span className="member-avatar">{state.currentUser?.name[0] ?? '?'}</span>
-        <span className="member-name">{state.currentUser?.name ?? ''}</span>
+      <div className="schedule-header">
+        <div>
+          <h3>근무 일정 설정</h3>
+          <p className="desc">요일별로 출퇴근 시간을 개별 설정할 수 있습니다.</p>
+        </div>
+        <div className="member-info">
+          <span className="member-avatar">{state.currentUser?.name[0] ?? '?'}</span>
+          <span className="member-name">{state.currentUser?.name ?? ''}</span>
+        </div>
       </div>
 
       {isLoading ? (
         <div className="schedule-loading">로딩 중...</div>
       ) : (
-        <div className="day-schedule-list">
+        <div className="day-schedule-grid">
           {DAY_NAMES.map((day, i) => (
-            <div key={day} className={`day-schedule-row ${workDays[i] ? 'active' : 'inactive'}`}>
+            <div key={day} className={`day-col ${workDays[i] ? 'active' : 'inactive'}`}>
+              <span className="day-label">{day}</span>
               <button
                 className={`toggle ${workDays[i] ? 'on' : ''}`}
                 onClick={() => toggleDay(i)}
                 aria-label={`${day} 토글`}
               />
-              <span className="day-label">{day}</span>
-              {workDays[i] && (
+              {workDays[i] ? (
                 <div className="day-times">
                   <div className="time-field">
                     <label>출근</label>
@@ -52,6 +53,8 @@ export function SetWorkDaysPersonal() {
                     />
                   </div>
                 </div>
+              ) : (
+                <div className="day-off-label">휴무</div>
               )}
             </div>
           ))}

--- a/src/pages/attendance/__tests__/Attendance.test.tsx
+++ b/src/pages/attendance/__tests__/Attendance.test.tsx
@@ -24,9 +24,9 @@ vi.mock('../../../features/attendance/ui', () => ({
 }))
 
 describe('Attendance 페이지', () => {
-  it('Attendance 헤더가 렌더링된다', () => {
+  it('출퇴근 헤더가 렌더링된다', () => {
     render(<Attendance />)
-    expect(screen.getByText('Attendance')).toBeInTheDocument()
+    expect(screen.getByText('출퇴근')).toBeInTheDocument()
   })
 
   it('관리자에게 Export CSV 버튼이 표시된다', () => {

--- a/src/pages/attendance/attendance.css
+++ b/src/pages/attendance/attendance.css
@@ -68,7 +68,6 @@
 
 .two-cards-row.single {
   grid-template-columns: 1fr;
-  max-width: 700px;
 }
 
 .set-work-days-section {

--- a/src/pages/attendance/index.tsx
+++ b/src/pages/attendance/index.tsx
@@ -69,7 +69,7 @@ export function Attendance() {
         <Toast message={errorMessage} type="error" onClose={() => setErrorMessage(null)} />
       )}
       <header className="attendance-header">
-        <h1>Attendance</h1>
+        <h1>출퇴근</h1>
         <div className="header-actions">
           {isAdmin && (
             <button className="export-btn glass" onClick={handleExport}>

--- a/src/pages/dashboard/dashboard.css
+++ b/src/pages/dashboard/dashboard.css
@@ -1,14 +1,18 @@
 .dashboard {
   max-width: 1200px;
+  height: calc(100vh - 48px);
+  display: flex;
+  flex-direction: column;
 }
 
 /* ── 그리드: 3칸 2줄 ── */
 .dashboard-grid {
   display: grid;
   grid-template-columns: 240px 1fr 1fr;
-  grid-template-rows: auto auto;
+  grid-template-rows: 1fr 1fr;
   gap: 20px;
-  align-items: start;
+  flex: 1;
+  min-height: 0;
 }
 
 /* 클락 카드: 1열 전체 높이 */
@@ -21,7 +25,6 @@
   justify-content: center;
   gap: 16px;
   padding: 32px 24px;
-  min-height: 340px;
 }
 
 .clock-card-loading {
@@ -367,9 +370,14 @@
 
 /* ── 반응형 ── */
 @media (max-width: 900px) {
+  .dashboard {
+    height: auto;
+  }
+
   .dashboard-grid {
     grid-template-columns: 1fr;
     grid-template-rows: auto;
+    flex: none;
   }
 
   .clock-card,

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -43,8 +43,8 @@ export function Members() {
 
   const filtered = state.users.filter((u) => {
     const matchSearch = !search || u.name.toLowerCase().includes(search.toLowerCase())
-    const matchTeam = teamFilter === 'All Teams' || teamLabels[u.team] === teamFilter
-    const matchRole = roleFilter === 'All Roles' || roleLabels[u.role] === roleFilter
+    const matchTeam = teamFilter === 'All Teams' || u.team === teamFilter
+    const matchRole = roleFilter === 'All Roles' || u.role === roleFilter
     return matchSearch && matchTeam && matchRole
   })
 


### PR DESCRIPTION
## 변경 사항 요약

- **fix(members)**: 팀/역할 필터 비교 오류 수정 — BACKEND, FRONTEND 클릭 시 필터링 안 되던 문제 해결
- **fix(attendance)**: 페이지 제목 "Attendance" → "출퇴근" 변경
- **feat(attendance)**: 근무 일정 설정 레이아웃을 세로 리스트에서 요일별 가로 컬럼으로 개편
- **fix(dashboard)**: 홈 화면 그리드가 뷰포트 전체 높이를 채우도록 개선 (빈 공간 제거)

관련 PR: #97