### PR TITLE
fix(members): 멤버 페이지 무한 API 요청 버그 수정

### DIFF
--- a/src/features/auth/model/AppProvider.tsx
+++ b/src/features/auth/model/AppProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect } from 'react'
+import { createContext, useContext, useState, useEffect, useCallback } from 'react'
 import type { ReactNode } from 'react'
 import type { User, PersonalWorkSchedule } from '../../../entities/user/model/types'
 import { getMe } from '../api/authClient'
@@ -54,18 +54,18 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const isAdmin =
     state.currentUser?.role === 'ADMIN' || state.currentUser?.role === 'TEAM_LEAD'
 
-  function loadUser(user: User) {
+  const loadUser = useCallback((user: User) => {
     setState((prev) => ({ ...prev, currentUser: user }))
-  }
+  }, [])
 
-  function loadMembers(users: User[]) {
+  const loadMembers = useCallback((users: User[]) => {
     setState((prev) => ({ ...prev, users }))
-  }
+  }, [])
 
-  function logout() {
+  const logout = useCallback(() => {
     localStorage.removeItem('accessToken')
     setState({ currentUser: null, users: [] })
-  }
+  }, [])
 
   return (
     <AppContext.Provider


### PR DESCRIPTION
## 요약

- 멤버 페이지 진입 시 `/api/v1/members` 요청이 무한 반복되는 버그 수정

## 원인

`AppProvider`의 `loadMembers`, `loadUser`, `logout` 함수가 `useCallback` 없이 일반 함수로 선언되어, 매 렌더마다 새 함수 참조가 생성됨. `useEffect` 의존성 배열에 `loadMembers`가 포함된 경우 무한 루프 발생.

## 해결

세 함수 모두 `useCallback`으로 감싸 참조 안정화.

관련 이슈: #106