### PR TITLE
[feat] #156 - 회원 탈퇴 및 관리자 멤버 퇴출 흐름 추가

### DIFF
--- a/src/features/attendance/ui/TeamWorkSchedulePanel.css
+++ b/src/features/attendance/ui/TeamWorkSchedulePanel.css
@@ -34,15 +34,16 @@
 }
 
 .team-work-schedule-list {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
 }
 
 .team-work-schedule-card {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
+  display: grid;
+  grid-template-columns: 180px minmax(0, 1fr);
+  align-items: center;
+  gap: 18px;
   padding: 18px;
   border-radius: 20px;
   background: var(--bg-soft);
@@ -83,20 +84,31 @@
   font-size: 0.8rem;
 }
 
-.team-work-badges {
-  display: flex;
-  flex-wrap: wrap;
+.team-work-week-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(82px, 1fr));
   gap: 10px;
 }
 
-.team-work-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.04);
+.team-work-day-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  padding: 10px 12px;
+  border-radius: 16px;
   border: 1px solid rgba(138, 114, 216, 0.16);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.team-work-day-card.active {
+  background: rgba(124, 58, 237, 0.12);
+  border-color: rgba(138, 114, 216, 0.26);
+}
+
+.team-work-day-card.off {
+  background: rgba(148, 163, 184, 0.06);
+  border-color: rgba(148, 163, 184, 0.12);
 }
 
 .team-work-day {
@@ -109,6 +121,7 @@
   font-size: 0.8rem;
   color: var(--text-primary);
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .team-work-schedule-empty {
@@ -118,8 +131,20 @@
   color: var(--text-secondary);
 }
 
-@media (max-width: 900px) {
-  .team-work-schedule-list {
+@media (max-width: 1200px) {
+  .team-work-schedule-card {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 900px) {
+  .team-work-week-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .team-work-week-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/src/features/attendance/ui/TeamWorkSchedulePanel.tsx
+++ b/src/features/attendance/ui/TeamWorkSchedulePanel.tsx
@@ -47,15 +47,22 @@ export function TeamWorkSchedulePanel({ schedules, title = '팀 근무 일정' }
                 </div>
               </div>
 
-              <div className="team-work-badges">
-                {[...member.workSchedules]
-                  .sort((a, b) => DAY_ORDER.indexOf(a.dayOfWeek) - DAY_ORDER.indexOf(b.dayOfWeek))
-                  .map((schedule) => (
-                    <div key={`${member.memberId}-${schedule.dayOfWeek}`} className="team-work-badge">
-                      <span className="team-work-day">{DAY_LABEL[schedule.dayOfWeek] ?? schedule.dayOfWeek}</span>
-                      <span className="team-work-time">{formatTimeRange(schedule.startTime, schedule.endTime)}</span>
+              <div className="team-work-week-grid">
+                {DAY_ORDER.map((dayOfWeek) => {
+                  const schedule = member.workSchedules.find((item) => item.dayOfWeek === dayOfWeek)
+
+                  return (
+                    <div
+                      key={`${member.memberId}-${dayOfWeek}`}
+                      className={`team-work-day-card ${schedule ? 'active' : 'off'}`}
+                    >
+                      <span className="team-work-day">{DAY_LABEL[dayOfWeek] ?? dayOfWeek}</span>
+                      <span className="team-work-time">
+                        {schedule ? formatTimeRange(schedule.startTime, schedule.endTime) : '휴무'}
+                      </span>
                     </div>
-                  ))}
+                  )
+                })}
               </div>
             </article>
           ))}

--- a/src/pages/admin/__tests__/Admin.test.tsx
+++ b/src/pages/admin/__tests__/Admin.test.tsx
@@ -8,8 +8,8 @@ import { AppProvider } from '../../../features/auth/model'
 import { Admin } from '../index'
 
 const mockMembers = [
-  { id: '1', name: '김민준', email: 'min@yanus.kr', team: 'BACKEND', role: 'MEMBER' },
-  { id: '2', name: '이서연', email: 'seo@yanus.kr', team: 'FRONTEND', role: 'TEAM_LEAD' },
+  { id: '1', name: '김민준', email: 'min@yanus.kr', team: 'BACKEND', role: 'MEMBER', status: 'ACTIVE' },
+  { id: '2', name: '이서연', email: 'seo@yanus.kr', team: 'FRONTEND', role: 'TEAM_LEAD', status: 'ACTIVE' },
 ]
 
 const mockRecords = [
@@ -76,6 +76,7 @@ describe('Admin 페이지', () => {
     renderAdmin()
     await user.click(screen.getByRole('button', { name: '멤버 관리' }))
     expect(screen.getByText('멤버 목록')).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: '퇴출' }).length).toBeGreaterThan(0)
   })
 
   it('출근 현황 탭에 요약 카운트가 표시된다', async () => {

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -74,6 +74,11 @@ export function Admin() {
   }
 
   const handleDeactivate = async (id: string) => {
+    const member = members.find((item) => item.id === id)
+    if (!window.confirm(`${member?.name ?? '선택한 멤버'}를 퇴출하시겠습니까?`)) {
+      return
+    }
+
     setSaving(true)
     try {
       await deactivateMember(id)
@@ -206,7 +211,7 @@ export function Admin() {
                         disabled={saving}
                         onClick={() => handleActivate(u.id)}
                       >
-                        활성화
+                        복구
                       </button>
                     ) : (
                       <button
@@ -215,7 +220,7 @@ export function Admin() {
                         disabled={saving}
                         onClick={() => handleDeactivate(u.id)}
                       >
-                        비활성화
+                        퇴출
                       </button>
                     )}
                   </td>

--- a/src/pages/attendance/index.tsx
+++ b/src/pages/attendance/index.tsx
@@ -37,6 +37,11 @@ const ORDERED_WORK_DAYS = [
   'SUNDAY',
 ] as const
 
+const ATTENDANCE_STATUS_LABEL = {
+  LEFT: '퇴근',
+  WORKING: '근무 중',
+} as const
+
 export function Attendance() {
   const { isAdmin, state } = useApp()
   const [filter, setFilter] = useState<'week' | 'month' | 'custom'>('month')
@@ -232,7 +237,7 @@ export function Attendance() {
                         <td>{r.workDate}</td>
                         <td>
                           <span className={`status-badge ${r.status === 'LEFT' ? 'present' : 'late'}`}>
-                            {r.status === 'LEFT' ? 'Present' : 'Working'}
+                            {ATTENDANCE_STATUS_LABEL[r.status]}
                           </span>
                         </td>
                       </tr>
@@ -273,7 +278,7 @@ export function Attendance() {
                       <td>{r.checkOutTime?.slice(11, 16) ?? '-'}</td>
                       <td>
                         <span className={`status-badge ${r.status === 'LEFT' ? 'present' : 'late'}`}>
-                          {r.status === 'LEFT' ? 'Present' : 'Working'}
+                          {ATTENDANCE_STATUS_LABEL[r.status]}
                         </span>
                       </td>
                     </tr>
@@ -291,15 +296,15 @@ export function Attendance() {
               <span className="value">{todayRecords.length}</span>
             </div>
             <div className="stat-card glass">
-              <span className="label">Present</span>
+              <span className="label">퇴근</span>
               <span className="value green">{todayRecords.filter((r) => r.status === 'LEFT').length}</span>
             </div>
             <div className="stat-card glass">
-              <span className="label">Working</span>
+              <span className="label">근무 중</span>
               <span className="value yellow">{todayRecords.filter((r) => r.status === 'WORKING').length}</span>
             </div>
             <div className="stat-card glass">
-              <span className="label">Absent</span>
+              <span className="label">미출근</span>
               <span className="value red">{todayRecords.filter((r) => r.checkInTime === null).length}</span>
             </div>
           </div>

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -67,6 +67,11 @@ export function Members() {
   }
 
   const handleDeactivate = async (id: string) => {
+    const member = state.users.find((item) => item.id === id)
+    if (!window.confirm(`${member?.name ?? '선택한 멤버'}를 퇴출하시겠습니까?`)) {
+      return
+    }
+
     setSaving(true)
     try {
       await deactivateMember(id)
@@ -176,11 +181,11 @@ export function Members() {
                       </button>
                       {u.status === 'INACTIVE' ? (
                         <button className="action-btn activate-btn" disabled={saving} onClick={() => handleActivate(u.id)}>
-                          활성화
+                          복구
                         </button>
                       ) : (
                         <button className="action-btn deactivate-btn" disabled={saving} onClick={() => handleDeactivate(u.id)}>
-                          비활성화
+                          퇴출
                         </button>
                       )}
                     </td>

--- a/src/pages/settings/__tests__/Settings.test.tsx
+++ b/src/pages/settings/__tests__/Settings.test.tsx
@@ -3,17 +3,22 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { Settings } from '../index'
 
 const mockUpdateMyProfile = vi.fn()
+const mockDeactivateMember = vi.fn()
 const mockSetTheme = vi.fn()
+const mockLogout = vi.fn()
+const mockNavigate = vi.fn()
 
 vi.mock('../../../features/auth/model', () => ({
   useApp: () => ({
     state: { currentUser: { id: '1', name: '홍길동', role: 'member', team: '개발팀' }, users: [] },
     isAdmin: false,
+    logout: mockLogout,
   }),
 }))
 
 vi.mock('../../../shared/api/membersApi', () => ({
   updateMyProfile: (...args: unknown[]) => mockUpdateMyProfile(...args),
+  deactivateMember: (...args: unknown[]) => mockDeactivateMember(...args),
 }))
 
 vi.mock('../../../shared/theme', () => ({
@@ -23,6 +28,14 @@ vi.mock('../../../shared/theme', () => ({
     toggleTheme: vi.fn(),
   }),
 }))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
 
 describe('Settings 페이지', () => {
   beforeEach(() => {
@@ -143,6 +156,23 @@ describe('Settings 페이지', () => {
 
       await waitFor(() => {
         expect(screen.getByText('서버 오류')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('회원 탈퇴', () => {
+    it('회원 탈퇴 확인 후 deactivateMember와 logout이 호출된다', async () => {
+      mockDeactivateMember.mockResolvedValueOnce(null)
+
+      render(<Settings />)
+      fireEvent.click(screen.getByText('보안'))
+      fireEvent.click(screen.getByRole('button', { name: '회원 탈퇴' }))
+      fireEvent.click(screen.getByRole('button', { name: '탈퇴 진행' }))
+
+      await waitFor(() => {
+        expect(mockDeactivateMember).toHaveBeenCalledWith('1')
+        expect(mockLogout).toHaveBeenCalled()
+        expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true })
       })
     })
   })

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -1,15 +1,17 @@
 import { useState } from 'react'
-import { User, Bell, Palette, Shield, Save, Monitor, Moon, Sun } from 'lucide-react'
+import { User, Bell, Palette, Shield, Save, Monitor, Moon, Sun, AlertTriangle } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
 import { useApp } from '../../features/auth/model'
 import { useTheme, type ThemeMode } from '../../shared/theme'
-import { updateMyProfile } from '../../shared/api/membersApi'
+import { updateMyProfile, deactivateMember } from '../../shared/api/membersApi'
 import { Toast } from '../../shared/ui/Toast'
 import './settings.css'
 
 type SettingsTab = 'profile' | 'notifications' | 'appearance' | 'security'
 
 export function Settings() {
-  const { state } = useApp()
+  const navigate = useNavigate()
+  const { state, logout } = useApp()
   const { theme, setTheme } = useTheme()
   const [activeTab, setActiveTab] = useState<SettingsTab>('profile')
   const [notifications, setNotifications] = useState({
@@ -26,6 +28,8 @@ export function Settings() {
   const [confirmPassword, setConfirmPassword] = useState('')
   const [passwordError, setPasswordError] = useState<string | null>(null)
   const [passwordSaved, setPasswordSaved] = useState(false)
+  const [showWithdrawConfirm, setShowWithdrawConfirm] = useState(false)
+  const [isWithdrawing, setIsWithdrawing] = useState(false)
 
   const handleSave = async () => {
     try {
@@ -56,6 +60,22 @@ export function Settings() {
       setTimeout(() => setPasswordSaved(false), 2000)
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : '비밀번호 변경에 실패했습니다')
+    }
+  }
+
+  const handleWithdraw = async () => {
+    if (!state.currentUser?.id) return
+
+    setIsWithdrawing(true)
+    try {
+      await deactivateMember(state.currentUser.id)
+      logout()
+      navigate('/login', { replace: true })
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '회원 탈퇴에 실패했습니다')
+    } finally {
+      setIsWithdrawing(false)
+      setShowWithdrawConfirm(false)
     }
   }
 
@@ -241,6 +261,48 @@ export function Settings() {
                 <Save size={16} />
                 {passwordSaved ? '변경됨!' : '비밀번호 변경'}
               </button>
+
+              <div className="danger-zone">
+                <div className="danger-zone-head">
+                  <span className="danger-zone-icon">
+                    <AlertTriangle size={16} />
+                  </span>
+                  <div>
+                    <h4>회원 탈퇴</h4>
+                    <p>탈퇴하면 계정이 비활성화되고 현재 세션이 종료됩니다. 다시 사용하려면 관리자 도움이 필요합니다.</p>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  className="danger-btn"
+                  onClick={() => setShowWithdrawConfirm((prev) => !prev)}
+                >
+                  회원 탈퇴
+                </button>
+
+                {showWithdrawConfirm && (
+                  <div className="danger-confirm-box">
+                    <p>정말 탈퇴하시겠습니까? 현재 계정이 즉시 비활성화됩니다.</p>
+                    <div className="danger-confirm-actions">
+                      <button
+                        type="button"
+                        className="danger-cancel-btn"
+                        onClick={() => setShowWithdrawConfirm(false)}
+                      >
+                        취소
+                      </button>
+                      <button
+                        type="button"
+                        className="danger-confirm-btn"
+                        onClick={handleWithdraw}
+                        disabled={isWithdrawing}
+                      >
+                        {isWithdrawing ? '탈퇴 처리 중...' : '탈퇴 진행'}
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
             </section>
           )}
         </div>

--- a/src/pages/settings/settings.css
+++ b/src/pages/settings/settings.css
@@ -217,6 +217,77 @@
   margin: -4px 0 8px;
 }
 
+.danger-zone {
+  margin-top: 32px;
+  padding: 20px;
+  border-radius: 20px;
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  background: rgba(239, 68, 68, 0.06);
+}
+
+.danger-zone-head {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  margin-bottom: 16px;
+}
+
+.danger-zone-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #fca5a5;
+  background: rgba(239, 68, 68, 0.12);
+  flex-shrink: 0;
+}
+
+.danger-zone h4 {
+  margin: 0 0 6px;
+  font-size: 1rem;
+}
+
+.danger-zone p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.danger-btn,
+.danger-confirm-btn,
+.danger-cancel-btn {
+  border: none;
+  border-radius: 14px;
+  padding: 11px 16px;
+  font-weight: 700;
+}
+
+.danger-btn,
+.danger-confirm-btn {
+  background: rgba(239, 68, 68, 0.18);
+  color: #fecaca;
+}
+
+.danger-cancel-btn {
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--text-primary);
+}
+
+.danger-confirm-box {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(239, 68, 68, 0.14);
+}
+
+.danger-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 14px;
+}
+
 /* Notification rows */
 .setting-row {
   display: flex;
@@ -416,6 +487,44 @@
 .appearance-note p {
   color: var(--text-secondary);
   line-height: 1.6;
+}
+
+@media (max-width: 1080px) {
+  .settings-header {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-summary-card {
+    justify-self: stretch;
+  }
+
+  .settings-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-nav {
+    position: static;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .settings-nav-item {
+    width: auto;
+  }
+}
+
+@media (max-width: 720px) {
+  .theme-options-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-content {
+    padding: 22px;
+  }
+
+  .danger-confirm-actions {
+    flex-direction: column;
+  }
 }
 
 @media (max-width: 900px) {

--- a/src/shared/lib/exportCsv.ts
+++ b/src/shared/lib/exportCsv.ts
@@ -17,7 +17,7 @@ export function exportAttendanceToCsv(records: AttendanceExportRow[], filename: 
     r.date,
     r.clockIn,
     r.clockOut ?? '-',
-    r.status === 'done' ? 'Present' : 'Working',
+    r.status === 'done' ? '퇴근' : '근무 중',
   ])
 
   const csvContent = [header, ...rows]


### PR DESCRIPTION
## 작업 내용
- 설정 보안 탭에 회원 탈퇴 위험 구역과 확인 흐름을 추가했습니다.
- 관리자/멤버 관리 화면에서 멤버 퇴출과 복구 액션이 더 명확하게 보이도록 정리했습니다.
- 출퇴근 페이지 상태 문구를 한국어로 통일하고, 관리자 근무 일정 패널을 가로 중심 레이아웃으로 개편했습니다.

## 변경 이유
- 일반 사용자가 직접 회원 탈퇴할 수 있는 흐름이 화면에 노출되어 있지 않았습니다.
- 관리자의 멤버 비활성화 액션이 퇴출 의미로 읽히지 않아 UX가 모호했습니다.
- 출퇴근 상태와 근무 일정 화면이 영어/세로 중심으로 남아 있어 일관성과 가독성이 떨어졌습니다.

## 상세 변경 사항
### 주요 변경
- [x] 설정 보안 탭에 회원 탈퇴 위험 구역과 확인 단계 추가
- [x] 관리자/멤버 관리 화면의 퇴출/복구 액션 정리
- [x] 출퇴근 상태 한글화 및 관리자 근무 일정 가로 레이아웃 적용

### 추가 메모
- 열려 있는 main 배포 PR `#153`은 head가 `develop`이라, 이번 develop 머지 내용도 자동으로 포함됩니다.

## 테스트
- [x] `npm run test:run`
- [x] `npm run build`
- [ ] 브라우저에서 주요 동작 확인

## 리뷰 포인트
- 회원 탈퇴 시 현재 계정 비활성화 후 로그인 화면으로 자연스럽게 이동하는지
- 관리자/멤버 관리 화면의 퇴출/복구 액션이 의도대로 읽히는지
- 관리자 출퇴근 페이지 근무 일정 패널이 가로 흐름으로 더 빠르게 읽히는지

## 관련 이슈
- closes #156
