### PR TITLE
feat(admin): 관리자 전용 대시보드 페이지 구현

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { Layout } from '../widgets/Layout'
 import { PrivateRoute } from '../shared/ui/PrivateRoute'
+import { AdminRoute } from '../shared/ui/AdminRoute'
 import { Login } from '../pages/login'
 import { Register } from '../pages/register'
 import { Dashboard } from '../pages/dashboard'
@@ -11,6 +12,7 @@ import { Drive } from '../pages/drive'
 import { AIChat } from '../pages/ai-chat'
 import { Members } from '../pages/members'
 import { Settings } from '../pages/settings'
+import { Admin } from '../pages/admin'
 
 export function AppRouter() {
   return (
@@ -29,6 +31,9 @@ export function AppRouter() {
             <Route path="ai" element={<AIChat />} />
             <Route path="members" element={<Members />} />
             <Route path="settings" element={<Settings />} />
+            <Route element={<AdminRoute />}>
+              <Route path="admin" element={<Admin />} />
+            </Route>
             <Route path="*" element={<Navigate to="/" replace />} />
           </Route>
         </Route>

--- a/src/pages/admin/__tests__/Admin.test.tsx
+++ b/src/pages/admin/__tests__/Admin.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { setupServer } from 'msw/node'
+import { http, HttpResponse } from 'msw'
+import { AppProvider } from '../../../features/auth/model'
+import { Admin } from '../index'
+
+const mockMembers = [
+  { id: '1', name: '김민준', email: 'min@yanus.kr', team: 'BACKEND', role: 'MEMBER' },
+  { id: '2', name: '이서연', email: 'seo@yanus.kr', team: 'FRONTEND', role: 'TEAM_LEAD' },
+]
+
+const mockRecords = [
+  {
+    id: 1,
+    memberId: 1,
+    memberName: '김민준',
+    workDate: '2026-03-23',
+    checkInTime: '2026-03-23T09:00:00',
+    checkOutTime: null,
+    status: 'WORKING',
+  },
+]
+
+const server = setupServer(
+  http.get('/api/v1/auth/me', () =>
+    HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: { id: '99', name: '관리자', email: 'admin@yanus.kr', team: 'BACKEND', role: 'ADMIN' },
+    }),
+  ),
+  http.get('/api/v1/members', () =>
+    HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: mockMembers }),
+  ),
+  http.get('/api/v1/attendances', () =>
+    HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: mockRecords }),
+  ),
+)
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+function renderAdmin() {
+  return render(
+    <MemoryRouter>
+      <AppProvider>
+        <Admin />
+      </AppProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('Admin 페이지', () => {
+  it('페이지 제목이 렌더링된다', () => {
+    renderAdmin()
+    expect(screen.getByText('관리자 대시보드')).toBeInTheDocument()
+  })
+
+  it('출근 현황 탭이 기본으로 활성화된다', () => {
+    renderAdmin()
+    const tab = screen.getByRole('button', { name: '출근 현황' })
+    expect(tab).toHaveClass('active')
+  })
+
+  it('멤버 관리 탭이 존재한다', () => {
+    renderAdmin()
+    expect(screen.getByRole('button', { name: '멤버 관리' })).toBeInTheDocument()
+  })
+
+  it('멤버 관리 탭 클릭 시 멤버 테이블이 표시된다', async () => {
+    const user = userEvent.setup()
+    renderAdmin()
+    await user.click(screen.getByRole('button', { name: '멤버 관리' }))
+    expect(screen.getByText('멤버 목록')).toBeInTheDocument()
+  })
+
+  it('출근 현황 탭에 요약 카운트가 표시된다', async () => {
+    renderAdmin()
+    await waitFor(() => {
+      expect(screen.getByText('근무 중')).toBeInTheDocument()
+      expect(screen.getByText('퇴근')).toBeInTheDocument()
+      expect(screen.getByText('미출근')).toBeInTheDocument()
+    })
+  })
+
+  it('출근 현황 탭에 팀원 카드가 표시된다', async () => {
+    renderAdmin()
+    await waitFor(() => {
+      expect(screen.getByText('김민준')).toBeInTheDocument()
+      expect(screen.getByText('이서연')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/pages/admin/admin.css
+++ b/src/pages/admin/admin.css
@@ -1,0 +1,348 @@
+.admin-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* ── 헤더 ── */
+.admin-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.admin-title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.admin-title-row h1 {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.admin-crown-icon {
+  color: var(--accent-purple);
+}
+
+.admin-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.admin-export-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-family: inherit;
+}
+
+.admin-export-btn:hover {
+  color: var(--text-primary);
+  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+/* ── 탭 ── */
+.admin-tabs {
+  display: flex;
+  gap: 4px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 12px;
+  padding: 4px;
+  width: fit-content;
+}
+
+.admin-tab-btn {
+  padding: 9px 24px;
+  border-radius: 9px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-family: inherit;
+}
+
+.admin-tab-btn:hover {
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.admin-tab-btn.active {
+  background: var(--accent-purple);
+  color: #fff;
+}
+
+/* ── 탭 콘텐츠 ── */
+.admin-tab-content {
+  border-radius: 16px;
+  padding: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* ── 멤버 관리 ── */
+.admin-section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 18px;
+}
+
+.admin-members-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.admin-members-table th {
+  text-align: left;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 10px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.admin-members-table td {
+  padding: 12px 14px;
+  font-size: 0.88rem;
+  color: var(--text-primary);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  vertical-align: middle;
+}
+
+.admin-members-table tr:last-child td {
+  border-bottom: none;
+}
+
+.admin-members-table tr:hover td {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.admin-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: var(--accent-purple);
+  color: #fff;
+  font-size: 0.78rem;
+  font-weight: 700;
+  margin-right: 10px;
+  flex-shrink: 0;
+}
+
+.admin-team-tag {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 3px 10px;
+  border-radius: 20px;
+}
+
+.admin-team-tag.BACKEND  { background: rgba(99, 102, 241, 0.2); color: #a5b4fc; }
+.admin-team-tag.FRONTEND { background: rgba(236, 72, 153, 0.2); color: #f9a8d4; }
+.admin-team-tag.AI       { background: rgba(16, 185, 129, 0.2); color: #6ee7b7; }
+.admin-team-tag.SECURITY { background: rgba(245, 158, 11, 0.2); color: #fcd34d; }
+
+.admin-role-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 3px 10px;
+  border-radius: 20px;
+}
+
+.admin-role-tag.ADMIN     { background: rgba(124, 58, 237, 0.25); color: #c4b5fd; }
+.admin-role-tag.TEAM_LEAD { background: rgba(59, 130, 246, 0.2);  color: #93c5fd; }
+.admin-role-tag.MEMBER    { background: rgba(100, 116, 139, 0.2); color: var(--text-secondary); }
+
+.admin-actions-cell {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.admin-action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-family: inherit;
+}
+
+.admin-action-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary);
+}
+
+.admin-action-btn.deactivate-btn {
+  color: #f87171;
+  border-color: rgba(239, 68, 68, 0.2);
+}
+
+.admin-action-btn.deactivate-btn:hover {
+  background: rgba(239, 68, 68, 0.1);
+}
+
+.admin-action-btn.activate-btn {
+  color: #4ade80;
+  border-color: rgba(34, 197, 94, 0.2);
+}
+
+.admin-action-btn.activate-btn:hover {
+  background: rgba(34, 197, 94, 0.1);
+}
+
+/* ── 역할 변경 모달 ── */
+.admin-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  backdrop-filter: blur(4px);
+}
+
+.admin-modal {
+  background: #1a1a2e;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 28px;
+  width: 360px;
+  max-width: 90vw;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.admin-modal h3 {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.admin-role-options {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.admin-role-option {
+  display: flex;
+  align-items: center;
+  padding: 12px 16px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.admin-role-option:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.admin-role-option.selected {
+  border-color: var(--accent-purple);
+  background: rgba(124, 58, 237, 0.12);
+}
+
+.admin-role-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.admin-role-pill.ADMIN     { color: #c4b5fd; }
+.admin-role-pill.TEAM_LEAD { color: #93c5fd; }
+.admin-role-pill.MEMBER    { color: var(--text-secondary); }
+
+.admin-modal-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.cancel-btn,
+.confirm-btn {
+  padding: 9px 20px;
+  border-radius: 10px;
+  border: none;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-family: inherit;
+}
+
+.cancel-btn {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-secondary);
+}
+
+.cancel-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+}
+
+.confirm-btn {
+  background: var(--accent-purple);
+  color: #fff;
+}
+
+.confirm-btn:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.confirm-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── 반응형 ── */
+@media (max-width: 768px) {
+  .admin-members-table th:nth-child(2),
+  .admin-members-table td:nth-child(2) {
+    display: none;
+  }
+
+  .admin-actions-cell {
+    flex-direction: column;
+    gap: 4px;
+  }
+}

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,0 +1,266 @@
+import { useState, useEffect } from 'react'
+import { Crown, ChevronDown, Download } from 'lucide-react'
+import { useApp } from '../../features/auth/model'
+import { TeamAttendanceStatus } from '../../features/attendance/ui'
+import { getAttendanceByDate } from '../../shared/api/attendanceApi'
+import type { AttendanceRecord } from '../../shared/api/attendanceApi'
+import { getMembers, updateMemberRole, deactivateMember, activateMember } from '../../shared/api/membersApi'
+import type { User, UserRole } from '../../entities/user/model/types'
+import { exportAttendanceToCsv } from '../../shared/lib/exportCsv'
+import { Toast } from '../../shared/ui/Toast'
+import { getTodayStr } from '../../shared/lib/date'
+import './admin.css'
+
+type Tab = 'attendance' | 'members'
+
+const ALL_ROLES: UserRole[] = ['MEMBER', 'TEAM_LEAD', 'ADMIN']
+const roleLabels: Record<string, string> = {
+  ADMIN: 'Admin',
+  TEAM_LEAD: 'Team Lead',
+  MEMBER: 'Member',
+}
+const teamLabels: Record<string, string> = {
+  BACKEND: 'Backend',
+  FRONTEND: 'Frontend',
+  AI: 'AI',
+  SECURITY: 'Security',
+}
+
+export function Admin() {
+  const { loadMembers } = useApp()
+  const [tab, setTab] = useState<Tab>('attendance')
+  const [records, setRecords] = useState<AttendanceRecord[]>([])
+  const [members, setMembers] = useState<User[]>([])
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [changeRoleFor, setChangeRoleFor] = useState<{ id: string; name: string; current: UserRole } | null>(null)
+  const [selectedRole, setSelectedRole] = useState<UserRole>('MEMBER')
+
+  const todayStr = getTodayStr()
+
+  useEffect(() => {
+    getMembers()
+      .then((data) => {
+        setMembers(data)
+        loadMembers(data)
+      })
+      .catch((err) => setErrorMessage(err instanceof Error ? err.message : '멤버 목록을 불러오지 못했습니다'))
+
+    getAttendanceByDate(todayStr)
+      .then(setRecords)
+      .catch((err) => setErrorMessage(err instanceof Error ? err.message : '출근 기록을 불러오지 못했습니다'))
+  }, [todayStr, loadMembers])
+
+  const handleOpenRoleChange = (id: string, name: string, current: UserRole) => {
+    setChangeRoleFor({ id, name, current })
+    setSelectedRole(current)
+  }
+
+  const handleConfirmRoleChange = async () => {
+    if (!changeRoleFor) return
+    setSaving(true)
+    try {
+      await updateMemberRole(changeRoleFor.id, selectedRole)
+      const updated = members.map((u) =>
+        u.id === changeRoleFor.id ? { ...u, role: selectedRole } : u,
+      )
+      setMembers(updated)
+      loadMembers(updated)
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '역할 변경에 실패했습니다')
+    }
+    setSaving(false)
+    setChangeRoleFor(null)
+  }
+
+  const handleDeactivate = async (id: string) => {
+    setSaving(true)
+    try {
+      await deactivateMember(id)
+      const updated = await getMembers()
+      setMembers(updated)
+      loadMembers(updated)
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '비활성화에 실패했습니다')
+    }
+    setSaving(false)
+  }
+
+  const handleActivate = async (id: string) => {
+    setSaving(true)
+    try {
+      await activateMember(id)
+      const updated = await getMembers()
+      setMembers(updated)
+      loadMembers(updated)
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '활성화에 실패했습니다')
+    }
+    setSaving(false)
+  }
+
+  const handleExportCsv = () => {
+    exportAttendanceToCsv(
+      records.map((r) => ({
+        id: String(r.id),
+        userId: String(r.memberId),
+        userName: r.memberName,
+        date: r.workDate,
+        clockIn: r.checkInTime?.slice(11, 16) ?? '',
+        clockOut: r.checkOutTime?.slice(11, 16),
+        status: r.status === 'LEFT' ? 'done' : 'working',
+      })),
+      todayStr,
+    )
+  }
+
+  return (
+    <div className="admin-page">
+      {errorMessage && (
+        <Toast message={errorMessage} type="error" onClose={() => setErrorMessage(null)} />
+      )}
+
+      <header className="admin-header">
+        <div className="admin-title-row">
+          <Crown size={22} className="admin-crown-icon" />
+          <h1>관리자 대시보드</h1>
+        </div>
+        <div className="admin-header-actions">
+          {tab === 'attendance' && (
+            <button className="admin-export-btn glass" onClick={handleExportCsv}>
+              <Download size={16} />
+              CSV 내보내기
+            </button>
+          )}
+        </div>
+      </header>
+
+      {/* 탭 */}
+      <div className="admin-tabs">
+        <button
+          type="button"
+          className={`admin-tab-btn ${tab === 'attendance' ? 'active' : ''}`}
+          onClick={() => setTab('attendance')}
+        >
+          출근 현황
+        </button>
+        <button
+          type="button"
+          className={`admin-tab-btn ${tab === 'members' ? 'active' : ''}`}
+          onClick={() => setTab('members')}
+        >
+          멤버 관리
+        </button>
+      </div>
+
+      {/* 출근 현황 탭 */}
+      {tab === 'attendance' && (
+        <div className="admin-tab-content glass">
+          <TeamAttendanceStatus members={members} records={records} date={todayStr} />
+        </div>
+      )}
+
+      {/* 멤버 관리 탭 */}
+      {tab === 'members' && (
+        <div className="admin-tab-content glass">
+          <h3 className="admin-section-title">멤버 목록</h3>
+          <table className="admin-members-table">
+            <thead>
+              <tr>
+                <th>이름</th>
+                <th>팀</th>
+                <th>역할</th>
+                <th>관리</th>
+              </tr>
+            </thead>
+            <tbody>
+              {members.map((u) => (
+                <tr key={u.id}>
+                  <td>
+                    <span className="admin-avatar">{u.name[0]}</span>
+                    {u.name}
+                  </td>
+                  <td>
+                    <span className={`admin-team-tag ${u.team}`}>
+                      {teamLabels[u.team] ?? u.team}
+                    </span>
+                  </td>
+                  <td>
+                    <span className={`admin-role-tag ${u.role}`}>
+                      {u.role === 'ADMIN' && <Crown size={12} />}
+                      {roleLabels[u.role] ?? u.role}
+                    </span>
+                  </td>
+                  <td className="admin-actions-cell">
+                    <button
+                      type="button"
+                      className="admin-action-btn"
+                      onClick={() => handleOpenRoleChange(u.id, u.name, u.role)}
+                    >
+                      역할 변경 <ChevronDown size={13} />
+                    </button>
+                    {'active' in u && !(u as { active?: boolean }).active ? (
+                      <button
+                        type="button"
+                        className="admin-action-btn activate-btn"
+                        disabled={saving}
+                        onClick={() => handleActivate(u.id)}
+                      >
+                        활성화
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        className="admin-action-btn deactivate-btn"
+                        disabled={saving}
+                        onClick={() => handleDeactivate(u.id)}
+                      >
+                        비활성화
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* 역할 변경 모달 */}
+      {changeRoleFor && (
+        <div className="admin-modal-overlay" onClick={() => setChangeRoleFor(null)}>
+          <div className="admin-modal glass" onClick={(e) => e.stopPropagation()}>
+            <h3>역할 변경 — {changeRoleFor.name}</h3>
+            <div className="admin-role-options">
+              {ALL_ROLES.map((r) => (
+                <div
+                  key={r}
+                  className={`admin-role-option ${selectedRole === r ? 'selected' : ''}`}
+                  onClick={() => setSelectedRole(r)}
+                >
+                  <span className={`admin-role-pill ${r}`}>
+                    {r === 'ADMIN' && <Crown size={13} />}
+                    {roleLabels[r]}
+                  </span>
+                </div>
+              ))}
+            </div>
+            <div className="admin-modal-actions">
+              <button type="button" className="cancel-btn" onClick={() => setChangeRoleFor(null)}>
+                취소
+              </button>
+              <button
+                type="button"
+                className="confirm-btn"
+                disabled={saving}
+                onClick={handleConfirmRoleChange}
+              >
+                {saving ? '저장 중...' : '변경 확인'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/widgets/Layout/Layout.css
+++ b/src/widgets/Layout/Layout.css
@@ -83,6 +83,27 @@
   color: inherit;
 }
 
+/* 관리자 전용 메뉴 — 구분선 + 강조색 */
+.admin-nav-item {
+  margin-top: 8px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  padding-top: 14px;
+  color: var(--accent-purple) !important;
+  opacity: 0.85;
+}
+
+.admin-nav-item:hover {
+  opacity: 1;
+  background: rgba(124, 58, 237, 0.18) !important;
+  color: var(--accent-purple) !important;
+}
+
+.admin-nav-item.active {
+  opacity: 1;
+  background: var(--accent-purple) !important;
+  color: #fff !important;
+}
+
 .main-content {
   flex: 1;
   margin-left: 200px;

--- a/src/widgets/Layout/Layout.tsx
+++ b/src/widgets/Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { Home, MessageSquare, Calendar, RotateCw, FolderUp, Bot, Users, Settings, LogOut } from 'lucide-react'
+import { Home, MessageSquare, Calendar, RotateCw, FolderUp, Bot, Users, Settings, LogOut, ShieldCheck } from 'lucide-react'
 import { NavLink, Outlet, useNavigate } from 'react-router-dom'
 import { useApp } from '../../features/auth/model'
 import logoImg from '../../assets/logo.png'
@@ -17,7 +17,7 @@ const navItems = [
 
 export function Layout() {
   const navigate = useNavigate()
-  const { state, logout } = useApp()
+  const { state, isAdmin, logout } = useApp()
   const { currentUser } = state
 
   function handleLogout() {
@@ -43,6 +43,16 @@ export function Layout() {
               <span className="nav-label">{label}</span>
             </NavLink>
           ))}
+          {isAdmin && (
+            <NavLink
+              to="/admin"
+              className={({ isActive }) => `nav-item admin-nav-item ${isActive ? 'active' : ''}`}
+              title="관리자"
+            >
+              <ShieldCheck size={22} />
+              <span className="nav-label">관리자</span>
+            </NavLink>
+          )}
         </nav>
         {currentUser && (
           <div className="sidebar-bottom">


### PR DESCRIPTION
## 요약

- 관리자 전용 `/admin` 페이지 신규 구현 (출근 현황 탭 + 멤버 관리 탭)
- 사이드바에 관리자 계정에만 노출되는 "관리자" 메뉴 추가
- `/admin` 라우트 `AdminRoute` 가드 적용

관련 이슈: #103