### PR TITLE
feat(calendar): 드래그 권한 분리 및 팀 할일 다중 멤버 기능 구현

### DIFF
--- a/src/entities/task/model/types.ts
+++ b/src/entities/task/model/types.ts
@@ -8,7 +8,9 @@ export interface Task {
   priority: TaskPriority
   done: boolean
   isTeamTask: boolean
-  assigneeId?: string
-  assigneeName?: string
+  assigneeId?: string       // 주 담당자 ID
+  assigneeName?: string     // 주 담당자 이름
+  memberIds?: string[]      // 추가 참여 멤버 ID 목록
+  memberNames?: string[]    // 추가 참여 멤버 이름 목록
   createdBy: string
 }

--- a/src/features/calendar/ui/AddTaskModal.tsx
+++ b/src/features/calendar/ui/AddTaskModal.tsx
@@ -18,6 +18,7 @@ interface Props {
   date: string
   priority: TaskPriority
   assigneeId: string
+  memberIds: string[]
   users: User[]
   inputRef: RefObject<HTMLInputElement | null>
   onTitleChange: (v: string) => void
@@ -25,23 +26,30 @@ interface Props {
   onDateChange: (v: string) => void
   onPriorityChange: (v: TaskPriority) => void
   onAssigneeChange: (v: string) => void
+  onMemberIdsChange: (ids: string[]) => void
   onAdd: () => void
   onClose: () => void
 }
 
 export function AddTaskModal({
-  open, tabType, title, time, date, priority, assigneeId, users, inputRef,
+  open, tabType, title, time, date, priority, assigneeId, memberIds, users, inputRef,
   onTitleChange, onTimeChange, onDateChange, onPriorityChange, onAssigneeChange,
-  onAdd, onClose,
+  onMemberIdsChange, onAdd, onClose,
 }: Props) {
   if (!open) return null
+
+  const addMember = (id: string) => {
+    if (id && !memberIds.includes(id)) onMemberIdsChange([...memberIds, id])
+  }
+  const removeMember = (id: string) => onMemberIdsChange(memberIds.filter((i) => i !== id))
+
   return (
     <div className="edit-task-modal-overlay" onClick={onClose}>
       <div className="edit-task-modal add-task-modal" onClick={(e) => e.stopPropagation()}>
         <div className="edit-task-header">
           <div className="edit-task-header-title">
             <h4>할일 추가</h4>
-            <span className={"task-type-badge " + (tabType === 'team' ? 'team' : 'my')}>
+            <span className={`task-type-badge ${tabType === 'team' ? 'team' : 'my'}`}>
               {tabType === 'team' ? '팀 할일' : '내 할일'}
             </span>
           </div>
@@ -68,14 +76,39 @@ export function AddTaskModal({
             </select>
           </div>
           {tabType === 'team' && (
-            <div className="add-task-row">
-              <label>담당자</label>
-              <select className="add-task-assignee" value={assigneeId} onChange={(e) => onAssigneeChange(e.target.value)}>
-                <option value="">담당자 없음</option>
-                <option value="all">팀원 전체</option>
-                {users.map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
-              </select>
-            </div>
+            <>
+              <div className="add-task-row">
+                <label>담당자</label>
+                <select className="add-task-assignee" value={assigneeId} onChange={(e) => onAssigneeChange(e.target.value)}>
+                  <option value="">담당자 없음</option>
+                  {users.map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
+                </select>
+              </div>
+              <div className="add-task-row">
+                <label>참여 멤버</label>
+                <div className="member-select-area">
+                  {memberIds.map((id) => {
+                    const u = users.find((u) => u.id === id)
+                    return (
+                      <span key={id} className="member-tag">
+                        {u?.name ?? id}
+                        <button type="button" onClick={() => removeMember(id)}>×</button>
+                      </span>
+                    )
+                  })}
+                  <select
+                    className="add-task-assignee"
+                    value=""
+                    onChange={(e) => addMember(e.target.value)}
+                  >
+                    <option value="">+ 멤버 추가</option>
+                    {users
+                      .filter((u) => u.id !== assigneeId && !memberIds.includes(u.id))
+                      .map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
+                  </select>
+                </div>
+              </div>
+            </>
           )}
           <div className="edit-task-actions add-task-modal-actions">
             <button className="cancel-btn" onClick={onClose}>취소</button>

--- a/src/features/calendar/ui/EditTaskModal.tsx
+++ b/src/features/calendar/ui/EditTaskModal.tsx
@@ -13,8 +13,10 @@ interface Props {
   currentUserId: string | undefined
   users: User[]
   assigneeId: string
+  memberIds: string[]
   priority: TaskPriority
   onAssigneeChange: (id: string) => void
+  onMemberIdsChange: (ids: string[]) => void
   onPriorityChange: (p: TaskPriority) => void
   onSave: () => void
   onClose: () => void
@@ -22,20 +24,28 @@ interface Props {
 }
 
 export function EditTaskModal({
-  task, currentUserId, users, assigneeId, priority,
-  onAssigneeChange, onPriorityChange, onSave, onClose, editInputRef,
+  task, currentUserId, users, assigneeId, memberIds, priority,
+  onAssigneeChange, onMemberIdsChange, onPriorityChange, onSave, onClose, editInputRef,
 }: Props) {
   if (!task) return null
+
+  const isTeamTask = task.isTeamTask
+
+  const addMember = (id: string) => {
+    if (id && !memberIds.includes(id)) onMemberIdsChange([...memberIds, id])
+  }
+  const removeMember = (id: string) => onMemberIdsChange(memberIds.filter((i) => i !== id))
+
   return (
     <div className="edit-task-modal-overlay" onClick={onClose}>
       <div className="edit-task-modal" onClick={(e) => e.stopPropagation()}>
         <div className="edit-task-header">
           <div className="edit-task-header-title">
             <h4>태스크 수정</h4>
-            <span className={"task-type-badge " + (!task.assigneeId || task.assigneeId === currentUserId ? 'my' : 'team')}>
-              {!task.assigneeId || task.assigneeId === currentUserId
-                ? '내 할일'
-                : task.assigneeId === 'all' ? '팀 할일 · 팀원 전체' : `팀 할일 · ${task.assigneeName || '담당자'}`}
+            <span className={`task-type-badge ${isTeamTask ? 'team' : 'my'}`}>
+              {isTeamTask
+                ? `팀 할일${task.assigneeName ? ` · ${task.assigneeName}` : ''}`
+                : '내 할일'}
             </span>
           </div>
           <button className="edit-task-close" onClick={onClose}><X size={20} /></button>
@@ -51,10 +61,35 @@ export function EditTaskModal({
           <label>담당자</label>
           <select className="add-task-assignee" value={assigneeId} onChange={(e) => onAssigneeChange(e.target.value)}>
             <option value="">담당자 없음 (내 할일)</option>
-            <option value="all">팀원 전체</option>
             {users.map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
           </select>
         </div>
+        {isTeamTask && (
+          <div className="add-task-row">
+            <label>참여 멤버</label>
+            <div className="member-select-area">
+              {memberIds.map((id) => {
+                const u = users.find((u) => u.id === id)
+                return (
+                  <span key={id} className="member-tag">
+                    {u?.name ?? id}
+                    <button type="button" onClick={() => removeMember(id)}>×</button>
+                  </span>
+                )
+              })}
+              <select
+                className="add-task-assignee"
+                value=""
+                onChange={(e) => addMember(e.target.value)}
+              >
+                <option value="">+ 멤버 추가</option>
+                {users
+                  .filter((u) => u.id !== assigneeId && !memberIds.includes(u.id) && u.id !== currentUserId)
+                  .map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
+              </select>
+            </div>
+          </div>
+        )}
         <div className="edit-task-actions">
           <button className="cancel-btn" onClick={onClose}>취소</button>
           <button className="add-btn" onClick={onSave}>저장</button>

--- a/src/features/tasks/model/TasksProvider.tsx
+++ b/src/features/tasks/model/TasksProvider.tsx
@@ -76,6 +76,8 @@ function toTask(api: ApiTask): Task {
     isTeamTask: api.isTeamTask,
     assigneeId: api.assigneeId != null ? String(api.assigneeId) : undefined,
     assigneeName: api.assigneeName ?? undefined,
+    memberIds: api.memberIds?.map(String) ?? undefined,
+    memberNames: api.memberNames?.filter(Boolean) as string[] | undefined,
     // createdById 있으면 생성자 ID 사용, 없으면 빈 문자열 (권한 체크 시 fallback)
     createdBy: api.createdById != null ? String(api.createdById) : '',
   }
@@ -105,6 +107,7 @@ export function TasksProvider({ children }: { children: ReactNode }) {
       priority: PRIORITY_TO_API[task.priority] ?? 'MEDIUM',
       isTeamTask: task.isTeamTask,
       assigneeId: task.assigneeId ? Number(task.assigneeId) : null,
+      memberIds: task.memberIds?.map(Number),
     })
     // 생성 직후: 백엔드가 createdById를 안 내려줘도 현재 유저 ID로 보존
     const newTask = toTask(apiTask)

--- a/src/pages/calendar/calendar.css
+++ b/src/pages/calendar/calendar.css
@@ -784,6 +784,43 @@
   color: var(--text-secondary);
 }
 
+/* 멀티 멤버 선택 영역 */
+.member-select-area {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.member-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: rgba(139, 92, 246, 0.2);
+  border: 1px solid rgba(139, 92, 246, 0.4);
+  border-radius: 20px;
+  padding: 2px 8px 2px 10px;
+  font-size: 0.8rem;
+  color: var(--text-primary);
+}
+
+.member-tag button {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  transition: color 0.15s;
+}
+
+.member-tag button:hover {
+  color: #ef4444;
+}
+
 .event-detail-creator {
   font-size: 0.82rem;
   color: var(--text-secondary);

--- a/src/pages/calendar/index.tsx
+++ b/src/pages/calendar/index.tsx
@@ -57,6 +57,8 @@ export function Calendar() {
   const [newTaskDate, setNewTaskDate] = useState(getTodayStr())
   const [newTaskPriority, setNewTaskPriority] = useState<TaskPriority>('medium')
   const [newTaskAssigneeId, setNewTaskAssigneeId] = useState<string>('')
+  const [newTaskMemberIds, setNewTaskMemberIds] = useState<string[]>([])
+  const [editTaskMemberIds, setEditTaskMemberIds] = useState<string[]>([])
   const [editingTask, setEditingTask] = useState<Task | null>(null)
   const [contextMenuModalOpen, setContextMenuModalOpen] = useState(false)
   const [pendingSelectRange, setPendingSelectRange] = useState<{ start: Date; end: Date } | null>(null)
@@ -96,18 +98,37 @@ export function Calendar() {
   const todayStr = getTodayStr()
   const DELETE_ANIM_DURATION = 320
 
-  // 권한 헬퍼 — admin/team_lead는 모두 편집 가능
-  const isAdmin = state.currentUser?.role === 'ADMIN' || state.currentUser?.role === 'TEAM_LEAD'
+  // 권한 헬퍼
+  // ADMIN: 일정·팀 할일 모두 이동/편집 가능
+  // TEAM_LEAD: 팀 할일만 이동/편집 가능, 일정은 본인 것만
+  // MEMBER: 본인이 만든 것만
+  const isAdmin = state.currentUser?.role === 'ADMIN'
+  const isTeamLead = state.currentUser?.role === 'TEAM_LEAD'
+
   const canEditEvent = useCallback((event: CalendarEvent) =>
     isAdmin || event.createdBy === state.currentUser?.name,
     [isAdmin, state.currentUser],
   )
   const canEditTask = useCallback((task: Task) => {
     if (isAdmin) return true
-    if (!task.isTeamTask) return true // 내 할일은 항상 본인 것
-    // 팀 할일: 생성자(createdBy)만 편집 가능
+    if (!task.isTeamTask) return true
+    // 팀 할일: TEAM_LEAD 또는 생성자만 편집 가능
+    if (isTeamLead) return true
     return task.createdBy === String(state.currentUser?.id)
-  }, [isAdmin, state.currentUser])
+  }, [isAdmin, isTeamLead, state.currentUser])
+
+  // 드래그 전용 권한 (편집 권한과 분리)
+  // - 일정: ADMIN 또는 본인 것
+  // - 팀 할일: ADMIN, TEAM_LEAD 또는 생성자
+  // - 내 할일: 항상 본인 것
+  const canDragEvent = useCallback((event: CalendarEvent) =>
+    isAdmin || event.createdBy === state.currentUser?.name,
+    [isAdmin, state.currentUser],
+  )
+  const canDragTask = useCallback((task: Task) => {
+    if (!task.isTeamTask) return true
+    return isAdmin || isTeamLead || task.createdBy === String(state.currentUser?.id)
+  }, [isAdmin, isTeamLead, state.currentUser])
 
   const handleAddTask = (closeModal?: boolean) => {
     const title = newTaskTitle.trim()
@@ -115,22 +136,26 @@ export function Calendar() {
     const timeStr = newTaskTime ? formatTimeForDisplay(newTaskTime) : '--:--'
     let assigneeId: string | undefined
     let assigneeName: string | undefined
-    if (activeTab === 'team' && newTaskAssigneeId) {
-      if (newTaskAssigneeId === 'all') {
-        assigneeId = 'all'
-        assigneeName = '팀원 전체'
-      } else {
+    let memberIds: string[] | undefined
+    let memberNames: string[] | undefined
+    if (activeTab === 'team') {
+      if (newTaskAssigneeId) {
         const assignee = state.users.find((u) => u.id === newTaskAssigneeId)
         assigneeId = newTaskAssigneeId
         assigneeName = assignee?.name
       }
+      if (newTaskMemberIds.length > 0) {
+        memberIds = newTaskMemberIds
+        memberNames = newTaskMemberIds.map((id) => state.users.find((u) => u.id === id)?.name ?? '').filter(Boolean)
+      }
     }
-    addTask({ title, time: timeStr, date: newTaskDate, priority: newTaskPriority, done: false, isTeamTask: activeTab === 'team', assigneeId, assigneeName })
+    addTask({ title, time: timeStr, date: newTaskDate, priority: newTaskPriority, done: false, isTeamTask: activeTab === 'team', assigneeId, assigneeName, memberIds, memberNames })
     setNewTaskTitle('')
     setNewTaskTime(getCurrentTimeStr())
     setNewTaskDate(getTodayStr())
     setNewTaskPriority('medium')
     setNewTaskAssigneeId('')
+    setNewTaskMemberIds([])
     if (closeModal) setAddTaskModalOpen(false)
   }
 
@@ -214,17 +239,18 @@ export function Calendar() {
     if (!title) return
     let assigneeId: string | undefined
     let assigneeName: string | undefined
+    let memberIds: string[] | undefined
+    let memberNames: string[] | undefined
     if (editTaskAssigneeId) {
-      if (editTaskAssigneeId === 'all') {
-        assigneeId = 'all'
-        assigneeName = '팀원 전체'
-      } else {
-        const assignee = state.users.find((u) => u.id === editTaskAssigneeId)
-        assigneeId = editTaskAssigneeId
-        assigneeName = assignee?.name
-      }
+      const assignee = state.users.find((u) => u.id === editTaskAssigneeId)
+      assigneeId = editTaskAssigneeId
+      assigneeName = assignee?.name
     }
-    updateTask(editingTask.id, { title, assigneeId, assigneeName, priority: editTaskPriority })
+    if (editTaskMemberIds.length > 0) {
+      memberIds = editTaskMemberIds
+      memberNames = editTaskMemberIds.map((id) => state.users.find((u) => u.id === id)?.name ?? '').filter(Boolean)
+    }
+    updateTask(editingTask.id, { title, assigneeId, assigneeName, memberIds, memberNames, priority: editTaskPriority })
     setEditingTask(null)
   }
 
@@ -267,11 +293,10 @@ export function Calendar() {
     const start = arg.event.start!
     const end = arg.event.end!
     if (ext?.isTask && id.startsWith('task-')) {
-      if (!ext.rawTask || !canEditTask(ext.rawTask)) { arg.revert(); return }
+      if (!ext.rawTask || !canDragTask(ext.rawTask)) { arg.revert(); return }
       const taskId = id.replace(/^task-/, '')
       const newDate = parseDateToStr(start)
       const time24 = parseDateToTime(start)
-      // PUT 백엔드 호환: 기존 title·priority 함께 전송
       updateTask(taskId, {
         title: ext.rawTask.title,
         date: newDate,
@@ -279,7 +304,7 @@ export function Calendar() {
         priority: ext.rawTask.priority,
       })
     } else {
-      if (!ext.rawEvent || !canEditEvent(ext.rawEvent)) { arg.revert(); return }
+      if (!ext.rawEvent || !canDragEvent(ext.rawEvent)) { arg.revert(); return }
       updateEvent(id, {
         title: ext.rawEvent.title,
         startDate: parseDateToStr(start),
@@ -288,7 +313,7 @@ export function Calendar() {
         endTime: parseDateToTime(end),
       })
     }
-  }, [updateEvent, updateTask, canEditEvent, canEditTask])
+  }, [updateEvent, updateTask, canDragEvent, canDragTask])
 
   const handleDatesSet = useCallback((arg: { start: Date; end: Date; view: { type: string } }) => {
     const key = `${arg.view.type}-${arg.start.getFullYear()}-${arg.start.getMonth()}`
@@ -308,7 +333,7 @@ export function Calendar() {
     if (!id) return
     const ext = arg.event.extendedProps as { isTask?: boolean; rawEvent?: CalendarEvent }
     if (ext?.isTask && id.startsWith('task-')) return
-    if (ext.rawEvent && !canEditEvent(ext.rawEvent)) { arg.revert(); return }
+    if (ext.rawEvent && !canDragEvent(ext.rawEvent)) { arg.revert(); return }
     const start = arg.event.start!
     const end = arg.event.end!
     updateEvent(id, { startDate: parseDateToStr(start), startTime: parseDateToTime(start), endDate: parseDateToStr(end), endTime: parseDateToTime(end) })
@@ -318,6 +343,7 @@ export function Calendar() {
     if (editingTask) {
       setEditTaskAssigneeId(editingTask.assigneeId || '')
       setEditTaskPriority(editingTask.priority)
+      setEditTaskMemberIds(editingTask.memberIds ?? [])
       editInputRef.current?.focus()
     }
   }, [editingTask])
@@ -454,14 +480,42 @@ export function Calendar() {
               </select>
             </div>
             {activeTab === 'team' && (
-              <div className="add-task-row">
-                <label>담당자</label>
-                <select className="add-task-assignee" value={newTaskAssigneeId} onChange={(e) => setNewTaskAssigneeId(e.target.value)}>
-                  <option value="">담당자 없음</option>
-                  <option value="all">팀원 전체</option>
-                  {state.users.map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
-                </select>
-              </div>
+              <>
+                <div className="add-task-row">
+                  <label>담당자</label>
+                  <select className="add-task-assignee" value={newTaskAssigneeId} onChange={(e) => setNewTaskAssigneeId(e.target.value)}>
+                    <option value="">담당자 없음</option>
+                    {state.users.map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
+                  </select>
+                </div>
+                <div className="add-task-row">
+                  <label>멤버 추가</label>
+                  <div className="member-select-area">
+                    {newTaskMemberIds.map((id) => {
+                      const u = state.users.find((u) => u.id === id)
+                      return (
+                        <span key={id} className="member-tag">
+                          {u?.name}
+                          <button type="button" onClick={() => setNewTaskMemberIds((prev) => prev.filter((i) => i !== id))}>×</button>
+                        </span>
+                      )
+                    })}
+                    <select
+                      className="add-task-assignee"
+                      value=""
+                      onChange={(e) => {
+                        const val = e.target.value
+                        if (val && !newTaskMemberIds.includes(val)) setNewTaskMemberIds((prev) => [...prev, val])
+                      }}
+                    >
+                      <option value="">+ 멤버 추가</option>
+                      {state.users.filter((u) => u.id !== newTaskAssigneeId && !newTaskMemberIds.includes(u.id)).map((u) => (
+                        <option key={u.id} value={u.id}>{u.name}</option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+              </>
             )}
             <div className="add-task-row">
               <button className="add-task-inline-btn" onClick={() => handleAddTask()}>추가</button>
@@ -558,8 +612,10 @@ export function Calendar() {
         currentUserId={state.currentUser?.id}
         users={state.users}
         assigneeId={editTaskAssigneeId}
+        memberIds={editTaskMemberIds}
         priority={editTaskPriority}
         onAssigneeChange={setEditTaskAssigneeId}
+        onMemberIdsChange={setEditTaskMemberIds}
         onPriorityChange={setEditTaskPriority}
         onSave={handleUpdateTask}
         onClose={() => setEditingTask(null)}
@@ -582,6 +638,7 @@ export function Calendar() {
         date={newTaskDate}
         priority={newTaskPriority}
         assigneeId={newTaskAssigneeId}
+        memberIds={newTaskMemberIds}
         users={state.users}
         inputRef={addTaskModalInputRef}
         onTitleChange={setNewTaskTitle}
@@ -589,6 +646,7 @@ export function Calendar() {
         onDateChange={setNewTaskDate}
         onPriorityChange={setNewTaskPriority}
         onAssigneeChange={setNewTaskAssigneeId}
+        onMemberIdsChange={setNewTaskMemberIds}
         onAdd={() => handleAddTask(true)}
         onClose={() => setAddTaskModalOpen(false)}
       />

--- a/src/shared/api/tasksApi.ts
+++ b/src/shared/api/tasksApi.ts
@@ -12,7 +12,9 @@ export interface ApiTask {
   isTeamTask: boolean
   assigneeId: number | null
   assigneeName: string | null
-  createdById?: number | null  // 생성자 ID (백엔드 반환 시)
+  memberIds?: number[] | null    // 추가 참여 멤버 ID 목록
+  memberNames?: string[] | null  // 추가 참여 멤버 이름 목록
+  createdById?: number | null    // 생성자 ID (백엔드 반환 시)
 }
 
 export interface CreateTaskPayload {
@@ -22,6 +24,7 @@ export interface CreateTaskPayload {
   priority: ApiTaskPriority
   isTeamTask: boolean
   assigneeId?: number | null
+  memberIds?: number[]  // 추가 참여 멤버 ID 목록
 }
 
 export interface GetTasksParams {


### PR DESCRIPTION
## 변경 내용

### 드래그 권한 분리
| 역할 | 일정(event) | 팀 할일 | 내 할일 |
|------|------------|---------|---------|
| ADMIN | ✅ 전체 | ✅ 전체 | ✅ |
| TEAM_LEAD | 본인 것만 | ✅ 전체 | ✅ |
| MEMBER | 본인 것만 | 생성자만 | ✅ |

### 팀 할일 다중 멤버 추가
- 기존 "팀원 전체" 옵션 제거
- 담당자 1명 (주 담당자) 설정
- 하위에 참여 멤버 복수 추가/삭제 가능 (태그 UI)
- `AddTaskModal`, `EditTaskModal`, 인라인 폼 모두 적용

### 데이터 구조
- `Task`: `memberIds?: string[]`, `memberNames?: string[]` 추가
- `ApiTask`: `memberIds`, `memberNames` 백엔드 필드 추가
- `CreateTaskPayload`: `memberIds?: number[]` 추가