### PR TITLE
release: v0.1.1

### DIFF
--- a/src/features/attendance/model/__tests__/useWorkSchedule.test.ts
+++ b/src/features/attendance/model/__tests__/useWorkSchedule.test.ts
@@ -56,6 +56,19 @@ describe('useWorkSchedule', () => {
       expect(result.current.daySchedules[0].checkOutTime).toBe('18:00')
     })
 
+    it('저장된 주차 패턴이 없으면 모든 요일이 매주 패턴이다', async () => {
+      const { result } = await mountHook()
+      expect(result.current.weekPatterns).toEqual([
+        'EVERY',
+        'EVERY',
+        'EVERY',
+        'EVERY',
+        'EVERY',
+        'EVERY',
+        'EVERY',
+      ])
+    })
+
     it('로드 완료 후 isLoading이 false가 된다', async () => {
       const { result } = await mountHook()
       expect(result.current.isLoading).toBe(false)
@@ -103,6 +116,14 @@ describe('useWorkSchedule', () => {
     })
   })
 
+  describe('setWeekPattern', () => {
+    it('특정 요일의 주차 패턴을 변경할 수 있다', async () => {
+      const { result } = await mountHook()
+      act(() => { result.current.setWeekPattern(0, 'SECOND') })
+      expect(result.current.weekPatterns[0]).toBe('SECOND')
+    })
+  })
+
   describe('saveSchedule', () => {
     it('저장 시 API를 호출하고 isSaving이 false로 돌아온다', async () => {
       const { result } = await mountHook()
@@ -120,6 +141,21 @@ describe('useWorkSchedule', () => {
       expect(parsed.length).toBe(7)
     })
 
+    it('저장 시 localStorage에 weekPatterns가 저장된다', async () => {
+      const { result } = await mountHook()
+      act(() => {
+        result.current.setWeekPattern(0, 'THIRD')
+      })
+
+      await act(async () => {
+        await result.current.saveSchedule()
+      })
+
+      const stored = localStorage.getItem('yanus-work-week-patterns')
+      expect(stored).not.toBeNull()
+      expect(JSON.parse(stored!)[0]).toBe('THIRD')
+    })
+
     it('localStorage에 저장된 workDays를 마운트 시 복원한다', async () => {
       localStorage.setItem('yanus-work-days', JSON.stringify(
         [false, true, true, true, true, false, false],
@@ -127,6 +163,21 @@ describe('useWorkSchedule', () => {
       const { result } = await mountHook()
       expect(result.current.workDays[0]).toBe(false)
       expect(result.current.workDays[1]).toBe(true)
+    })
+
+    it('localStorage에 저장된 weekPatterns를 마운트 시 복원한다', async () => {
+      localStorage.setItem('yanus-work-week-patterns', JSON.stringify([
+        'LAST',
+        'EVERY',
+        'EVERY',
+        'EVERY',
+        'EVERY',
+        'EVERY',
+        'EVERY',
+      ]))
+
+      const { result } = await mountHook()
+      expect(result.current.weekPatterns[0]).toBe('LAST')
     })
 
     it('기존에 저장된 요일을 비활성화하면 삭제 API를 호출한다', async () => {

--- a/src/features/attendance/model/useWorkSchedule.ts
+++ b/src/features/attendance/model/useWorkSchedule.ts
@@ -8,15 +8,19 @@ export interface DaySchedule {
   checkOutTime: string  // "HH:mm"
 }
 
+export type WeekPattern = 'EVERY' | 'FIRST' | 'SECOND' | 'THIRD' | 'FOURTH' | 'LAST'
+
 // 배열 인덱스 ↔ DayOfWeek 매핑 (0=Mon, 1=Tue, ..., 6=Sun)
 const INDEX_TO_DOW: DayOfWeek[] = [
   'MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY', 'SUNDAY',
 ]
 
 const WORK_DAYS_STORAGE_KEY = 'yanus-work-days'
+const WORK_WEEK_PATTERNS_STORAGE_KEY = 'yanus-work-week-patterns'
 const DEFAULT_CHECK_IN = '09:00'
 const DEFAULT_CHECK_OUT = '18:00'
 const DEFAULT_WORK_DAYS = [false, false, false, false, false, false, false]
+const DEFAULT_WEEK_PATTERNS: WeekPattern[] = Array.from({ length: 7 }, () => 'EVERY')
 
 function makeDefaultDaySchedules(checkIn: string, checkOut: string): DaySchedule[] {
   return Array.from({ length: 7 }, () => ({ checkInTime: checkIn, checkOutTime: checkOut }))
@@ -27,6 +31,7 @@ export function useWorkSchedule() {
   const [daySchedules, setDaySchedules] = useState<DaySchedule[]>(
     makeDefaultDaySchedules(DEFAULT_CHECK_IN, DEFAULT_CHECK_OUT),
   )
+  const [weekPatterns, setWeekPatterns] = useState<WeekPattern[]>(DEFAULT_WEEK_PATTERNS)
   const [isLoading, setIsLoading] = useState(true)
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -39,6 +44,14 @@ export function useWorkSchedule() {
       try {
         const parsed = JSON.parse(storedDays) as boolean[]
         if (Array.isArray(parsed) && parsed.length === 7) setWorkDays(parsed)
+      } catch {}
+    }
+
+    const storedWeekPatterns = localStorage.getItem(WORK_WEEK_PATTERNS_STORAGE_KEY)
+    if (storedWeekPatterns) {
+      try {
+        const parsed = JSON.parse(storedWeekPatterns) as WeekPattern[]
+        if (Array.isArray(parsed) && parsed.length === 7) setWeekPatterns(parsed)
       } catch {}
     }
 
@@ -84,6 +97,10 @@ export function useWorkSchedule() {
     setDaySchedules((prev) => prev.map((s, i) => (i === index ? { ...s, [field]: value } : s)))
   }
 
+  const setWeekPattern = (index: number, value: WeekPattern) => {
+    setWeekPatterns((prev) => prev.map((pattern, i) => (i === index ? value : pattern)))
+  }
+
   const saveSchedule = async () => {
     setIsSaving(true)
     setError(null)
@@ -109,6 +126,7 @@ export function useWorkSchedule() {
       await Promise.all([...upsertPromises, ...deletePromises])
       setSavedWorkDays([...workDays])
       localStorage.setItem(WORK_DAYS_STORAGE_KEY, JSON.stringify(workDays))
+      localStorage.setItem(WORK_WEEK_PATTERNS_STORAGE_KEY, JSON.stringify(weekPatterns))
     } catch (err) {
       if (err instanceof ApiError) {
         setError(err.message)
@@ -120,5 +138,16 @@ export function useWorkSchedule() {
     }
   }
 
-  return { workDays, daySchedules, isLoading, isSaving, error, toggleDay, setDayTime, saveSchedule }
+  return {
+    workDays,
+    daySchedules,
+    weekPatterns,
+    isLoading,
+    isSaving,
+    error,
+    toggleDay,
+    setDayTime,
+    setWeekPattern,
+    saveSchedule,
+  }
 }

--- a/src/features/attendance/ui/SetWorkDaysPersonal.css
+++ b/src/features/attendance/ui/SetWorkDaysPersonal.css
@@ -20,6 +20,8 @@
 .set-work-days-personal .desc {
   color: var(--text-secondary);
   font-size: 0.85rem;
+  line-height: 1.6;
+  margin: 0;
 }
 
 .member-info {
@@ -53,35 +55,75 @@
   padding: 12px 0;
 }
 
-/* ── 가로 배치 그리드 ── */
+.schedule-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  flex-wrap: wrap;
+  padding: 16px 18px;
+  border-radius: 18px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border-color);
+}
+
+.schedule-summary p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.83rem;
+  line-height: 1.6;
+}
+
+.summary-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: var(--surface-tint);
+  color: var(--text-primary);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
 .day-schedule-grid {
   display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  gap: 10px;
-  overflow-x: auto;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
 }
 
 .day-col {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 10px;
-  padding: 14px 8px;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid transparent;
-  transition: border-color 0.2s, background 0.2s;
-  min-width: 80px;
+  gap: 16px;
+  padding: 18px;
+  border-radius: 22px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border-color);
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+  min-height: 220px;
 }
 
 .day-col.active {
-  background: rgba(139, 92, 246, 0.08);
-  border-color: rgba(139, 92, 246, 0.2);
+  background: var(--surface-tint);
+  border-color: rgba(138, 114, 216, 0.28);
+  box-shadow: 0 18px 36px rgba(9, 12, 24, 0.18);
+}
+
+.day-col:hover {
+  transform: translateY(-1px);
+}
+
+.day-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .day-label {
-  font-size: 0.78rem;
-  font-weight: 600;
+  display: block;
+  font-size: 1rem;
+  font-weight: 700;
   color: var(--text-secondary);
 }
 
@@ -89,13 +131,34 @@
   color: var(--text-primary);
 }
 
+.day-status {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 8px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.day-status.active {
+  background: rgba(37, 164, 111, 0.16);
+  color: var(--success);
+}
+
+.day-status.inactive {
+  background: rgba(148, 163, 184, 0.14);
+  color: var(--text-secondary);
+}
+
 .toggle {
-  width: 36px;
-  height: 20px;
-  border-radius: 10px;
+  width: 48px;
+  height: 28px;
+  border-radius: 999px;
   background: rgba(148, 163, 184, 0.3);
   position: relative;
-  transition: background 0.2s;
+  border: 1px solid transparent;
+  transition: background 0.2s ease, border-color 0.2s ease;
   flex-shrink: 0;
   cursor: pointer;
 }
@@ -103,8 +166,8 @@
 .toggle::after {
   content: '';
   position: absolute;
-  width: 14px;
-  height: 14px;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
   background: var(--text-primary);
   top: 3px;
@@ -115,73 +178,122 @@
 
 .toggle.on {
   background: var(--accent-purple);
+  border-color: rgba(138, 114, 216, 0.34);
 }
 
 .toggle.on::after {
-  transform: translateX(16px);
+  transform: translateX(20px);
 }
 
-/* 시간 필드 — 세로 정렬 */
 .day-times {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
 }
 
 .time-field {
   display: flex;
   flex-direction: column;
-  gap: 3px;
-  align-items: center;
+  gap: 6px;
 }
 
 .time-field label {
-  font-size: 0.68rem;
+  font-size: 0.76rem;
+  font-weight: 600;
   color: var(--text-secondary);
-  white-space: nowrap;
 }
 
 .time-field input {
-  padding: 5px 6px;
-  border-radius: 6px;
+  padding: 10px 12px;
+  border-radius: 12px;
   border: 1px solid var(--border-color);
-  background: rgba(15, 15, 26, 0.5);
+  background: var(--bg-input);
   color: var(--text-primary);
-  font-size: 0.78rem;
+  font-size: 0.88rem;
   width: 100%;
-  min-width: 70px;
   color-scheme: dark;
-  text-align: center;
-  transition: border-color 0.2s;
+  transition: border-color 0.2s ease, background 0.2s ease;
 }
 
 .time-field input:focus {
   border-color: var(--accent-purple);
   outline: none;
+  background: var(--bg-card-solid);
 }
 
 .day-off-label {
-  font-size: 0.72rem;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
   color: var(--text-secondary);
-  opacity: 0.5;
-  margin-top: 4px;
+  margin-top: auto;
+}
+
+.day-off-label strong {
+  font-size: 0.86rem;
+  color: var(--text-primary);
+}
+
+.day-off-label span {
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.week-pattern-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.week-pattern-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.week-pattern-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.week-pattern-chip {
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid transparent;
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  font-weight: 600;
+  transition: all 0.2s ease;
+}
+
+.week-pattern-chip:hover {
+  background: rgba(138, 114, 216, 0.12);
+  color: var(--text-primary);
+}
+
+.week-pattern-chip.active {
+  background: var(--accent-purple);
+  color: var(--text-on-accent);
+  border-color: rgba(138, 114, 216, 0.38);
 }
 
 .schedule-error {
-  color: #f87171;
+  color: var(--error);
   font-size: 0.85rem;
 }
 
 .save-btn {
   align-self: flex-start;
-  padding: 10px 28px;
+  padding: 12px 24px;
   background: var(--gradient-purple);
-  color: var(--text-primary);
-  border-radius: 10px;
-  font-weight: 600;
-  font-size: 0.9rem;
-  transition: opacity 0.2s;
+  color: var(--text-on-accent);
+  border-radius: 14px;
+  font-weight: 700;
+  font-size: 0.92rem;
+  box-shadow: var(--shadow-soft);
+  transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
 .save-btn:disabled {
@@ -190,17 +302,27 @@
 }
 
 .save-btn:hover:not(:disabled) {
-  opacity: 0.85;
+  opacity: 0.92;
+  transform: translateY(-1px);
 }
 
-@media (max-width: 900px) {
+@media (max-width: 1100px) {
   .day-schedule-grid {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: 1fr;
   }
 }
 
-@media (max-width: 600px) {
-  .day-schedule-grid {
-    grid-template-columns: repeat(2, 1fr);
+@media (max-width: 640px) {
+  .schedule-summary {
+    padding: 14px 16px;
+  }
+
+  .day-col {
+    padding: 16px;
+    min-height: 0;
+  }
+
+  .day-times {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/features/attendance/ui/SetWorkDaysPersonal.tsx
+++ b/src/features/attendance/ui/SetWorkDaysPersonal.tsx
@@ -1,12 +1,32 @@
 import { useApp } from '../../auth/model/AppProvider'
 import { useWorkSchedule } from '../model/useWorkSchedule'
+import type { WeekPattern } from '../model/useWorkSchedule'
 import './SetWorkDaysPersonal.css'
 
 const DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+const WEEK_PATTERN_OPTIONS: { value: WeekPattern; label: string }[] = [
+  { value: 'EVERY', label: '매주' },
+  { value: 'FIRST', label: '1주차' },
+  { value: 'SECOND', label: '2주차' },
+  { value: 'THIRD', label: '3주차' },
+  { value: 'FOURTH', label: '4주차' },
+  { value: 'LAST', label: '마지막 주' },
+]
 
 export function SetWorkDaysPersonal() {
   const { state } = useApp()
-  const { workDays, daySchedules, isLoading, isSaving, error, toggleDay, setDayTime, saveSchedule } =
+  const {
+    workDays,
+    daySchedules,
+    weekPatterns,
+    isLoading,
+    isSaving,
+    error,
+    toggleDay,
+    setDayTime,
+    setWeekPattern,
+    saveSchedule,
+  } =
     useWorkSchedule()
 
   return (
@@ -14,12 +34,17 @@ export function SetWorkDaysPersonal() {
       <div className="schedule-header">
         <div>
           <h3>근무 일정 설정</h3>
-          <p className="desc">요일별로 출퇴근 시간을 개별 설정할 수 있습니다.</p>
+          <p className="desc">요일별 시간과 반복 주차를 함께 정리해 개인 근무 루틴을 관리할 수 있습니다.</p>
         </div>
         <div className="member-info">
           <span className="member-avatar">{state.currentUser?.name[0] ?? '?'}</span>
           <span className="member-name">{state.currentUser?.name ?? ''}</span>
         </div>
+      </div>
+
+      <div className="schedule-summary">
+        <span className="summary-chip">활성 요일 {workDays.filter(Boolean).length}일</span>
+        <p>주차 선택은 현재 브라우저에 함께 저장되며, 요일과 시간은 기존처럼 서버 저장을 유지합니다.</p>
       </div>
 
       {isLoading ? (
@@ -28,33 +53,63 @@ export function SetWorkDaysPersonal() {
         <div className="day-schedule-grid">
           {DAY_NAMES.map((day, i) => (
             <div key={day} className={`day-col ${workDays[i] ? 'active' : 'inactive'}`}>
-              <span className="day-label">{day}</span>
-              <button
-                className={`toggle ${workDays[i] ? 'on' : ''}`}
-                onClick={() => toggleDay(i)}
-                aria-label={`${day} 토글`}
-              />
-              {workDays[i] ? (
-                <div className="day-times">
-                  <div className="time-field">
-                    <label>출근</label>
-                    <input
-                      type="time"
-                      value={daySchedules[i].checkInTime}
-                      onChange={(e) => setDayTime(i, 'checkInTime', e.target.value)}
-                    />
-                  </div>
-                  <div className="time-field">
-                    <label>퇴근</label>
-                    <input
-                      type="time"
-                      value={daySchedules[i].checkOutTime}
-                      onChange={(e) => setDayTime(i, 'checkOutTime', e.target.value)}
-                    />
-                  </div>
+              <div className="day-card-head">
+                <div>
+                  <span className="day-label">{day}</span>
+                  <span className={`day-status ${workDays[i] ? 'active' : 'inactive'}`}>
+                    {workDays[i] ? '근무일' : '휴무'}
+                  </span>
                 </div>
+                <button
+                  type="button"
+                  className={`toggle ${workDays[i] ? 'on' : ''}`}
+                  onClick={() => toggleDay(i)}
+                  aria-label={`${day} 토글`}
+                />
+              </div>
+
+              {workDays[i] ? (
+                <>
+                  <div className="day-times">
+                    <div className="time-field">
+                      <label>출근</label>
+                      <input
+                        type="time"
+                        value={daySchedules[i].checkInTime}
+                        onChange={(e) => setDayTime(i, 'checkInTime', e.target.value)}
+                      />
+                    </div>
+                    <div className="time-field">
+                      <label>퇴근</label>
+                      <input
+                        type="time"
+                        value={daySchedules[i].checkOutTime}
+                        onChange={(e) => setDayTime(i, 'checkOutTime', e.target.value)}
+                      />
+                    </div>
+                  </div>
+
+                  <div className="week-pattern-group">
+                    <span className="week-pattern-label">반복 주차</span>
+                    <div className="week-pattern-options">
+                      {WEEK_PATTERN_OPTIONS.map((option) => (
+                        <button
+                          key={`${day}-${option.value}`}
+                          type="button"
+                          className={`week-pattern-chip ${weekPatterns[i] === option.value ? 'active' : ''}`}
+                          onClick={() => setWeekPattern(i, option.value)}
+                        >
+                          {option.label}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </>
               ) : (
-                <div className="day-off-label">휴무</div>
+                <div className="day-off-label">
+                  <strong>이번 요일은 비활성 상태입니다.</strong>
+                  <span>토글을 켜면 시간과 주차 패턴을 함께 설정할 수 있습니다.</span>
+                </div>
               )}
             </div>
           ))}

--- a/src/features/attendance/ui/__tests__/SetWorkDaysPersonal.test.tsx
+++ b/src/features/attendance/ui/__tests__/SetWorkDaysPersonal.test.tsx
@@ -87,6 +87,14 @@ describe('SetWorkDaysPersonal', () => {
     })
   })
 
+  it('활성 요일에는 반복 주차 선택 버튼이 표시된다', async () => {
+    render(<SetWorkDaysPersonal />, { wrapper })
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: '매주' }).length).toBe(5)
+    })
+  })
+
   it('저장 버튼이 존재한다', async () => {
     render(<SetWorkDaysPersonal />, { wrapper })
     await waitFor(() => {

--- a/src/pages/ai-chat/ai-chat.css
+++ b/src/pages/ai-chat/ai-chat.css
@@ -1,16 +1,14 @@
 .ai-chat-page {
-  margin: -24px;
-  min-height: calc(100vh - 48px);
-  height: calc(100vh - 48px);
-  max-height: calc(100vh - 48px);
+  min-height: 100%;
+  height: 100%;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  gap: 18px;
 }
 
 .ai-header {
   text-align: center;
-  padding: 16px 24px;
+  padding: 6px 12px 0;
   flex-shrink: 0;
 }
 
@@ -33,11 +31,12 @@
 }
 
 .ai-chat-area {
-  padding: 0 24px 24px;
+  padding: 24px;
   flex: 1;
   display: flex;
   flex-direction: column;
   min-height: 0;
+  border-radius: 28px;
 }
 
 .messages {
@@ -45,6 +44,7 @@
   overflow-y: auto;
   min-height: 200px;
   margin-bottom: 20px;
+  padding: 4px 4px 0;
 }
 
 .msg-bubble {
@@ -61,15 +61,16 @@
 
 .msg-bubble.user span {
   background: var(--accent-purple);
-  color: var(--text-primary);
+  color: var(--text-on-accent);
   padding: 12px 18px;
-  border-radius: 16px;
+  border-radius: 18px;
 }
 
 .msg-bubble.ai span {
-  background: rgba(148, 163, 184, 0.15);
+  background: var(--bg-soft);
+  border: 1px solid var(--border-color);
   padding: 12px 18px;
-  border-radius: 16px;
+  border-radius: 18px;
 }
 
 .msg-icon {
@@ -79,6 +80,10 @@
 
 .suggestions {
   margin-bottom: 20px;
+  padding: 16px 18px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
 }
 
 .suggestions p {
@@ -93,27 +98,31 @@
   padding: 12px 16px;
   margin-bottom: 8px;
   text-align: left;
-  background: rgba(124, 58, 237, 0.15);
-  color: var(--accent-purple-light);
-  border-radius: 10px;
+  background: rgba(138, 114, 216, 0.1);
+  color: var(--text-primary);
+  border: 1px solid transparent;
+  border-radius: 14px;
   font-size: 0.9rem;
+  transition: all 0.2s ease;
 }
 
 .suggestions button:hover {
-  background: rgba(124, 58, 237, 0.25);
+  background: rgba(138, 114, 216, 0.18);
+  border-color: rgba(138, 114, 216, 0.22);
 }
 
 .input-area {
   display: flex;
   gap: 12px;
+  padding-top: 4px;
 }
 
 .input-area input {
   flex: 1;
   padding: 14px 18px;
-  border-radius: 12px;
+  border-radius: 16px;
   border: 1px solid var(--border-color);
-  background: rgba(15, 15, 26, 0.6);
+  background: var(--bg-input);
   color: var(--text-primary);
   font-size: 1rem;
 }
@@ -125,12 +134,12 @@
 .input-area .send-btn {
   padding: 14px 20px;
   background: var(--gradient-purple);
-  color: var(--text-primary);
-  border-radius: 12px;
+  color: var(--text-on-accent);
+  border-radius: 16px;
 }
 
 @media (max-width: 768px) {
-  .ai-chat-page {
-    margin: -16px;
+  .ai-chat-area {
+    padding: 18px;
   }
 }

--- a/src/pages/chat/chat.css
+++ b/src/pages/chat/chat.css
@@ -1,10 +1,12 @@
 .chat-page {
   display: flex;
-  min-height: calc(100vh - 48px);
-  height: calc(100vh - 48px);
-  max-height: calc(100vh - 48px);
+  min-height: 100%;
+  height: 100%;
   gap: 0;
-  margin: -24px;
+  border-radius: 28px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-card);
+  box-shadow: var(--shadow-soft);
   overflow: hidden;
 }
 
@@ -13,7 +15,7 @@
   flex-shrink: 0;
   overflow-y: auto;
   padding: 20px;
-  border-radius: 0;
+  background: var(--bg-elevated);
   border-right: 1px solid var(--border-color);
 }
 
@@ -28,8 +30,9 @@
   align-items: center;
   gap: 8px;
   padding: 10px 12px;
-  background: rgba(15, 15, 26, 0.5);
-  border-radius: 8px;
+  background: var(--bg-input);
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
   margin-bottom: 20px;
 }
 
@@ -59,14 +62,20 @@
 
 .channel-item {
   padding: 12px;
-  border-radius: 8px;
+  border-radius: 14px;
   cursor: pointer;
   margin-bottom: 4px;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.channel-item:hover {
+  background: var(--nav-hover);
+  transform: translateX(2px);
 }
 
 .channel-item.active {
-  background: rgba(124, 58, 237, 0.25);
-  color: var(--accent-purple-light);
+  background: var(--nav-active);
+  color: var(--text-primary);
 }
 
 .channel-name {
@@ -86,13 +95,14 @@
   align-items: center;
   gap: 10px;
   padding: 10px 12px;
-  border-radius: 8px;
+  border-radius: 14px;
   cursor: pointer;
   margin-bottom: 4px;
+  transition: background 0.2s ease;
 }
 
 .dm-item:hover {
-  background: rgba(148, 163, 184, 0.08);
+  background: var(--nav-hover);
 }
 
 .dm-avatar {
@@ -127,15 +137,17 @@
   flex-direction: column;
   min-width: 0;
   min-height: 0;
+  background: rgba(16, 20, 36, 0.45);
 }
 
 .chat-header {
-  padding: 16px 24px;
+  padding: 18px 24px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  border-radius: 0;
+  background: rgba(255, 255, 255, 0.02);
   border-bottom: 1px solid var(--border-color);
+  box-shadow: none;
 }
 
 .chat-header h3 {
@@ -156,12 +168,22 @@
 .header-actions button {
   padding: 8px;
   color: var(--text-secondary);
+  border-radius: 10px;
+  background: transparent;
+}
+
+.header-actions button:hover {
+  background: var(--nav-hover);
+  color: var(--text-primary);
 }
 
 .chat-messages {
   flex: 1;
   overflow-y: auto;
   padding: 24px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.01) 0%, rgba(255, 255, 255, 0) 100%),
+    radial-gradient(circle at top right, rgba(212, 74, 153, 0.08), transparent 30%);
 }
 
 .msg {
@@ -199,8 +221,9 @@
 .msg-content {
   max-width: 75%;
   padding: 12px 16px;
-  background: rgba(30, 27, 45, 0.6);
-  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(164, 177, 214, 0.08);
+  border-radius: 16px;
 }
 
 .msg-meta {
@@ -309,12 +332,13 @@
 }
 
 .chat-input-area {
-  padding: 16px 24px;
+  padding: 18px 24px 22px;
   display: flex;
   flex-direction: column;
   gap: 10px;
-  border-radius: 0;
+  background: rgba(15, 18, 32, 0.72);
   border-top: 1px solid var(--border-color);
+  box-shadow: none;
 }
 
 .input-preview {
@@ -334,9 +358,9 @@
 .chat-input-area .chat-input {
   flex: 1;
   padding: 12px 16px;
-  background: rgba(15, 15, 26, 0.6);
+  background: var(--bg-input);
   border: 1px solid var(--border-color);
-  border-radius: 10px;
+  border-radius: 14px;
   color: var(--text-primary);
   font-size: 0.95rem;
   resize: none;
@@ -357,9 +381,12 @@
 .format-toolbar button {
   padding: 6px 8px;
   color: var(--text-secondary);
+  border-radius: 10px;
+  background: transparent;
 }
 
 .format-toolbar button:hover {
+  background: var(--nav-hover);
   color: var(--text-primary);
 }
 
@@ -506,22 +533,23 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 10px 20px;
+  padding: 12px 18px;
   background: var(--gradient-purple);
-  color: var(--text-primary);
-  border-radius: 10px;
-  font-weight: 500;
+  color: var(--text-on-accent);
+  border-radius: 14px;
+  font-weight: 700;
 }
 
 @media (max-width: 768px) {
   .chat-page {
     flex-direction: column;
+    min-height: 100%;
     height: auto;
   }
 
   .chat-sidebar {
     width: 100%;
-    max-height: 200px;
+    max-height: 240px;
   }
 
   .chat-main {

--- a/src/pages/settings/settings.css
+++ b/src/pages/settings/settings.css
@@ -6,9 +6,9 @@
 }
 
 .settings-header {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 380px);
+  align-items: end;
   gap: 20px;
 }
 
@@ -36,7 +36,8 @@
   align-items: center;
   gap: 14px;
   padding: 16px 18px;
-  max-width: 380px;
+  justify-self: end;
+  width: 100%;
 }
 
 .settings-summary-icon {
@@ -78,6 +79,8 @@
   padding: 14px;
   gap: 6px;
   border-radius: 20px;
+  position: sticky;
+  top: 16px;
 }
 
 .settings-nav-item {
@@ -109,6 +112,7 @@
 .settings-content {
   border-radius: 24px;
   padding: 30px;
+  min-width: 0;
 }
 
 .settings-section h3 {
@@ -416,12 +420,12 @@
 
 @media (max-width: 900px) {
   .settings-header {
-    flex-direction: column;
+    grid-template-columns: 1fr;
     align-items: stretch;
   }
 
   .settings-summary-card {
-    max-width: none;
+    justify-self: stretch;
   }
 
   .settings-layout {

--- a/src/widgets/Layout/Layout.css
+++ b/src/widgets/Layout/Layout.css
@@ -150,17 +150,20 @@
   padding: 24px 28px 28px;
   min-height: 100vh;
   height: 100vh;
+  display: flex;
+  flex-direction: column;
   overflow-y: auto;
   overflow-x: hidden;
 }
 
 .content-topbar {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  align-items: flex-end;
+  justify-content: flex-start;
   gap: 16px;
-  margin-bottom: 20px;
-  padding: 4px 4px 0;
+  margin-bottom: 24px;
+  padding: 4px 4px 18px;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .content-kicker {
@@ -177,28 +180,9 @@
   line-height: 1.1;
 }
 
-.content-user-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 14px;
-  border-radius: 999px;
-  background: var(--bg-card);
-  border: 1px solid var(--border-color);
-  color: var(--text-secondary);
-  box-shadow: var(--shadow-soft);
-}
-
-.content-user-status {
-  width: 8px;
-  height: 8px;
-  border-radius: 999px;
-  background: var(--success);
-  box-shadow: 0 0 0 6px rgba(37, 164, 111, 0.12);
-}
-
 .content-body {
-  min-height: calc(100vh - 140px);
+  flex: 1;
+  min-height: 0;
 }
 
 .sidebar-bottom {
@@ -328,13 +312,10 @@
 
   .content-topbar {
     padding-inline: 0;
+    padding-bottom: 14px;
   }
 
   .content-topbar h1 {
     font-size: 1.45rem;
-  }
-
-  .content-user-chip {
-    padding: 8px 12px;
   }
 }

--- a/src/widgets/Layout/Layout.tsx
+++ b/src/widgets/Layout/Layout.tsx
@@ -99,12 +99,6 @@ export function Layout() {
             <p className="content-kicker">Workspace</p>
             <h1>{pageTitle}</h1>
           </div>
-          {currentUser && (
-            <div className="content-user-chip">
-              <span className="content-user-status" />
-              <span>{currentUser.team}</span>
-            </div>
-          )}
         </header>
         <div className="content-body">
           <Outlet />


### PR DESCRIPTION
## 작업 내용
- 채팅, AI, 설정 화면의 레이아웃/CSS 정리와 상단 `BACKEND` 칩 제거를 배포합니다.
- 근무 일정 설정 카드 재구성과 주차 선택 기능을 배포합니다.
- 근무 일정 주차 선택 관련 테스트 보강을 함께 반영합니다.

## 변경 이유
- 최근 화면에서 상단 팀 칩, 과한 빈 공간, 카드 레이아웃이 어색하게 보여 운영 화면 정리가 필요했습니다.
- 근무 일정은 요일과 시간만으로는 반복 패턴을 담기 어려워 주차 선택 보강이 필요했습니다.
- 버전형 `main` PR 규칙에 맞춰 이번 배포는 `v0.1.1`로 정리했습니다.

## 상세 변경 사항
### 주요 변경
- [x] 상단 `BACKEND` 칩 제거 및 채팅/AI/설정 레이아웃 정리
- [x] 근무 일정 카드 개선과 `매주/1주차/2주차/3주차/4주차/마지막 주` 선택 추가
- [x] 주차 패턴 기본값과 localStorage 복원 테스트 반영

### 추가 메모
- 주차 선택은 현재 백엔드 스펙이 없어 브라우저 localStorage에 저장됩니다.
- 요일 on/off와 출퇴근 시간 저장은 기존 서버 API를 그대로 사용합니다.

## 테스트
- [x] `npm run test:run`
- [x] `npm run build`
- [ ] 브라우저에서 주요 동작 확인

## 리뷰 포인트
- 운영 화면에서 상단 칩 제거와 페이지 간격이 기대대로 보이는지 확인 부탁드립니다.
- 근무 일정 주차 선택이 저장 후 재진입 시 올바르게 복원되는지 확인 부탁드립니다.

## 관련 이슈
- refs #143