### PR TITLE
feat(deploy): develop → main 배포 (API 스펙 동기화, 휴가 기능, 테스트 수정)

### DIFF
--- a/src/shared/api/mock/handlers/calendar.ts
+++ b/src/shared/api/mock/handlers/calendar.ts
@@ -1,32 +1,58 @@
 import { http, HttpResponse } from 'msw'
 
-let mockEvents = [
-  { id: 'e1', title: '팀 주간 회의', startDate: '2026-03-18', startTime: '10:00', endDate: '2026-03-18', endTime: '11:00', createdBy: '1' },
-  { id: 'e2', title: '디자인 리뷰', startDate: '2026-03-19', startTime: '14:00', endDate: '2026-03-19', endTime: '15:00', createdBy: '2' },
-  { id: 'e3', title: '스프린트 계획', startDate: '2026-03-23', startTime: '09:00', endDate: '2026-03-23', endTime: '10:30', createdBy: '1' },
+interface MockEvent {
+  id: number
+  title: string
+  startDate: string
+  startTime: string
+  endDate: string
+  endTime: string
+  createdById: number
+  createdByName: string
+}
+
+let nextId = 4
+let mockEvents: MockEvent[] = [
+  { id: 1, title: '팀 주간 회의', startDate: '2026-03-18', startTime: '10:00:00', endDate: '2026-03-18', endTime: '11:00:00', createdById: 1, createdByName: '김리더' },
+  { id: 2, title: '디자인 리뷰', startDate: '2026-03-19', startTime: '14:00:00', endDate: '2026-03-19', endTime: '15:00:00', createdById: 2, createdByName: '박팀장' },
+  { id: 3, title: '스프린트 계획', startDate: '2026-03-23', startTime: '09:00:00', endDate: '2026-03-23', endTime: '10:30:00', createdById: 1, createdByName: '김리더' },
 ]
 
+const ok = <T>(data: T) => HttpResponse.json({ code: 'SUCCESS', message: 'ok', data })
+
 export const calendarHandlers = [
-  http.get('/events', () => {
-    return HttpResponse.json(mockEvents)
+  http.get('/api/v1/events', ({ request }) => {
+    const url = new URL(request.url)
+    const startDate = url.searchParams.get('startDate')
+    const endDate = url.searchParams.get('endDate')
+    const filtered = startDate && endDate
+      ? mockEvents.filter((e) => e.startDate >= startDate && e.startDate <= endDate)
+      : mockEvents
+    return ok(filtered)
   }),
 
-  http.post('/events', async ({ request }) => {
-    const body = await request.json() as { title: string; startDate: string; startTime: string; endDate: string; endTime: string }
-    const newEvent = { ...body, id: `e${Date.now()}`, createdBy: '1' }
+  http.get('/api/v1/events/me', () => {
+    return ok(mockEvents.filter((e) => e.createdById === 1))
+  }),
+
+  http.post('/api/v1/events', async ({ request }) => {
+    const body = await request.json() as Omit<MockEvent, 'id' | 'createdById' | 'createdByName'>
+    const newEvent: MockEvent = { ...body, id: nextId++, createdById: 1, createdByName: '김리더' }
     mockEvents = [...mockEvents, newEvent]
-    return HttpResponse.json(newEvent, { status: 201 })
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: newEvent }, { status: 201 })
   }),
 
-  http.put('/events/:id', async ({ params, request }) => {
-    const body = await request.json() as Partial<typeof mockEvents[0]>
-    mockEvents = mockEvents.map((e) => e.id === params.id ? { ...e, ...body } : e)
-    const updated = mockEvents.find((e) => e.id === params.id)
-    return HttpResponse.json(updated)
+  http.put('/api/v1/events/:id', async ({ params, request }) => {
+    const id = Number(params.id)
+    const body = await request.json() as Partial<MockEvent>
+    mockEvents = mockEvents.map((e) => e.id === id ? { ...e, ...body } : e)
+    const updated = mockEvents.find((e) => e.id === id)
+    return ok(updated)
   }),
 
-  http.delete('/events/:id', ({ params }) => {
-    mockEvents = mockEvents.filter((e) => e.id !== params.id)
-    return HttpResponse.json({ success: true })
+  http.delete('/api/v1/events/:id', ({ params }) => {
+    const id = Number(params.id)
+    mockEvents = mockEvents.filter((e) => e.id !== id)
+    return ok(null)
   }),
 ]

--- a/src/shared/api/mock/handlers/drive.ts
+++ b/src/shared/api/mock/handlers/drive.ts
@@ -12,13 +12,25 @@ export const driveHandlers = [
   }),
 
   http.post('/drive/upload', async ({ request }) => {
-    const formData = await request.formData()
-    const file = formData.get('file') as File | null
+    let fileName = 'unknown'
+    let fileType = 'application/octet-stream'
+    let fileSize = 0
+    try {
+      const formData = await request.formData()
+      const file = formData.get('file') as File | null
+      if (file) {
+        fileName = file.name
+        fileType = file.type
+        fileSize = file.size
+      }
+    } catch {
+      // node 환경에서 formData 파싱 실패 시 기본값 사용
+    }
     const newFile = {
       id: `f${Date.now()}`,
-      name: file?.name ?? 'unknown',
-      type: file?.type ?? 'application/octet-stream',
-      size: file?.size ?? 0,
+      name: fileName,
+      type: fileType,
+      size: fileSize,
       uploadedBy: '1',
       uploadedAt: new Date().toISOString(),
       folder: null,


### PR DESCRIPTION
## 배포 내용

### API 스펙 동기화 (feat/api-spec-sync)
- 백엔드 OpenAPI 3.1.0 스펙 기반 타입/API/로직 전면 정합성 수정
- `User` 타입에 `status: 'ACTIVE' | 'INACTIVE'` 추가, `PersonalWorkSchedule` 제거
- 근무 일정: 단일 객체 → 요일별 배열 방식 (`DayOfWeek` enum)
- `getMyAttendance()` date 파라미터 제거 → 클라이언트 필터링으로 전환
- `membersApi`, `authClient` id 타입 `integer → String` 변환
- 비밀번호 변경: `currentPassword/newPassword` → `password` 단일 필드
- `tasksApi` `createdById` 제거, `UpdateTaskPayload`에 `memberIds` 추가
- 회원 상태 필드 `active` → `status('ACTIVE'|'INACTIVE')` 전환

### 휴가 신청 기능 구현 (feat/leave)
- `LeaveCategory`, `LeaveStatus`, `Leave` 엔티티 신규 추가
- 휴가 신청 폼 + 내 신청 내역 + 관리자 승인/반려 UI (`LeaveSection`)
- `leavesApi` 반환 타입 `Leave` 전체로 수정

### 테스트/Mock 수정 (fix/calendar-msw-handlers)
- `calendarHandlers` 경로 `/events` → `/api/v1/events` 수정
- 응답 포맷 `{ code, message, data }` 래퍼 통일
- `driveHandlers` `uploadFile` formData 파싱 fallback 처리
- CI `window is not defined` unhandled rejection 에러 해결

## 테스트

- 전체 테스트 44 파일, 286개 통과

관련 이슈: closes #129