### PR TITLE
[fix] #154 - 출퇴근 기록 Scheduled Days 근무 일정 반영

### DIFF
--- a/src/pages/attendance/__tests__/Attendance.test.tsx
+++ b/src/pages/attendance/__tests__/Attendance.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll, afterEach, afterAll } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
 import { attendanceHandlers } from '../../../shared/api/mock/handlers/attendance'
@@ -14,7 +14,7 @@ afterAll(() => server.close())
 
 vi.mock('../../../features/auth/model', () => ({
   useApp: () => ({
-    state: { currentUser: { id: '1', name: '김리더', role: 'admin' }, users: [] },
+    state: { currentUser: { id: '1', name: '김리더', role: 'ADMIN', team: 'BACKEND' }, users: [] },
     isAdmin: true,
   }),
 }))
@@ -63,6 +63,25 @@ describe('Attendance 페이지', () => {
     render(<Attendance />)
     await waitFor(() => {
       expect(screen.getAllByText('김리더').length).toBeGreaterThan(0)
+    })
+  })
+
+  it('Attendance Records의 Scheduled Days에 멤버 근무 일정이 반영된다', async () => {
+    server.use(
+      http.get('/api/v1/attendances', () =>
+        HttpResponse.json({
+          code: 'SUCCESS', message: 'ok',
+          data: [{ id: 1, memberId: 1, memberName: '김리더', workDate: TODAY, checkInTime: `${TODAY}T09:00:00`, checkOutTime: `${TODAY}T18:00:00`, status: 'LEFT' }],
+        }),
+      ),
+    )
+
+    render(<Attendance />)
+
+    await waitFor(() => {
+      const scheduledDaysCell = screen.getByTestId('scheduled-days-1')
+      expect(within(scheduledDaysCell).getAllByLabelText(/근무 예정/)).toHaveLength(3)
+      expect(within(scheduledDaysCell).getAllByLabelText(/휴무/)).toHaveLength(4)
     })
   })
 })

--- a/src/pages/attendance/index.tsx
+++ b/src/pages/attendance/index.tsx
@@ -17,7 +17,25 @@ import { Toast } from '../../shared/ui/Toast'
 import { getTeams } from '../../shared/api/teamsApi'
 import './attendance.css'
 
-const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+const DAY_LABELS: Record<string, string> = {
+  MONDAY: 'Mon',
+  TUESDAY: 'Tue',
+  WEDNESDAY: 'Wed',
+  THURSDAY: 'Thu',
+  FRIDAY: 'Fri',
+  SATURDAY: 'Sat',
+  SUNDAY: 'Sun',
+}
+
+const ORDERED_WORK_DAYS = [
+  'MONDAY',
+  'TUESDAY',
+  'WEDNESDAY',
+  'THURSDAY',
+  'FRIDAY',
+  'SATURDAY',
+  'SUNDAY',
+] as const
 
 export function Attendance() {
   const { isAdmin, state } = useApp()
@@ -83,6 +101,11 @@ export function Attendance() {
   const todayRecords = records.filter((r) => r.workDate === todayStr)
   const totalPages = Math.max(1, Math.ceil(records.length / PAGE_SIZE))
   const pageRecords = records.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)
+
+  const getScheduledDays = (memberId: number) => {
+    const memberSchedule = teamSchedules.find((schedule) => schedule.memberId === memberId)
+    return new Set(memberSchedule?.workSchedules.map((schedule) => schedule.dayOfWeek) ?? [])
+  }
 
   const handleDateFilter = () => {
     if (!dateInput) return
@@ -188,10 +211,21 @@ export function Attendance() {
                           <span className="record-avatar">{r.memberName[0]}</span>
                           {r.memberName}
                         </td>
-                        <td>
-                          {DAYS.map((_, i) => (
-                            <span key={i} className={`dot ${i < 5 ? 'on' : ''}`} />
-                          ))}
+                        <td data-testid={`scheduled-days-${r.memberId}`}>
+                          {ORDERED_WORK_DAYS.map((dayOfWeek) => {
+                            const scheduledDays = getScheduledDays(r.memberId)
+                            const isScheduled = scheduledDays.has(dayOfWeek)
+                            const dayLabel = DAY_LABELS[dayOfWeek]
+
+                            return (
+                              <span
+                                key={`${r.memberId}-${dayOfWeek}`}
+                                className={`dot ${isScheduled ? 'on' : ''}`}
+                                title={`${dayLabel} ${isScheduled ? '근무 예정' : '휴무'}`}
+                                aria-label={`${dayLabel} ${isScheduled ? '근무 예정' : '휴무'}`}
+                              />
+                            )
+                          })}
                         </td>
                         <td>{r.checkInTime?.slice(11, 16) ?? '-'}</td>
                         <td>{r.checkOutTime?.slice(11, 16) ?? '-'}</td>


### PR DESCRIPTION
## 작업 내용
- Attendance Records의 Scheduled Days 컬럼이 실제 근무 일정 데이터를 반영하도록 수정했습니다.
- 멤버별 근무 요일을 Mon-Sun 순서로 표시하고, 접근성 라벨을 함께 추가했습니다.
- 관련 테스트를 보강해 실제 근무 일정 반영을 검증했습니다.

## 변경 이유
- 기존 Scheduled Days는 하드코딩된 평일 점 표시로 남아 있어, 근무 일정 설정과 화면이 일치하지 않았습니다.
- 관리자와 팀장이 보는 출퇴근 기록 표에서 실제 근무 일정을 바로 확인할 수 있어야 했습니다.

## 상세 변경 사항
### 주요 변경
- [x] Attendance Records의 Scheduled Days를 멤버별 schedule 데이터와 연결
- [x] 요일별 근무 예정/휴무 상태를 접근성 라벨과 함께 표시
- [x] 관련 테스트 추가

### 추가 메모
- `getAllWorkSchedules` / `getTeamWorkSchedules`로 받아온 데이터를 표 셀 렌더링에 그대로 사용합니다.

## 테스트
- [x] `npm run test:run`
- [x] `npm run build`
- [ ] 브라우저에서 주요 동작 확인

## 리뷰 포인트
- 관리자/팀장 화면의 Scheduled Days가 실제 근무 일정과 일치하는지
- 멤버별 스케줄이 없는 경우 모든 점이 off로 표시되는지

## 관련 이슈
- closes #154
