### PR TITLE
fix(calendar): EventsContext MSW 핸들러 경로 및 응답 형식 수정

### DIFF
--- a/src/shared/api/mock/handlers/calendar.ts
+++ b/src/shared/api/mock/handlers/calendar.ts
@@ -1,32 +1,58 @@
 import { http, HttpResponse } from 'msw'
 
-let mockEvents = [
-  { id: 'e1', title: '팀 주간 회의', startDate: '2026-03-18', startTime: '10:00', endDate: '2026-03-18', endTime: '11:00', createdBy: '1' },
-  { id: 'e2', title: '디자인 리뷰', startDate: '2026-03-19', startTime: '14:00', endDate: '2026-03-19', endTime: '15:00', createdBy: '2' },
-  { id: 'e3', title: '스프린트 계획', startDate: '2026-03-23', startTime: '09:00', endDate: '2026-03-23', endTime: '10:30', createdBy: '1' },
+interface MockEvent {
+  id: number
+  title: string
+  startDate: string
+  startTime: string
+  endDate: string
+  endTime: string
+  createdById: number
+  createdByName: string
+}
+
+let nextId = 4
+let mockEvents: MockEvent[] = [
+  { id: 1, title: '팀 주간 회의', startDate: '2026-03-18', startTime: '10:00:00', endDate: '2026-03-18', endTime: '11:00:00', createdById: 1, createdByName: '김리더' },
+  { id: 2, title: '디자인 리뷰', startDate: '2026-03-19', startTime: '14:00:00', endDate: '2026-03-19', endTime: '15:00:00', createdById: 2, createdByName: '박팀장' },
+  { id: 3, title: '스프린트 계획', startDate: '2026-03-23', startTime: '09:00:00', endDate: '2026-03-23', endTime: '10:30:00', createdById: 1, createdByName: '김리더' },
 ]
 
+const ok = <T>(data: T) => HttpResponse.json({ code: 'SUCCESS', message: 'ok', data })
+
 export const calendarHandlers = [
-  http.get('/events', () => {
-    return HttpResponse.json(mockEvents)
+  http.get('/api/v1/events', ({ request }) => {
+    const url = new URL(request.url)
+    const startDate = url.searchParams.get('startDate')
+    const endDate = url.searchParams.get('endDate')
+    const filtered = startDate && endDate
+      ? mockEvents.filter((e) => e.startDate >= startDate && e.startDate <= endDate)
+      : mockEvents
+    return ok(filtered)
   }),
 
-  http.post('/events', async ({ request }) => {
-    const body = await request.json() as { title: string; startDate: string; startTime: string; endDate: string; endTime: string }
-    const newEvent = { ...body, id: `e${Date.now()}`, createdBy: '1' }
+  http.get('/api/v1/events/me', () => {
+    return ok(mockEvents.filter((e) => e.createdById === 1))
+  }),
+
+  http.post('/api/v1/events', async ({ request }) => {
+    const body = await request.json() as Omit<MockEvent, 'id' | 'createdById' | 'createdByName'>
+    const newEvent: MockEvent = { ...body, id: nextId++, createdById: 1, createdByName: '김리더' }
     mockEvents = [...mockEvents, newEvent]
-    return HttpResponse.json(newEvent, { status: 201 })
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: newEvent }, { status: 201 })
   }),
 
-  http.put('/events/:id', async ({ params, request }) => {
-    const body = await request.json() as Partial<typeof mockEvents[0]>
-    mockEvents = mockEvents.map((e) => e.id === params.id ? { ...e, ...body } : e)
-    const updated = mockEvents.find((e) => e.id === params.id)
-    return HttpResponse.json(updated)
+  http.put('/api/v1/events/:id', async ({ params, request }) => {
+    const id = Number(params.id)
+    const body = await request.json() as Partial<MockEvent>
+    mockEvents = mockEvents.map((e) => e.id === id ? { ...e, ...body } : e)
+    const updated = mockEvents.find((e) => e.id === id)
+    return ok(updated)
   }),
 
-  http.delete('/events/:id', ({ params }) => {
-    mockEvents = mockEvents.filter((e) => e.id !== params.id)
-    return HttpResponse.json({ success: true })
+  http.delete('/api/v1/events/:id', ({ params }) => {
+    const id = Number(params.id)
+    mockEvents = mockEvents.filter((e) => e.id !== id)
+    return ok(null)
   }),
 ]

--- a/src/shared/api/mock/handlers/drive.ts
+++ b/src/shared/api/mock/handlers/drive.ts
@@ -12,13 +12,25 @@ export const driveHandlers = [
   }),
 
   http.post('/drive/upload', async ({ request }) => {
-    const formData = await request.formData()
-    const file = formData.get('file') as File | null
+    let fileName = 'unknown'
+    let fileType = 'application/octet-stream'
+    let fileSize = 0
+    try {
+      const formData = await request.formData()
+      const file = formData.get('file') as File | null
+      if (file) {
+        fileName = file.name
+        fileType = file.type
+        fileSize = file.size
+      }
+    } catch {
+      // node 환경에서 formData 파싱 실패 시 기본값 사용
+    }
     const newFile = {
       id: `f${Date.now()}`,
-      name: file?.name ?? 'unknown',
-      type: file?.type ?? 'application/octet-stream',
-      size: file?.size ?? 0,
+      name: fileName,
+      type: fileType,
+      size: fileSize,
       uploadedBy: '1',
       uploadedAt: new Date().toISOString(),
       folder: null,


### PR DESCRIPTION
## 문제

CI에서 `ReferenceError: window is not defined` unhandled rejection 에러 발생으로 테스트 실패.

## 원인

- `calendarHandlers`가 `/events` 경로를 사용 → `calendarApi.ts`는 `/api/v1/events` 호출
- 응답 포맷 불일치: raw 배열 반환 vs 실제 `{ code, message, data }` 래퍼 필요
- 핸들러 미매칭 → MSW 오류 → `.catch(() => setEvents(...))` 가 테스트 종료 후 실행 → `window is not defined`
- `driveHandlers` uploadFile: `request.formData()` 파싱이 node 환경에서 실패 시 500 반환

## 해결

- `calendarHandlers` 경로 `/api/v1/events` 로 수정
- `startDate`, `endDate` 쿼리 파라미터 필터링 추가
- 응답 형식 `{ code: 'SUCCESS', message: 'ok', data }` 래퍼로 통일
- `ApiEvent` 타입 정합: `id: number`, `createdById`, `createdByName`, `HH:mm:ss` 시간 포맷
- `driveHandlers` `uploadFile`: `formData` 파싱 실패 시 기본값 fallback 처리

## 결과

- 전체 테스트 44 파일, 286개 통과

관련 이슈: closes #129