### PR TITLE
release: v0.1.2

### DIFF
--- a/src/pages/drive/__tests__/Drive.test.tsx
+++ b/src/pages/drive/__tests__/Drive.test.tsx
@@ -14,9 +14,9 @@ afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
 describe('Drive 페이지', () => {
-  it('파일 드라이브 제목이 렌더링된다', () => {
+  it('드라이브 안내 문구가 렌더링된다', () => {
     render(<Drive />)
-    expect(screen.getByText('파일 드라이브')).toBeInTheDocument()
+    expect(screen.getByText('최근 산출물과 문서를 한눈에 보고, 바로 업로드와 다운로드를 이어갈 수 있게 정리했습니다.')).toBeInTheDocument()
   })
 
   it('업로드 버튼이 렌더링된다', () => {

--- a/src/pages/drive/drive.css
+++ b/src/pages/drive/drive.css
@@ -18,22 +18,18 @@
 }
 
 .drive-kicker {
-  margin: 0 0 8px;
+  margin: 0 0 10px;
   color: var(--text-muted);
   font-size: 0.78rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.drive-header h1 {
-  font-size: 2rem;
-  margin: 0;
-}
-
 .drive-subtitle {
-  margin: 10px 0 0;
+  margin: 0;
   color: var(--text-secondary);
   line-height: 1.6;
+  font-size: 1rem;
 }
 
 .drive-header-actions {

--- a/src/pages/drive/index.tsx
+++ b/src/pages/drive/index.tsx
@@ -86,7 +86,6 @@ export function Drive() {
       <header className="drive-header">
         <div className="drive-header-copy">
           <p className="drive-kicker">Shared Library</p>
-          <h1>파일 드라이브</h1>
           <p className="drive-subtitle">
             최근 산출물과 문서를 한눈에 보고, 바로 업로드와 다운로드를 이어갈 수 있게 정리했습니다.
           </p>

--- a/src/pages/settings/__tests__/Settings.test.tsx
+++ b/src/pages/settings/__tests__/Settings.test.tsx
@@ -29,9 +29,9 @@ describe('Settings 페이지', () => {
     vi.clearAllMocks()
   })
 
-  it('설정 페이지 제목이 렌더링된다', () => {
+  it('설정 페이지 설명이 렌더링된다', () => {
     render(<Settings />)
-    expect(screen.getByText('설정')).toBeInTheDocument()
+    expect(screen.getByText('프로필, 알림, 테마, 보안 환경을 한 곳에서 관리하세요.')).toBeInTheDocument()
   })
 
   it('4개의 탭이 렌더링된다', () => {

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -76,9 +76,8 @@ export function Settings() {
         <Toast message={errorMessage} type="error" onClose={() => setErrorMessage(null)} />
       )}
       <header className="settings-header">
-        <div>
-          <p className="settings-kicker">Preferences</p>
-          <h1>설정</h1>
+        <div className="settings-header-copy">
+          <p className="settings-kicker">환경 관리</p>
           <p className="settings-subtitle">프로필, 알림, 테마, 보안 환경을 한 곳에서 관리하세요.</p>
         </div>
         <div className="settings-summary-card glass">

--- a/src/pages/settings/settings.css
+++ b/src/pages/settings/settings.css
@@ -12,23 +12,23 @@
   gap: 20px;
 }
 
+.settings-header-copy {
+  max-width: 620px;
+}
+
 .settings-kicker {
-  margin: 0 0 8px;
+  margin: 0 0 10px;
   color: var(--text-muted);
   font-size: 0.78rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.settings-header h1 {
-  margin: 0;
-  font-size: 2rem;
-}
-
 .settings-subtitle {
-  margin: 10px 0 0;
+  margin: 0;
   color: var(--text-secondary);
   line-height: 1.6;
+  font-size: 1rem;
 }
 
 .settings-summary-card {


### PR DESCRIPTION
## 작업 내용
- 설정과 드라이브 페이지에서 공통 상단 제목과 겹치던 내부 대제목을 제거합니다.
- 페이지 내부 헤더를 설명과 액션 중심 구조로 정리해 UI 일관성을 높입니다.
- 관련 화면 테스트 수정이 함께 포함됩니다.

## 변경 이유
- 공통 레이아웃이 이미 페이지명을 보여주고 있는데 페이지 내부에서 같은 제목을 반복해 UI가 겹쳐 보였습니다.
- 동일한 정보 반복을 줄여야 화면이 더 정돈되고 페이지 간 규칙도 맞출 수 있습니다.
- 버전형 `main` PR 규칙에 맞춰 이번 배포는 `v0.1.2`로 정리했습니다.

## 상세 변경 사항
### 주요 변경
- [x] 설정 페이지 내부 `설정` 대제목 제거
- [x] 드라이브 페이지 내부 `파일 드라이브` 대제목 제거
- [x] 설명형 헤더 기준으로 테스트 수정

### 추가 메모
- 공통 상단 타이틀은 그대로 유지하고, 페이지 내부는 설명/액션 역할만 남겼습니다.
- 이번 배포 범위는 설정과 드라이브 두 화면의 헤더 일관성 정리에 한정됩니다.

## 테스트
- [x] `npm run test:run`
- [x] `npm run build`
- [ ] 브라우저에서 주요 동작 확인

## 리뷰 포인트
- 공통 상단 제목과 페이지 내부 헤더가 더 이상 역할이 겹치지 않는지 확인 부탁드립니다.
- 이후 같은 기준을 다른 페이지에도 확장할지 검토해주시면 좋겠습니다.

## 관련 이슈
- refs #146