### PR TITLE
fix(attendance): 팀원 출근 상태 필터 미동작 버그 수정

### DIFF
--- a/src/features/attendance/ui/TeamAttendanceStatus.tsx
+++ b/src/features/attendance/ui/TeamAttendanceStatus.tsx
@@ -12,7 +12,7 @@ interface Props {
 type AttendStatus = 'working' | 'left' | 'absent'
 
 function getStatus(memberId: string, records: AttendanceRecord[]): AttendStatus {
-  const rec = records.find((r) => String(r.memberId) === memberId)
+  const rec = records.find((r) => String(r.memberId) === String(memberId))
   if (!rec) return 'absent'
   return rec.status === 'WORKING' ? 'working' : 'left'
 }
@@ -81,7 +81,7 @@ export function TeamAttendanceStatus({ members, records, date }: Props) {
           <p className="attend-empty">해당 상태의 팀원이 없습니다</p>
         ) : (
           filteredMembers.map((member) => {
-            const rec = records.find((r) => String(r.memberId) === member.id)
+            const rec = records.find((r) => String(r.memberId) === String(member.id))
             const status = getStatus(member.id, records)
             return (
               <div key={member.id} className={`attend-member-card ${status}`}>


### PR DESCRIPTION
## 문제

팀원 출근 현황에서 근무 중/퇴근 필터 클릭 시 해당 인원이 표시되지 않고 전부 미출근으로 보이는 버그

## 원인

- `AttendanceRecord.memberId` → 백엔드 JSON에서 **number**로 옴
- `User.id` → TypeScript 타입은 `string`이지만 런타임에서 실제 값이 **number**

`getStatus`에서 `String(r.memberId) === memberId` 비교 시  
→ `"1" === 1` (런타임) → **false** → 전원 미출근으로 분류

## 수정

양쪽 모두 `String()` 적용으로 타입 불일치 완전 제거

```ts
// 수정 전
records.find((r) => String(r.memberId) === memberId)

// 수정 후
records.find((r) => String(r.memberId) === String(memberId))
```