### PR TITLE
feat: 설정 탭 버그 수정, 캘린더 근무 블록, UI 개선 모음

### DIFF
--- a/src/pages/calendar/index.tsx
+++ b/src/pages/calendar/index.tsx
@@ -12,6 +12,7 @@ import { TimeInput } from '../../components/TimeInput'
 import { useApp } from '../../features/auth/model'
 import { useTasks, type Task, type TaskPriority } from '../../features/tasks/model'
 import { useEvents, type CalendarEvent } from '../../features/calendar/model'
+import { useWorkSchedule } from '../../features/attendance/model/useWorkSchedule'
 import { formatDateDisplay, getTodayStr } from '../../features/tasks/model'
 import {
   formatTimeForDisplay,
@@ -47,6 +48,7 @@ export function Calendar() {
   const { state } = useApp()
   const { tasks, addTask, updateTask, deleteTask, toggleTaskDone } = useTasks()
   const { events, addEvent, updateEvent, deleteEvent } = useEvents()
+  const { workDays, daySchedules } = useWorkSchedule()
 
   const [selectedDateStr, setSelectedDateStr] = useState<string | null>(() => getTodayStr())
   const [activeTab, setActiveTab] = useState<'my' | 'team' | 'schedule'>('my')
@@ -306,6 +308,23 @@ export function Calendar() {
     [events, filteredTasks]
   )
 
+  // 근무 일정 → FullCalendar businessHours (0=Sun, 1=Mon, ..., 6=Sat)
+  // useWorkSchedule 인덱스: 0=Mon, ..., 5=Sat, 6=Sun
+  const businessHours = useMemo(() =>
+    workDays
+      .map((isWork, i) => {
+        if (!isWork) return null
+        const fcDay = i === 6 ? 0 : i + 1
+        return {
+          daysOfWeek: [fcDay],
+          startTime: daySchedules[i].checkInTime,
+          endTime: daySchedules[i].checkOutTime,
+        }
+      })
+      .filter((v): v is NonNullable<typeof v> => v !== null),
+    [workDays, daySchedules]
+  )
+
   const todayTasks = useMemo(
     () => filteredTasks.filter((t) => t.date === todayStr).sort((a, b) => a.time.localeCompare(b.time)),
     [filteredTasks, todayStr]
@@ -365,6 +384,7 @@ export function Calendar() {
             editable
             dayMaxEvents={3}
             events={fullCalendarEvents}
+            businessHours={businessHours}
             dateClick={handleDateClick}
             select={handleSelect}
             eventClick={handleEventClick}

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -51,7 +51,7 @@ export function Settings() {
           {tabs.map((tab) => (
             <button
               key={tab.id}
-              className={`nav-item ${activeTab === tab.id ? 'active' : ''}`}
+              className={`settings-nav-item ${activeTab === tab.id ? 'active' : ''}`}
               onClick={() => setActiveTab(tab.id)}
             >
               {tab.icon}

--- a/src/pages/settings/settings.css
+++ b/src/pages/settings/settings.css
@@ -23,7 +23,7 @@
   border-radius: 12px;
 }
 
-.settings-nav .nav-item {
+.settings-nav-item {
   display: flex;
   align-items: center;
   gap: 10px;
@@ -36,16 +36,17 @@
   font-size: 14px;
   transition: all 0.2s;
   text-align: left;
+  width: 100%;
 }
 
-.settings-nav .nav-item:hover {
+.settings-nav-item:hover {
   background: rgba(255, 255, 255, 0.05);
   color: var(--text-primary);
 }
 
-.settings-nav .nav-item.active {
+.settings-nav-item.active {
   background: rgba(150, 128, 204, 0.2);
-  color: var(--purple);
+  color: var(--accent-purple-light, #b39ddb);
 }
 
 .settings-content {


### PR DESCRIPTION
## 변경 사항 요약

### fix(settings): 설정 탭 클릭 시 내용 안 보이는 문제 수정
- Layout nav-item 스타일 충돌 → settings-nav-item 클래스로 분리

### feat(calendar): 근무 일정 → 캘린더 business hours 자동 반영
- 출퇴근 설정의 요일/시간이 주 보기/일 보기에서 배경 음영으로 표시

### fix(ui): 홈 빈 공간, 출퇴근 가로 배치, 멤버 필터, 페이지 제목 한국어
- 홈 화면 그리드 뷰포트 높이 채우기
- 근무 일정 설정 요일별 가로 컬럼 배치
- 멤버 팀/역할 필터 대소문자 불일치 버그 수정
- "Attendance" → "출퇴근" 한국어 변경

관련 PR: #97 #99