### PR TITLE
feat(calendar): 캘린더 할일 통합 표시, 드래그 수정, 팀 할일 생성자 권한 적용

### DIFF
--- a/src/features/calendar/lib/calendarUtils.ts
+++ b/src/features/calendar/lib/calendarUtils.ts
@@ -65,7 +65,8 @@ export function taskToEventFormat(t: Task): EventInput {
     end: endStr,
     allDay: false,
     extendedProps: { rawTask: t, isTask: true },
-    className: `fc-event-task fc-event-priority-${t.priority}`,
+    // 팀 할일은 별도 클래스로 색상 구분
+    className: `fc-event-task fc-event-priority-${t.priority}${t.isTeamTask ? ' fc-event-team-task' : ''}`,
     durationEditable: false,
   }
 }

--- a/src/features/tasks/model/TasksProvider.tsx
+++ b/src/features/tasks/model/TasksProvider.tsx
@@ -76,7 +76,8 @@ function toTask(api: ApiTask): Task {
     isTeamTask: api.isTeamTask,
     assigneeId: api.assigneeId != null ? String(api.assigneeId) : undefined,
     assigneeName: api.assigneeName ?? undefined,
-    createdBy: api.assigneeId != null ? String(api.assigneeId) : '',
+    // createdById 있으면 생성자 ID 사용, 없으면 빈 문자열 (권한 체크 시 fallback)
+    createdBy: api.createdById != null ? String(api.createdById) : '',
   }
 }
 
@@ -105,7 +106,12 @@ export function TasksProvider({ children }: { children: ReactNode }) {
       isTeamTask: task.isTeamTask,
       assigneeId: task.assigneeId ? Number(task.assigneeId) : null,
     })
-    setTasks((prev) => [...prev, toTask(apiTask)])
+    // 생성 직후: 백엔드가 createdById를 안 내려줘도 현재 유저 ID로 보존
+    const newTask = toTask(apiTask)
+    if (!newTask.createdBy && state.currentUser?.id) {
+      newTask.createdBy = String(state.currentUser.id)
+    }
+    setTasks((prev) => [...prev, newTask])
   }, [state.currentUser?.id])
 
   const updateTask = useCallback(async (id: string, updates: Partial<Task>) => {

--- a/src/pages/calendar/calendar.css
+++ b/src/pages/calendar/calendar.css
@@ -160,6 +160,29 @@
   box-shadow: 0 2px 8px rgba(34, 197, 94, 0.25);
 }
 
+/* 팀 할일 — 보라/인디고 계열로 내 할일과 구분 */
+.fullcalendar-wrapper .fc-event-team-task.fc-event-priority-high {
+  background: rgba(167, 139, 250, 0.35);
+  border-color: rgba(167, 139, 250, 0.6);
+}
+.fullcalendar-wrapper .fc-event-team-task.fc-event-priority-high:hover {
+  background: rgba(167, 139, 250, 0.5);
+}
+.fullcalendar-wrapper .fc-event-team-task.fc-event-priority-medium {
+  background: rgba(99, 102, 241, 0.35);
+  border-color: rgba(99, 102, 241, 0.6);
+}
+.fullcalendar-wrapper .fc-event-team-task.fc-event-priority-medium:hover {
+  background: rgba(99, 102, 241, 0.5);
+}
+.fullcalendar-wrapper .fc-event-team-task.fc-event-priority-low {
+  background: rgba(139, 92, 246, 0.3);
+  border-color: rgba(139, 92, 246, 0.5);
+}
+.fullcalendar-wrapper .fc-event-team-task.fc-event-priority-low:hover {
+  background: rgba(139, 92, 246, 0.45);
+}
+
 .fullcalendar-wrapper .fc-daygrid-day {
   transition: background 0.2s ease;
 }

--- a/src/pages/calendar/index.tsx
+++ b/src/pages/calendar/index.tsx
@@ -105,7 +105,8 @@ export function Calendar() {
   const canEditTask = useCallback((task: Task) => {
     if (isAdmin) return true
     if (!task.isTeamTask) return true // 내 할일은 항상 본인 것
-    return task.assigneeId === String(state.currentUser?.id)
+    // 팀 할일: 생성자(createdBy)만 편집 가능
+    return task.createdBy === String(state.currentUser?.id)
   }, [isAdmin, state.currentUser])
 
   const handleAddTask = (closeModal?: boolean) => {
@@ -266,13 +267,26 @@ export function Calendar() {
     const start = arg.event.start!
     const end = arg.event.end!
     if (ext?.isTask && id.startsWith('task-')) {
-      if (ext.rawTask && !canEditTask(ext.rawTask)) { arg.revert(); return }
+      if (!ext.rawTask || !canEditTask(ext.rawTask)) { arg.revert(); return }
       const taskId = id.replace(/^task-/, '')
+      const newDate = parseDateToStr(start)
       const time24 = parseDateToTime(start)
-      updateTask(taskId, { date: parseDateToStr(start), time: formatTimeForDisplay(time24) })
+      // PUT 백엔드 호환: 기존 title·priority 함께 전송
+      updateTask(taskId, {
+        title: ext.rawTask.title,
+        date: newDate,
+        time: formatTimeForDisplay(time24),
+        priority: ext.rawTask.priority,
+      })
     } else {
-      if (ext.rawEvent && !canEditEvent(ext.rawEvent)) { arg.revert(); return }
-      updateEvent(id, { startDate: parseDateToStr(start), startTime: parseDateToTime(start), endDate: parseDateToStr(end), endTime: parseDateToTime(end) })
+      if (!ext.rawEvent || !canEditEvent(ext.rawEvent)) { arg.revert(); return }
+      updateEvent(id, {
+        title: ext.rawEvent.title,
+        startDate: parseDateToStr(start),
+        startTime: parseDateToTime(start),
+        endDate: parseDateToStr(end),
+        endTime: parseDateToTime(end),
+      })
     }
   }, [updateEvent, updateTask, canEditEvent, canEditTask])
 
@@ -315,9 +329,10 @@ export function Calendar() {
     return activeTab === 'my' ? tasks.filter((t) => !t.isTeamTask) : tasks.filter((t) => t.isTeamTask)
   }, [tasks, activeTab])
 
+  // 캘린더에는 내 할일 + 팀 할일 모두 표시 (사이드바는 탭으로 필터)
   const fullCalendarEvents = useMemo(
-    () => [...events.map(toOurEventFormat), ...filteredTasks.filter((t) => !t.done).map(taskToEventFormat)],
-    [events, filteredTasks]
+    () => [...events.map(toOurEventFormat), ...tasks.filter((t) => !t.done).map(taskToEventFormat)],
+    [events, tasks]
   )
 
   // 근무 일정 → FullCalendar businessHours (0=Sun, 1=Mon, ..., 6=Sat)

--- a/src/shared/api/tasksApi.ts
+++ b/src/shared/api/tasksApi.ts
@@ -12,6 +12,7 @@ export interface ApiTask {
   isTeamTask: boolean
   assigneeId: number | null
   assigneeName: string | null
+  createdById?: number | null  // 생성자 ID (백엔드 반환 시)
 }
 
 export interface CreateTaskPayload {
@@ -41,7 +42,9 @@ export const getTasks = (params?: GetTasksParams) => {
 export const createTask = (body: CreateTaskPayload) =>
   baseClient.post<ApiTask>('/api/v1/tasks', body)
 
-export const updateTask = (id: number, body: Partial<Omit<CreateTaskPayload, 'isTeamTask'>>) =>
+// PUT 요청 시 백엔드 필수 필드(title, date, time, priority) 포함
+export type UpdateTaskPayload = Partial<Omit<CreateTaskPayload, 'isTeamTask'>>
+export const updateTask = (id: number, body: UpdateTaskPayload) =>
   baseClient.put<ApiTask>(`/api/v1/tasks/${id}`, body)
 
 export const toggleTaskDone = (id: number) =>


### PR DESCRIPTION
## 변경 내용

### 캘린더 통합 표시
- 기존: activeTab에 따라 내 할일 OR 팀 할일만 캘린더에 표시
- 변경: 내 할일 + 팀 할일 **모두 캘린더에 동시 표시**
- 팀 할일은 보라/인디고 계열 색상으로 구분

### 드래그 날짜 미반영 버그 수정
- 원인: `handleEventDrop`에서 `date`·`time`만 PUT 전송 → 백엔드 필수 필드 누락
- 수정: `title`·`priority` 포함하여 전송

### 팀 할일 권한 수정
- 기존: 담당자(`assigneeId`) 기준으로 편집 권한 체크 (잘못됨)
- 변경: **생성자(`createdBy`)** 기준으로 편집·삭제 권한 체크
- `ApiTask`에 `createdById` 필드 추가 (백엔드 반환 시 활용)
- `addTask` 시 백엔드 미지원해도 `currentUser.id`로 `createdBy` 보존