### PR TITLE
[feat] #151 - 일반 멤버 공용 드라이브 접근 개선

### DIFF
--- a/src/pages/drive/__tests__/Drive.test.tsx
+++ b/src/pages/drive/__tests__/Drive.test.tsx
@@ -1,8 +1,18 @@
-import { describe, it, expect, beforeAll, afterEach, afterAll, vi } from 'vitest'
+import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { setupServer } from 'msw/node'
-import { driveHandlers } from '../../../shared/api/mock/handlers/drive'
+import { driveHandlers, resetDriveMockData } from '../../../shared/api/mock/handlers/drive'
 import { Drive } from '../index'
+
+vi.mock('../../../features/auth/model', () => ({
+  useApp: () => ({
+    state: {
+      currentUser: { id: '3', name: '이멤버', role: 'MEMBER', team: 'AI' },
+      users: [],
+    },
+    isAdmin: false,
+  }),
+}))
 
 // jsdom에서 URL.createObjectURL 미구현 → 스텁
 URL.createObjectURL = vi.fn(() => 'blob:mock-url')
@@ -10,13 +20,23 @@ URL.revokeObjectURL = vi.fn()
 
 const server = setupServer(...driveHandlers)
 beforeAll(() => server.listen())
+beforeEach(() => {
+  localStorage.clear()
+  resetDriveMockData()
+})
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
 describe('Drive 페이지', () => {
   it('드라이브 안내 문구가 렌더링된다', () => {
     render(<Drive />)
-    expect(screen.getByText('최근 산출물과 문서를 한눈에 보고, 바로 업로드와 다운로드를 이어갈 수 있게 정리했습니다.')).toBeInTheDocument()
+    expect(screen.getByText('모든 멤버가 함께 쓰는 공용 문서함입니다. 업로드한 파일은 팀 전체가 바로 확인할 수 있습니다.')).toBeInTheDocument()
+  })
+
+  it('일반 멤버에게도 공용 업로드 버튼이 표시된다', () => {
+    render(<Drive />)
+    expect(screen.getByRole('button', { name: '공용 파일 업로드' })).toBeInTheDocument()
+    expect(screen.getByText('일반 멤버, 팀장, 관리자 모두 같은 공유 드라이브를 사용합니다.')).toBeInTheDocument()
   })
 
   it('업로드 버튼이 렌더링된다', () => {

--- a/src/pages/drive/drive.css
+++ b/src/pages/drive/drive.css
@@ -35,6 +35,21 @@
 .drive-header-actions {
   display: flex;
   align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.drive-access-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.12);
+  border: 1px solid rgba(129, 140, 248, 0.24);
+  color: var(--accent-purple-light);
+  font-size: 0.82rem;
+  font-weight: 600;
 }
 
 .upload-btn {
@@ -135,6 +150,32 @@
   color: var(--text-primary);
   font-weight: 700;
   border: 1px solid rgba(124, 58, 237, 0.24);
+}
+
+.drive-access-note {
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(99, 102, 241, 0.08);
+  border: 1px solid rgba(129, 140, 248, 0.16);
+}
+
+.drive-access-note span {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
+.drive-access-note strong {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 1rem;
+}
+
+.drive-access-note p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.6;
 }
 
 .drive-side-stats {

--- a/src/pages/drive/index.tsx
+++ b/src/pages/drive/index.tsx
@@ -2,18 +2,23 @@ import { useState, useEffect, useRef } from 'react'
 import { FileText, Image, Upload, Trash2, Download, Files, HardDrive, Clock3, Sparkles } from 'lucide-react'
 import { getFiles, uploadFile, deleteFile, downloadFile } from '../../shared/api/driveApi'
 import type { DriveFile } from '../../shared/api/driveApi'
+import { useApp } from '../../features/auth/model'
 import { Toast } from '../../shared/ui/Toast'
 import './drive.css'
 
 export function Drive() {
+  const { state } = useApp()
   const [files, setFiles] = useState<DriveFile[]>([])
   const [uploading, setUploading] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
+  const sortFilesByNewest = (items: DriveFile[]) =>
+    [...items].sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+
   useEffect(() => {
     getFiles()
-      .then(setFiles)
+      .then((items) => setFiles(sortFilesByNewest(items)))
       .catch(() => setErrorMessage('파일 목록을 불러오지 못했습니다'))
   }, [])
 
@@ -23,7 +28,7 @@ export function Drive() {
     setUploading(true)
     try {
       const newFile = await uploadFile(file)
-      setFiles((prev) => [...prev, newFile])
+      setFiles((prev) => sortFilesByNewest([...prev, newFile]))
     } catch {
       setErrorMessage('파일 업로드에 실패했습니다')
     } finally {
@@ -38,7 +43,7 @@ export function Drive() {
       await deleteFile(id)
     } catch {
       setErrorMessage('파일 삭제에 실패했습니다')
-      getFiles().then(setFiles).catch(() => {})
+      getFiles().then((items) => setFiles(sortFilesByNewest(items))).catch(() => {})
     }
   }
 
@@ -76,6 +81,7 @@ export function Drive() {
   const totalSize = files.reduce((sum, file) => sum + file.size, 0)
   const latestFile = [...files].sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0]
   const uploaderCount = new Set(files.map((file) => file.uploadedById)).size
+  const currentUserName = state.currentUser?.name ?? '모든 멤버'
 
   return (
     <div className="drive-page">
@@ -87,17 +93,18 @@ export function Drive() {
         <div className="drive-header-copy">
           <p className="drive-kicker">Shared Library</p>
           <p className="drive-subtitle">
-            최근 산출물과 문서를 한눈에 보고, 바로 업로드와 다운로드를 이어갈 수 있게 정리했습니다.
+            모든 멤버가 함께 쓰는 공용 문서함입니다. 업로드한 파일은 팀 전체가 바로 확인할 수 있습니다.
           </p>
         </div>
         <div className="drive-header-actions">
+          <span className="drive-access-badge">전체 멤버 공유</span>
           <button
             className="upload-btn"
             onClick={() => fileInputRef.current?.click()}
             disabled={uploading}
           >
             <Upload size={18} />
-            {uploading ? '업로드 중...' : '파일 업로드'}
+            {uploading ? '업로드 중...' : '공용 파일 업로드'}
           </button>
         </div>
         <input
@@ -143,10 +150,10 @@ export function Drive() {
           <div className="drive-panel-head">
             <span className="drive-panel-badge">
               <Sparkles size={14} />
-              정리된 업로드 흐름
+              팀 공유 라이브러리
             </span>
-            <h3>빠른 업로드</h3>
-            <p>회의록, 산출물, 참고 자료를 바로 올리고 팀원이 즉시 확인할 수 있게 구성했습니다.</p>
+            <h3>빠른 공유 업로드</h3>
+            <p>회의록, 산출물, 참고 자료를 올리면 일반 멤버를 포함한 팀 전체가 바로 같은 파일을 확인합니다.</p>
           </div>
           <button
             className="upload-cta"
@@ -154,8 +161,13 @@ export function Drive() {
             disabled={uploading}
           >
             <Upload size={18} />
-            {uploading ? '업로드 중...' : '새 파일 추가'}
+            {uploading ? '업로드 중...' : '새 공유 파일 추가'}
           </button>
+          <div className="drive-access-note">
+            <span>현재 업로드 가능 계정</span>
+            <strong>{currentUserName}</strong>
+            <p>일반 멤버, 팀장, 관리자 모두 같은 공유 드라이브를 사용합니다.</p>
+          </div>
           <div className="drive-side-stats">
             <div>
               <span>업로드 참여자</span>

--- a/src/shared/api/__tests__/driveApi.test.ts
+++ b/src/shared/api/__tests__/driveApi.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, afterEach, beforeEach, vi } from 'vitest'
 import { setupServer } from 'msw/node'
-import { driveHandlers } from '../mock/handlers/drive'
+import { driveHandlers, resetDriveMockData } from '../mock/handlers/drive'
 import { getFiles, uploadFile, deleteFile, downloadFile } from '../driveApi'
 
 // jsdom에서 URL.createObjectURL 미구현 → 메서드만 스텁
@@ -10,6 +10,10 @@ URL.revokeObjectURL = vi.fn()
 const server = setupServer(...driveHandlers)
 
 beforeAll(() => server.listen())
+beforeEach(() => {
+  localStorage.clear()
+  resetDriveMockData()
+})
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -28,6 +32,16 @@ describe('driveApi', () => {
     expect(result).toHaveProperty('id')
     expect(result).toHaveProperty('originalName')
     expect(result).toHaveProperty('contentType')
+  })
+
+  it('uploadFile()은 로그인한 멤버 이름으로 업로더를 기록한다', async () => {
+    localStorage.setItem('accessToken', 'mock-token-3')
+
+    const file = new File(['content'], 'shared-notes.md', { type: 'text/markdown' })
+    const result = await uploadFile(file)
+
+    expect(result.uploadedById).toBe(3)
+    expect(result.uploadedByName).toBe('이멤버')
   })
 
   it('deleteFile() 파일을 삭제한다', async () => {

--- a/src/shared/api/mock/handlers/__tests__/handlers.test.ts
+++ b/src/shared/api/mock/handlers/__tests__/handlers.test.ts
@@ -1,13 +1,17 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
 import { setupServer } from 'msw/node'
 import { handlers } from '../index'
+import { resetDriveMockData } from '../drive'
 
 // auth, members, attendance, calendar — 실제 백엔드 사용 (mock 핸들러 테스트 제외)
 // chat, drive mock 핸들러만 테스트
 const server = setupServer(...handlers)
 
 beforeAll(() => server.listen())
-afterEach(() => server.resetHandlers())
+afterEach(() => {
+  server.resetHandlers()
+  resetDriveMockData()
+})
 afterAll(() => server.close())
 
 describe('MSW 핸들러 — 채팅', () => {
@@ -57,5 +61,26 @@ describe('MSW 핸들러 — 드라이브', () => {
       headers: { Authorization: 'Bearer mock-token' },
     })
     expect(res.status).toBe(200)
+  })
+
+  it('POST /api/v1/drive/upload 성공 시 로그인한 멤버 업로더를 반환한다', async () => {
+    const formData = new FormData()
+    formData.append('file', new File(['hello'], 'shared-guide.txt', { type: 'text/plain' }))
+
+    const res = await fetch('/api/v1/drive/upload', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer mock-token-3' },
+      body: formData,
+    })
+
+    const body = await res.json() as {
+      code: string
+      data: { uploadedById: number; uploadedByName: string }
+    }
+
+    expect(res.status).toBe(201)
+    expect(body.code).toBe('SUCCESS')
+    expect(body.data.uploadedById).toBe(3)
+    expect(body.data.uploadedByName).toBe('이멤버')
   })
 })

--- a/src/shared/api/mock/handlers/auth.ts
+++ b/src/shared/api/mock/handlers/auth.ts
@@ -22,6 +22,17 @@ export function resetAuthMockData() {
   validCredentials = { ...INITIAL_CREDENTIALS }
 }
 
+export function getAuthMockUserByAuthorization(authorization: string | null): User {
+  if (!authorization?.startsWith('Bearer ')) {
+    return mockUsers[0]
+  }
+
+  const token = authorization.replace('Bearer ', '')
+  const userId = token.replace('mock-token-', '')
+
+  return mockUsers.find((user) => user.id === userId) ?? mockUsers[0]
+}
+
 export const authHandlers = [
   http.post('/api/v1/auth/login', async ({ request }) => {
     const body = await request.json() as { email: string; password: string }
@@ -69,15 +80,14 @@ export const authHandlers = [
   }),
 
   http.get('/api/v1/auth/me', ({ request }) => {
-    const auth = request.headers.get('Authorization') ?? ''
-    if (!auth.startsWith('Bearer ')) {
+    const authorization = request.headers.get('Authorization')
+    if (!authorization?.startsWith('Bearer ')) {
       return HttpResponse.json(
         { code: 'UNAUTHORIZED', message: '인증이 필요합니다', data: null },
         { status: 401 },
       )
     }
-    const userId = auth.replace('Bearer mock-token-', '')
-    const user = mockUsers.find((u) => u.id === userId) ?? mockUsers[0]
+    const user = getAuthMockUserByAuthorization(authorization)
     return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: user })
   }),
 

--- a/src/shared/api/mock/handlers/drive.ts
+++ b/src/shared/api/mock/handlers/drive.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from 'msw'
+import { getAuthMockUserByAuthorization } from './auth'
 
 interface MockDriveFile {
   id: number
@@ -10,12 +11,19 @@ interface MockDriveFile {
   createdAt: string
 }
 
-let nextId = 4
-let mockFiles: MockDriveFile[] = [
+const INITIAL_FILES: MockDriveFile[] = [
   { id: 1, originalName: '프로젝트 기획서.pdf', contentType: 'application/pdf', size: 204800, uploadedById: 1, uploadedByName: '김리더', createdAt: '2026-03-15T10:00:00Z' },
   { id: 2, originalName: '디자인 시안 v2.fig', contentType: 'application/figma', size: 1048576, uploadedById: 2, uploadedByName: '박팀장', createdAt: '2026-03-16T14:30:00Z' },
-  { id: 3, originalName: '회의록_0318.docx', contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', size: 51200, uploadedById: 1, uploadedByName: '김리더', createdAt: '2026-03-18T11:00:00Z' },
+  { id: 3, originalName: '회의록_0318.docx', contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', size: 51200, uploadedById: 3, uploadedByName: '이멤버', createdAt: '2026-03-18T11:00:00Z' },
 ]
+
+let nextId = INITIAL_FILES.length + 1
+let mockFiles: MockDriveFile[] = [...INITIAL_FILES]
+
+export function resetDriveMockData() {
+  nextId = INITIAL_FILES.length + 1
+  mockFiles = [...INITIAL_FILES]
+}
 
 const ok = <T>(data: T) => HttpResponse.json({ code: 'SUCCESS', message: 'ok', data })
 
@@ -25,6 +33,7 @@ export const driveHandlers = [
   }),
 
   http.post('/api/v1/drive/upload', async ({ request }) => {
+    const uploader = getAuthMockUserByAuthorization(request.headers.get('Authorization'))
     let fileName = 'unknown'
     let fileType = 'application/octet-stream'
     let fileSize = 0
@@ -44,8 +53,8 @@ export const driveHandlers = [
       originalName: fileName,
       contentType: fileType,
       size: fileSize,
-      uploadedById: 1,
-      uploadedByName: '김리더',
+      uploadedById: Number(uploader.id),
+      uploadedByName: uploader.name,
       createdAt: new Date().toISOString(),
     }
     mockFiles = [...mockFiles, newFile]


### PR DESCRIPTION
## 작업 내용
- 일반 멤버도 공용 드라이브를 바로 사용할 수 있도록 화면 문구와 업로드 흐름을 정리했습니다.
- 로그인 사용자 기준으로 업로더 정보가 반영되도록 drive mock 핸들러를 수정했습니다.
- 공용 드라이브 관련 테스트를 보강하고 테스트 간 mock 상태를 초기화하도록 정리했습니다.

## 변경 이유
- 현재 드라이브가 개인 파일함처럼 보이거나 일반 멤버가 쓰기 어려운 인상을 주는 부분이 있었습니다.
- 모든 멤버가 같은 파일을 보고 업로드하는 공유 라이브러리라는 점을 UI와 테스트에서 분명히 맞출 필요가 있었습니다.

## 상세 변경 사항
### 주요 변경
- [x] 드라이브 헤더와 사이드 패널을 공용 라이브러리 기준으로 정리
- [x] 로그인 사용자 기준 업로더 반영 및 drive mock 초기화 함수 추가
- [x] drive 페이지/API/MSW 테스트 보강

### 추가 메모
- 실제 OpenAPI 기준 `/api/v1/drive` 응답은 그대로 사용하고, 프론트에서 공용 드라이브 UX가 더 명확히 보이도록 정리했습니다.

## 테스트
- [x] `npm run test:run`
- [x] `npm run build`
- [ ] 브라우저에서 주요 동작 확인

## 리뷰 포인트
- 일반 멤버 기준에서도 드라이브가 공용 영역으로 읽히는지
- 업로드 시 업로더 이름이 로그인 사용자 기준으로 반영되는지
- 테스트 간 mock 데이터가 누적되지 않는지

## 관련 이슈
- closes #151
