### PR TITLE
feat(drive): 드라이브 API 스펙 연동 및 다운로드 기능 구현

### DIFF
--- a/src/pages/drive/__tests__/Drive.test.tsx
+++ b/src/pages/drive/__tests__/Drive.test.tsx
@@ -1,8 +1,12 @@
-import { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterEach, afterAll, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { setupServer } from 'msw/node'
 import { driveHandlers } from '../../../shared/api/mock/handlers/drive'
 import { Drive } from '../index'
+
+// jsdom에서 URL.createObjectURL 미구현 → 스텁
+URL.createObjectURL = vi.fn(() => 'blob:mock-url')
+URL.revokeObjectURL = vi.fn()
 
 const server = setupServer(...driveHandlers)
 beforeAll(() => server.listen())
@@ -20,10 +24,26 @@ describe('Drive 페이지', () => {
     expect(screen.getByText('업로드')).toBeInTheDocument()
   })
 
-  it('파일 목록을 로드한다', async () => {
+  it('파일 목록을 로드하면 파일명이 표시된다', async () => {
     render(<Drive />)
     await waitFor(() => {
-      expect(screen.getAllByRole('button').length).toBeGreaterThan(1)
+      expect(screen.getByText('프로젝트 기획서.pdf')).toBeInTheDocument()
+    })
+  })
+
+  it('파일 목록에 다운로드 버튼이 표시된다', async () => {
+    render(<Drive />)
+    await waitFor(() => {
+      const downloadBtns = screen.getAllByTitle('다운로드')
+      expect(downloadBtns.length).toBeGreaterThan(0)
+    })
+  })
+
+  it('파일 목록에 삭제 버튼이 표시된다', async () => {
+    render(<Drive />)
+    await waitFor(() => {
+      const deleteBtns = screen.getAllByTitle('삭제')
+      expect(deleteBtns.length).toBeGreaterThan(0)
     })
   })
 })

--- a/src/pages/drive/drive.css
+++ b/src/pages/drive/drive.css
@@ -116,6 +116,12 @@
   font-size: 0.875rem;
 }
 
+.file-meta {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.download-btn,
 .delete-btn {
   background: transparent;
   border: none;
@@ -126,9 +132,39 @@
   display: flex;
   align-items: center;
   transition: color 0.2s;
-  margin-left: auto;
 }
+.download-btn:hover { color: var(--accent-purple-light); }
 .delete-btn:hover { color: #ef4444; }
-.file-size { font-size: 12px; color: var(--text-secondary); margin-left: auto; }
+.file-size { font-size: 12px; color: var(--text-secondary); }
 .empty-msg { color: var(--text-secondary); font-size: 14px; padding: 20px 0; }
+
+.drive-toast {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 10px;
+  margin-bottom: 16px;
+  font-size: 0.9rem;
+}
+
+.drive-toast.error {
+  background: rgba(239, 68, 68, 0.15);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  color: #fca5a5;
+}
+
+.drive-toast button {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 0 4px;
+  opacity: 0.7;
+  transition: opacity 0.2s;
+}
+
+.drive-toast button:hover { opacity: 1; }
 

--- a/src/pages/drive/index.tsx
+++ b/src/pages/drive/index.tsx
@@ -1,30 +1,20 @@
 import { useState, useEffect, useRef } from 'react'
-import { Folder, FileText, Image, Upload, Trash2, ChevronRight } from 'lucide-react'
-import { getFiles, uploadFile, deleteFile } from '../../shared/api/driveApi'
+import { FileText, Image, Upload, Trash2, Download } from 'lucide-react'
+import { getFiles, uploadFile, deleteFile, downloadFile } from '../../shared/api/driveApi'
 import type { DriveFile } from '../../shared/api/driveApi'
 import './drive.css'
 
-const folderColors: Record<string, string> = {
-  디자인: '#7c3aed',
-  Documents: '#3b82f6',
-  Projects: '#22c55e',
-  Shared: '#ec4899',
-}
-
 export function Drive() {
   const [files, setFiles] = useState<DriveFile[]>([])
-  const [currentFolder, setCurrentFolder] = useState<string | null>(null)
   const [uploading, setUploading] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     getFiles()
       .then(setFiles)
-      .catch(() => {})
+      .catch(() => setErrorMessage('파일 목록을 불러오지 못했습니다'))
   }, [])
-
-  const folders = [...new Set(files.map((f) => f.folder).filter(Boolean))] as string[]
-  const visibleFiles = files.filter((f) => f.folder === currentFolder)
 
   const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
@@ -34,28 +24,55 @@ export function Drive() {
       const newFile = await uploadFile(file)
       setFiles((prev) => [...prev, newFile])
     } catch {
+      setErrorMessage('파일 업로드에 실패했습니다')
     } finally {
       setUploading(false)
       if (fileInputRef.current) fileInputRef.current.value = ''
     }
   }
 
-  const handleDelete = async (id: string) => {
+  const handleDelete = async (id: number) => {
     setFiles((prev) => prev.filter((f) => f.id !== id))
     try {
       await deleteFile(id)
     } catch {
+      setErrorMessage('파일 삭제에 실패했습니다')
       getFiles().then(setFiles).catch(() => {})
     }
   }
 
-  const getFileIcon = (type: string) => {
-    if (type.includes('image')) return <Image size={20} />
+  const handleDownload = async (file: DriveFile) => {
+    try {
+      const url = await downloadFile(file.id)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = file.originalName
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch {
+      setErrorMessage('파일 다운로드에 실패했습니다')
+    }
+  }
+
+  const getFileIcon = (contentType: string) => {
+    if (contentType.startsWith('image/')) return <Image size={20} />
     return <FileText size={20} />
+  }
+
+  const formatSize = (bytes: number) => {
+    if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+    return `${(bytes / 1024).toFixed(0)} KB`
   }
 
   return (
     <div className="drive-page">
+      {errorMessage && (
+        <div className="drive-toast error" role="alert">
+          {errorMessage}
+          <button onClick={() => setErrorMessage(null)}>✕</button>
+        </div>
+      )}
+
       <header className="drive-header">
         <h1>파일 드라이브</h1>
         <button
@@ -75,53 +92,25 @@ export function Drive() {
       </header>
 
       <div className="drive-content glass">
-        <div className="breadcrumb">
-          <button onClick={() => setCurrentFolder(null)}>드라이브</button>
-          {currentFolder && (
-            <span>
-              <ChevronRight size={14} />
-              <button>{currentFolder}</button>
-            </span>
-          )}
-        </div>
-
-        {currentFolder === null && (
-          <section className="folders-section">
-            <h3>폴더</h3>
-            <div className="folder-grid">
-              {folders.map((name) => (
-                <div
-                  key={name}
-                  className="folder-card"
-                  onClick={() => setCurrentFolder(name)}
-                >
-                  <div
-                    className="folder-icon"
-                    style={{
-                      background: (folderColors[name] ?? '#7c3aed') + '30',
-                      color: folderColors[name] ?? '#7c3aed',
-                    }}
-                  >
-                    <Folder size={32} />
-                  </div>
-                  <span>{name}</span>
-                </div>
-              ))}
-            </div>
-          </section>
-        )}
-
         <section className="recent-section">
-          <h3>{currentFolder ? `${currentFolder} 파일` : '루트 파일'}</h3>
-          {visibleFiles.length === 0 ? (
+          <h3>파일 목록</h3>
+          {files.length === 0 ? (
             <p className="empty-msg">파일이 없습니다.</p>
           ) : (
             <div className="file-list">
-              {visibleFiles.map((f) => (
+              {files.map((f) => (
                 <div key={f.id} className="file-row">
-                  <span className="file-icon">{getFileIcon(f.type)}</span>
-                  <span className="file-name">{f.name}</span>
-                  <span className="file-size">{(f.size / 1024).toFixed(0)} KB</span>
+                  <span className="file-icon">{getFileIcon(f.contentType)}</span>
+                  <span className="file-name">{f.originalName}</span>
+                  <span className="file-meta">{f.uploadedByName}</span>
+                  <span className="file-size">{formatSize(f.size)}</span>
+                  <button
+                    className="download-btn"
+                    onClick={() => handleDownload(f)}
+                    title="다운로드"
+                  >
+                    <Download size={16} />
+                  </button>
                   <button
                     className="delete-btn"
                     onClick={() => handleDelete(f.id)}

--- a/src/shared/api/__tests__/driveApi.test.ts
+++ b/src/shared/api/__tests__/driveApi.test.ts
@@ -1,7 +1,11 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest'
 import { setupServer } from 'msw/node'
 import { driveHandlers } from '../mock/handlers/drive'
-import { getFiles, uploadFile, deleteFile } from '../driveApi'
+import { getFiles, uploadFile, deleteFile, downloadFile } from '../driveApi'
+
+// jsdom에서 URL.createObjectURL 미구현 → 메서드만 스텁
+URL.createObjectURL = vi.fn(() => 'blob:mock-url')
+URL.revokeObjectURL = vi.fn()
 
 const server = setupServer(...driveHandlers)
 
@@ -13,20 +17,26 @@ describe('driveApi', () => {
   it('getFiles() 파일 목록을 반환한다', async () => {
     const files = await getFiles()
     expect(files).toHaveLength(3)
-    expect(files[0]).toHaveProperty('name')
-    expect(files[0]).toHaveProperty('type')
+    expect(files[0]).toHaveProperty('originalName')
+    expect(files[0]).toHaveProperty('contentType')
+    expect(typeof files[0].id).toBe('number')
   })
 
   it('uploadFile() 파일을 업로드하고 새 파일 정보를 반환한다', async () => {
     const file = new File(['content'], 'test.pdf', { type: 'application/pdf' })
     const result = await uploadFile(file)
     expect(result).toHaveProperty('id')
-    expect(result).toHaveProperty('name')
-    expect(result).toHaveProperty('type')
+    expect(result).toHaveProperty('originalName')
+    expect(result).toHaveProperty('contentType')
   })
 
-  it('deleteFile() 파일을 삭제하고 success를 반환한다', async () => {
-    const result = await deleteFile('1')
-    expect(result).toEqual({ success: true })
+  it('deleteFile() 파일을 삭제한다', async () => {
+    await expect(deleteFile(1)).resolves.not.toThrow()
+  })
+
+  it('downloadFile() Blob URL을 반환한다', async () => {
+    const url = await downloadFile(2)
+    expect(typeof url).toBe('string')
+    expect(url.length).toBeGreaterThan(0)
   })
 })

--- a/src/shared/api/baseClient.ts
+++ b/src/shared/api/baseClient.ts
@@ -62,6 +62,45 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   return body as T
 }
 
+async function requestBlob(path: string): Promise<Blob> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    headers: getAuthHeaders(),
+  })
+  if (res.status === 401) {
+    handleUnauthorized()
+    throw new ApiError(401, '인증이 만료되었습니다')
+  }
+  if (!res.ok) throw new ApiError(res.status, `다운로드 실패: ${res.status}`)
+  return res.blob()
+}
+
+async function requestUpload<T>(path: string, formData: FormData): Promise<T> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: 'POST',
+    headers: getAuthHeaders(), // Content-Type 미설정 → 브라우저가 multipart boundary 자동 지정
+    body: formData,
+  })
+  if (res.status === 401) {
+    handleUnauthorized()
+    throw new ApiError(401, '인증이 만료되었습니다')
+  }
+  if (!res.ok) {
+    let message = `업로드 실패: ${res.status}`
+    let code = ''
+    try {
+      const data = await res.json() as { message?: string; code?: string }
+      if (data.message) message = data.message
+      if (data.code) code = data.code
+    } catch { /* noop */ }
+    throw new ApiError(res.status, message, code)
+  }
+  const body = await res.json() as unknown
+  if (body !== null && typeof body === 'object' && 'data' in body && 'code' in body) {
+    return (body as { data: T }).data
+  }
+  return body as T
+}
+
 export const baseClient = {
   get: <T>(path: string) => request<T>(path),
   post: <T>(path: string, body: unknown) =>
@@ -71,4 +110,6 @@ export const baseClient = {
   patch: <T>(path: string, body: unknown) =>
     request<T>(path, { method: 'PATCH', body: JSON.stringify(body) }),
   delete: <T>(path: string) => request<T>(path, { method: 'DELETE' }),
+  upload: <T>(path: string, formData: FormData) => requestUpload<T>(path, formData),
+  download: (path: string) => requestBlob(path),
 }

--- a/src/shared/api/driveApi.ts
+++ b/src/shared/api/driveApi.ts
@@ -1,31 +1,29 @@
 import { baseClient } from './baseClient'
 
+// OpenAPI DriveFileResponse 스펙
 export interface DriveFile {
-  id: string
-  name: string
-  type: string
+  id: number
+  originalName: string
   size: number
-  uploadedBy: string
-  uploadedAt: string
-  folder: string | null
+  contentType: string
+  uploadedById: number
+  uploadedByName: string
+  createdAt: string
 }
 
-export const getFiles = () => baseClient.get<DriveFile[]>('/drive/files')
+export const getFiles = () =>
+  baseClient.get<DriveFile[]>('/api/v1/drive')
 
-export async function uploadFile(file: File): Promise<DriveFile> {
+export const uploadFile = (file: File): Promise<DriveFile> => {
   const formData = new FormData()
   formData.append('file', file)
-  const BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? ''
-  const token = localStorage.getItem('accessToken')
-  const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {}
-  const res = await fetch(`${BASE_URL}/drive/upload`, {
-    method: 'POST',
-    headers,
-    body: formData,
-  })
-  if (!res.ok) throw new Error(`업로드 실패: ${res.status}`)
-  return res.json() as Promise<DriveFile>
+  return baseClient.upload<DriveFile>('/api/v1/drive/upload', formData)
 }
 
-export const deleteFile = (id: string) =>
-  baseClient.delete<{ success: boolean }>(`/drive/files/${id}`)
+export const deleteFile = (id: number) =>
+  baseClient.delete<null>(`/api/v1/drive/${id}`)
+
+export const downloadFile = async (id: number): Promise<string> => {
+  const blob = await baseClient.download(`/api/v1/drive/${id}/download`)
+  return URL.createObjectURL(blob)
+}

--- a/src/shared/api/mock/handlers/__tests__/handlers.test.ts
+++ b/src/shared/api/mock/handlers/__tests__/handlers.test.ts
@@ -41,17 +41,18 @@ describe('MSW 핸들러 — 채팅', () => {
 })
 
 describe('MSW 핸들러 — 드라이브', () => {
-  it('GET /drive/files 성공 시 파일 배열을 반환한다', async () => {
-    const res = await fetch('/drive/files', {
+  it('GET /api/v1/drive 성공 시 파일 배열을 반환한다', async () => {
+    const res = await fetch('/api/v1/drive', {
       headers: { Authorization: 'Bearer mock-token' },
     })
-    const data = await res.json()
+    const body = await res.json() as { code: string; data: unknown[] }
     expect(res.status).toBe(200)
-    expect(Array.isArray(data)).toBe(true)
+    expect(body.code).toBe('SUCCESS')
+    expect(Array.isArray(body.data)).toBe(true)
   })
 
-  it('DELETE /drive/files/:id 성공 시 200을 반환한다', async () => {
-    const res = await fetch('/drive/files/1', {
+  it('DELETE /api/v1/drive/:id 성공 시 200을 반환한다', async () => {
+    const res = await fetch('/api/v1/drive/1', {
       method: 'DELETE',
       headers: { Authorization: 'Bearer mock-token' },
     })

--- a/src/shared/api/mock/handlers/drive.ts
+++ b/src/shared/api/mock/handlers/drive.ts
@@ -1,17 +1,30 @@
 import { http, HttpResponse } from 'msw'
 
-let mockFiles = [
-  { id: '1', name: '프로젝트 기획서.pdf', type: 'application/pdf', size: 204800, uploadedBy: '1', uploadedAt: '2026-03-15T10:00:00Z', folder: null },
-  { id: '2', name: '디자인 시안 v2.fig', type: 'application/figma', size: 1048576, uploadedBy: '2', uploadedAt: '2026-03-16T14:30:00Z', folder: '디자인' },
-  { id: '3', name: '회의록_0318.docx', type: 'application/docx', size: 51200, uploadedBy: '1', uploadedAt: '2026-03-18T11:00:00Z', folder: null },
+interface MockDriveFile {
+  id: number
+  originalName: string
+  size: number
+  contentType: string
+  uploadedById: number
+  uploadedByName: string
+  createdAt: string
+}
+
+let nextId = 4
+let mockFiles: MockDriveFile[] = [
+  { id: 1, originalName: '프로젝트 기획서.pdf', contentType: 'application/pdf', size: 204800, uploadedById: 1, uploadedByName: '김리더', createdAt: '2026-03-15T10:00:00Z' },
+  { id: 2, originalName: '디자인 시안 v2.fig', contentType: 'application/figma', size: 1048576, uploadedById: 2, uploadedByName: '박팀장', createdAt: '2026-03-16T14:30:00Z' },
+  { id: 3, originalName: '회의록_0318.docx', contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', size: 51200, uploadedById: 1, uploadedByName: '김리더', createdAt: '2026-03-18T11:00:00Z' },
 ]
 
+const ok = <T>(data: T) => HttpResponse.json({ code: 'SUCCESS', message: 'ok', data })
+
 export const driveHandlers = [
-  http.get('/drive/files', () => {
-    return HttpResponse.json(mockFiles)
+  http.get('/api/v1/drive', () => {
+    return ok(mockFiles)
   }),
 
-  http.post('/drive/upload', async ({ request }) => {
+  http.post('/api/v1/drive/upload', async ({ request }) => {
     let fileName = 'unknown'
     let fileType = 'application/octet-stream'
     let fileSize = 0
@@ -20,27 +33,37 @@ export const driveHandlers = [
       const file = formData.get('file') as File | null
       if (file) {
         fileName = file.name
-        fileType = file.type
+        fileType = file.type || 'application/octet-stream'
         fileSize = file.size
       }
     } catch {
       // node 환경에서 formData 파싱 실패 시 기본값 사용
     }
-    const newFile = {
-      id: `f${Date.now()}`,
-      name: fileName,
-      type: fileType,
+    const newFile: MockDriveFile = {
+      id: nextId++,
+      originalName: fileName,
+      contentType: fileType,
       size: fileSize,
-      uploadedBy: '1',
-      uploadedAt: new Date().toISOString(),
-      folder: null,
+      uploadedById: 1,
+      uploadedByName: '김리더',
+      createdAt: new Date().toISOString(),
     }
     mockFiles = [...mockFiles, newFile]
-    return HttpResponse.json(newFile, { status: 201 })
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: newFile }, { status: 201 })
   }),
 
-  http.delete('/drive/files/:id', ({ params }) => {
-    mockFiles = mockFiles.filter((f) => f.id !== params.id)
-    return HttpResponse.json({ success: true })
+  http.get('/api/v1/drive/:fileId/download', ({ params }) => {
+    const id = Number(params.fileId)
+    const file = mockFiles.find((f) => f.id === id)
+    if (!file) return new HttpResponse(null, { status: 404 })
+    return HttpResponse.arrayBuffer(new TextEncoder().encode('dummy-file-content').buffer as ArrayBuffer, {
+      headers: { 'Content-Type': 'application/octet-stream' },
+    })
+  }),
+
+  http.delete('/api/v1/drive/:fileId', ({ params }) => {
+    const id = Number(params.fileId)
+    mockFiles = mockFiles.filter((f) => f.id !== id)
+    return ok(null)
   }),
 ]


### PR DESCRIPTION
## 배포 내용

### 드라이브 API 스펙 연동
- `DriveFile` 타입을 `DriveFileResponse` 스펙으로 전면 갱신
  - `id: number`, `originalName`, `contentType`, `uploadedById/Name`, `createdAt`
  - 기존 `folder` 필드 제거
- 엔드포인트 `/api/v1/drive`, `/api/v1/drive/upload`, `/api/v1/drive/{fileId}` 로 변경
- `downloadFile()` 신규 추가 (`/api/v1/drive/{fileId}/download`)
- `baseClient`에 `upload()`, `download()` 메서드 추가 (multipart/form-data 지원)

### Drive 페이지 UI
- 폴더 네비게이션 제거 (스펙에 folder 없음)
- 다운로드 버튼 추가
- 에러 Toast 처리 추가

### 이전 배포 포함 내역 (develop → main)
- `fix/calendar-msw-handlers`: EventsContext MSW 핸들러 경로 수정 (CI 테스트 오류 해결)

## 테스트

- 전체 44 파일, 289개 통과

관련 이슈: closes #132