### PR TITLE
fix(attendance): 팀원 출근 상태 필터 memberId 매칭 버그 수정

### DIFF
--- a/src/features/attendance/ui/TeamAttendanceStatus.tsx
+++ b/src/features/attendance/ui/TeamAttendanceStatus.tsx
@@ -12,7 +12,7 @@ interface Props {
 type AttendStatus = 'working' | 'left' | 'absent'
 
 function getStatus(memberId: string, records: AttendanceRecord[]): AttendStatus {
-  const rec = records.find((r) => String(r.memberId) === memberId)
+  const rec = records.find((r) => String(r.memberId) === String(memberId))
   if (!rec) return 'absent'
   return rec.status === 'WORKING' ? 'working' : 'left'
 }
@@ -81,7 +81,7 @@ export function TeamAttendanceStatus({ members, records, date }: Props) {
           <p className="attend-empty">해당 상태의 팀원이 없습니다</p>
         ) : (
           filteredMembers.map((member) => {
-            const rec = records.find((r) => String(r.memberId) === member.id)
+            const rec = records.find((r) => String(r.memberId) === String(member.id))
             const status = getStatus(member.id, records)
             return (
               <div key={member.id} className={`attend-member-card ${status}`}>


### PR DESCRIPTION
## 포함 내용

- `fix(attendance)`: 팀원 출근 현황에서 근무 중/퇴근 필터 클릭 시 전원 미출근으로 보이던 버그 수정
  - 원인: `User.id`(런타임 number) vs `AttendanceRecord.memberId`(number) 비교 시 타입 불일치
  - 수정: `String()` 양쪽 모두 적용

관련 PR: #119