### PR TITLE
fix(calendar): 캘린더 일정·할일 편집·삭제 권한 체크 추가

### DIFF
--- a/src/features/calendar/ui/EventDetailModal.tsx
+++ b/src/features/calendar/ui/EventDetailModal.tsx
@@ -13,6 +13,7 @@ interface EditForm {
 
 interface Props {
   event: CalendarEvent | null
+  canEdit: boolean
   editMode: boolean
   editForm: EditForm
   onEditFormChange: (f: Partial<EditForm>) => void
@@ -23,7 +24,7 @@ interface Props {
 }
 
 export function EventDetailModal({
-  event, editMode, editForm, onEditFormChange,
+  event, canEdit, editMode, editForm, onEditFormChange,
   onEnterEditMode, onSave, onDelete, onClose,
 }: Props) {
   if (!event) return null
@@ -68,9 +69,12 @@ export function EventDetailModal({
               <div className="event-detail-title">{event.title}</div>
               <div className="event-detail-meta">{formatEventRange(event)}</div>
             </div>
+            <div className="event-detail-creator">
+              작성자: {event.createdBy}
+            </div>
             <div className="edit-task-actions add-task-modal-actions">
-              <button className="cancel-btn" onClick={onEnterEditMode}>수정</button>
-              <button className="cancel-btn delete-btn" onClick={onDelete}>삭제</button>
+              {canEdit && <button className="cancel-btn" onClick={onEnterEditMode}>수정</button>}
+              {canEdit && <button className="cancel-btn delete-btn" onClick={onDelete}>삭제</button>}
               <button className="add-btn" onClick={onClose}>닫기</button>
             </div>
           </>

--- a/src/pages/calendar/calendar.css
+++ b/src/pages/calendar/calendar.css
@@ -761,6 +761,14 @@
   color: var(--text-secondary);
 }
 
+.event-detail-creator {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
 .add-task-modal-actions .delete-btn {
   color: var(--error);
 }

--- a/src/pages/calendar/index.tsx
+++ b/src/pages/calendar/index.tsx
@@ -96,6 +96,18 @@ export function Calendar() {
   const todayStr = getTodayStr()
   const DELETE_ANIM_DURATION = 320
 
+  // 권한 헬퍼 — admin/team_lead는 모두 편집 가능
+  const isAdmin = state.currentUser?.role === 'ADMIN' || state.currentUser?.role === 'TEAM_LEAD'
+  const canEditEvent = useCallback((event: CalendarEvent) =>
+    isAdmin || event.createdBy === state.currentUser?.name,
+    [isAdmin, state.currentUser],
+  )
+  const canEditTask = useCallback((task: Task) => {
+    if (isAdmin) return true
+    if (!task.isTeamTask) return true // 내 할일은 항상 본인 것
+    return task.assigneeId === String(state.currentUser?.id)
+  }, [isAdmin, state.currentUser])
+
   const handleAddTask = (closeModal?: boolean) => {
     const title = newTaskTitle.trim()
     if (!title) return
@@ -250,17 +262,19 @@ export function Calendar() {
   const handleEventDrop = useCallback((arg: EventDropArg) => {
     const id = arg.event.id
     if (!id) return
-    const ext = arg.event.extendedProps as { isTask?: boolean }
+    const ext = arg.event.extendedProps as { isTask?: boolean; rawEvent?: CalendarEvent; rawTask?: Task }
     const start = arg.event.start!
     const end = arg.event.end!
     if (ext?.isTask && id.startsWith('task-')) {
+      if (ext.rawTask && !canEditTask(ext.rawTask)) { arg.revert(); return }
       const taskId = id.replace(/^task-/, '')
       const time24 = parseDateToTime(start)
       updateTask(taskId, { date: parseDateToStr(start), time: formatTimeForDisplay(time24) })
     } else {
+      if (ext.rawEvent && !canEditEvent(ext.rawEvent)) { arg.revert(); return }
       updateEvent(id, { startDate: parseDateToStr(start), startTime: parseDateToTime(start), endDate: parseDateToStr(end), endTime: parseDateToTime(end) })
     }
-  }, [updateEvent, updateTask])
+  }, [updateEvent, updateTask, canEditEvent, canEditTask])
 
   const handleDatesSet = useCallback((arg: { start: Date; end: Date; view: { type: string } }) => {
     const key = `${arg.view.type}-${arg.start.getFullYear()}-${arg.start.getMonth()}`
@@ -278,12 +292,13 @@ export function Calendar() {
   const handleEventResize = useCallback((arg: EventResizeDoneArg) => {
     const id = arg.event.id
     if (!id) return
-    const ext = arg.event.extendedProps as { isTask?: boolean }
+    const ext = arg.event.extendedProps as { isTask?: boolean; rawEvent?: CalendarEvent }
     if (ext?.isTask && id.startsWith('task-')) return
+    if (ext.rawEvent && !canEditEvent(ext.rawEvent)) { arg.revert(); return }
     const start = arg.event.start!
     const end = arg.event.end!
     updateEvent(id, { startDate: parseDateToStr(start), startTime: parseDateToTime(start), endDate: parseDateToStr(end), endTime: parseDateToTime(end) })
-  }, [updateEvent])
+  }, [updateEvent, canEditEvent])
 
   useEffect(() => {
     if (editingTask) {
@@ -345,24 +360,27 @@ export function Calendar() {
     return Array.from(byDate.entries()).map(([date, items]) => ({ date: formatDateDisplay(date, new Date()), dateStr: date, items }))
   }, [filteredTasks, todayStr])
 
-  const TaskItemRow = ({ t, showCheckbox = true, showAssignee = true }: { t: Task; showCheckbox?: boolean; showAssignee?: boolean }) => (
-    <div key={t.id} className={`task-item ${t.done ? 'done' : ''} ${deletingTaskId === t.id ? 'deleting' : ''}`}>
-      {showCheckbox && (
-        <span className="task-checkbox" onClick={() => toggleTaskDone(t.id)} role="button" tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && toggleTaskDone(t.id)}>
-          {t.done ? '✓' : ''}
-        </span>
-      )}
-      <div className="task-info">
-        <span className="task-title">{t.title}</span>
-        <span className="task-meta">{t.time} · <span className={`priority-dot ${t.priority}`}>{PRIORITY_LABELS[t.priority]}</span></span>
+  const TaskItemRow = ({ t, showCheckbox = true, showAssignee = true }: { t: Task; showCheckbox?: boolean; showAssignee?: boolean }) => {
+    const canEdit = canEditTask(t)
+    return (
+      <div key={t.id} className={`task-item ${t.done ? 'done' : ''} ${deletingTaskId === t.id ? 'deleting' : ''}`}>
+        {showCheckbox && (
+          <span className="task-checkbox" onClick={() => toggleTaskDone(t.id)} role="button" tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && toggleTaskDone(t.id)}>
+            {t.done ? '✓' : ''}
+          </span>
+        )}
+        <div className="task-info">
+          <span className="task-title">{t.title}</span>
+          <span className="task-meta">{t.time} · <span className={`priority-dot ${t.priority}`}>{PRIORITY_LABELS[t.priority]}</span></span>
+        </div>
+        <div className="task-actions">
+          {showAssignee && t.assigneeName && <span className="assignee" title={t.assigneeName}><User size={14} /></span>}
+          {canEdit && <button onClick={() => setEditingTask(t)} aria-label="수정"><Pencil size={14} /></button>}
+          {canEdit && <button onClick={(e) => { e.stopPropagation(); handleDeleteTaskWithAnimation(t.id) }} aria-label="삭제"><Trash2 size={14} /></button>}
+        </div>
       </div>
-      <div className="task-actions">
-        {showAssignee && t.assigneeName && <span className="assignee" title={t.assigneeName}><User size={14} /></span>}
-        <button onClick={() => setEditingTask(t)} aria-label="수정"><Pencil size={14} /></button>
-        <button onClick={(e) => { e.stopPropagation(); handleDeleteTaskWithAnimation(t.id) }} aria-label="삭제"><Trash2 size={14} /></button>
-      </div>
-    </div>
-  )
+    )
+  }
 
   return (
     <div className="calendar-page">
@@ -506,9 +524,11 @@ export function Calendar() {
                         <span className="event-item-title">{e.title}</span>
                         <span className="event-item-meta">{formatEventRange(e)}</span>
                       </div>
-                      <button className="event-item-delete" onClick={(ev) => { ev.stopPropagation(); handleDeleteEventWithAnimation(e.id) }} aria-label="삭제">
-                        <Trash2 size={14} />
-                      </button>
+                      {canEditEvent(e) && (
+                        <button className="event-item-delete" onClick={(ev) => { ev.stopPropagation(); handleDeleteEventWithAnimation(e.id) }} aria-label="삭제">
+                          <Trash2 size={14} />
+                        </button>
+                      )}
                     </div>
                   ))}
                 </div>
@@ -577,6 +597,7 @@ export function Calendar() {
 
       <EventDetailModal
         event={selectedEvent}
+        canEdit={selectedEvent ? canEditEvent(selectedEvent) : false}
         editMode={eventDetailEditMode}
         editForm={editEventForm}
         onEditFormChange={handleEventDetailFormChange}


### PR DESCRIPTION
## 문제

캘린더에서 다른 사람이 등록한 일정/할일을 누구나 수정·삭제할 수 있었음

## 수정 내용

| 구분 | 수정 |
|------|------|
| 일정 (EventDetailModal) | 작성자 또는 admin/team_lead만 수정·삭제 버튼 노출 |
| 할일 (TaskItemRow) | 팀 할일은 담당자 또는 admin/team_lead만 수정·삭제 가능 |
| 드래그 (EventDrop) | 권한 없는 이벤트 드래그 시 원위치 복구 (`arg.revert()`) |
| 리사이즈 (EventResize) | 권한 없는 이벤트 리사이즈 시 원위치 복구 |
| 일정 상세 모달 | 작성자 이름 표시 추가 |

## 권한 기준

- `ADMIN`, `TEAM_LEAD`: 모든 일정/할일 편집 가능
- 일반 멤버: 본인이 만든 일정, 본인의 내 할일, 담당된 팀 할일만 편집 가능