### PR TITLE
[fix] #159 - 관리자 출퇴근 레이아웃 및 멤버 상태/퇴출 분리

### DIFF
--- a/src/features/attendance/ui/SetWorkDaysPersonal.css
+++ b/src/features/attendance/ui/SetWorkDaysPersonal.css
@@ -87,8 +87,10 @@
 
 .day-schedule-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 16px;
+  grid-template-columns: repeat(7, minmax(170px, 1fr));
+  gap: 14px;
+  overflow-x: auto;
+  padding-bottom: 6px;
 }
 
 .day-col {
@@ -100,7 +102,8 @@
   background: var(--bg-soft);
   border: 1px solid var(--border-color);
   transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
-  min-height: 220px;
+  min-height: 240px;
+  min-width: 170px;
 }
 
 .day-col.active {
@@ -306,9 +309,9 @@
   transform: translateY(-1px);
 }
 
-@media (max-width: 1100px) {
+@media (max-width: 1400px) {
   .day-schedule-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(7, minmax(160px, 1fr));
   }
 }
 

--- a/src/pages/admin/__tests__/Admin.test.tsx
+++ b/src/pages/admin/__tests__/Admin.test.tsx
@@ -77,6 +77,7 @@ describe('Admin 페이지', () => {
     await user.click(screen.getByRole('button', { name: '멤버 관리' }))
     expect(screen.getByText('멤버 목록')).toBeInTheDocument()
     expect(screen.getAllByRole('button', { name: '퇴출' }).length).toBeGreaterThan(0)
+    expect(screen.getAllByRole('button', { name: '비활성화' }).length).toBeGreaterThan(0)
   })
 
   it('출근 현황 탭에 요약 카운트가 표시된다', async () => {

--- a/src/pages/admin/admin.css
+++ b/src/pages/admin/admin.css
@@ -187,6 +187,34 @@
   flex-wrap: wrap;
 }
 
+.admin-status-cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.admin-status-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 64px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.admin-status-tag.ACTIVE {
+  background: rgba(34, 197, 94, 0.16);
+  color: #86efac;
+}
+
+.admin-status-tag.INACTIVE {
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--text-secondary);
+}
+
 .admin-action-btn {
   display: inline-flex;
   align-items: center;
@@ -224,6 +252,15 @@
 
 .admin-action-btn.activate-btn:hover {
   background: rgba(34, 197, 94, 0.1);
+}
+
+.admin-action-btn.mute-btn {
+  color: #fbbf24;
+  border-color: rgba(234, 179, 8, 0.2);
+}
+
+.admin-action-btn.mute-btn:hover {
+  background: rgba(234, 179, 8, 0.1);
 }
 
 /* ── 역할 변경 모달 ── */
@@ -344,5 +381,10 @@
   .admin-actions-cell {
     flex-direction: column;
     gap: 4px;
+  }
+
+  .admin-status-cell {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -26,6 +26,11 @@ const teamLabels: Record<string, string> = {
   SECURITY: 'Security',
 }
 
+const statusLabels: Record<string, string> = {
+  ACTIVE: '활성',
+  INACTIVE: '비활성',
+}
+
 export function Admin() {
   const { loadMembers } = useApp()
   const [tab, setTab] = useState<Tab>('attendance')
@@ -74,6 +79,19 @@ export function Admin() {
   }
 
   const handleDeactivate = async (id: string) => {
+    setSaving(true)
+    try {
+      await deactivateMember(id)
+      const updated = await getMembers()
+      setMembers(updated)
+      loadMembers(updated)
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '비활성화에 실패했습니다')
+    }
+    setSaving(false)
+  }
+
+  const handleExpel = async (id: string) => {
     const member = members.find((item) => item.id === id)
     if (!window.confirm(`${member?.name ?? '선택한 멤버'}를 퇴출하시겠습니까?`)) {
       return
@@ -86,7 +104,7 @@ export function Admin() {
       setMembers(updated)
       loadMembers(updated)
     } catch (err) {
-      setErrorMessage(err instanceof Error ? err.message : '비활성화에 실패했습니다')
+      setErrorMessage(err instanceof Error ? err.message : '퇴출에 실패했습니다')
     }
     setSaving(false)
   }
@@ -175,6 +193,7 @@ export function Admin() {
                 <th>이름</th>
                 <th>팀</th>
                 <th>역할</th>
+                <th>상태</th>
                 <th>관리</th>
               </tr>
             </thead>
@@ -196,6 +215,32 @@ export function Admin() {
                       {roleLabels[u.role] ?? u.role}
                     </span>
                   </td>
+                  <td>
+                    <div className="admin-status-cell">
+                      <span className={`admin-status-tag ${u.status ?? 'ACTIVE'}`}>
+                        {statusLabels[u.status ?? 'ACTIVE'] ?? (u.status ?? 'ACTIVE')}
+                      </span>
+                      {u.status === 'INACTIVE' ? (
+                        <button
+                          type="button"
+                          className="admin-action-btn activate-btn"
+                          disabled={saving}
+                          onClick={() => handleActivate(u.id)}
+                        >
+                          활성화
+                        </button>
+                      ) : (
+                        <button
+                          type="button"
+                          className="admin-action-btn mute-btn"
+                          disabled={saving}
+                          onClick={() => handleDeactivate(u.id)}
+                        >
+                          비활성화
+                        </button>
+                      )}
+                    </div>
+                  </td>
                   <td className="admin-actions-cell">
                     <button
                       type="button"
@@ -204,25 +249,14 @@ export function Admin() {
                     >
                       역할 변경 <ChevronDown size={13} />
                     </button>
-                    {u.status === 'INACTIVE' ? (
-                      <button
-                        type="button"
-                        className="admin-action-btn activate-btn"
-                        disabled={saving}
-                        onClick={() => handleActivate(u.id)}
-                      >
-                        복구
-                      </button>
-                    ) : (
-                      <button
-                        type="button"
-                        className="admin-action-btn deactivate-btn"
-                        disabled={saving}
-                        onClick={() => handleDeactivate(u.id)}
-                      >
-                        퇴출
-                      </button>
-                    )}
+                    <button
+                      type="button"
+                      className="admin-action-btn deactivate-btn"
+                      disabled={saving || u.status === 'INACTIVE'}
+                      onClick={() => handleExpel(u.id)}
+                    >
+                      {u.status === 'INACTIVE' ? '퇴출됨' : '퇴출'}
+                    </button>
                   </td>
                 </tr>
               ))}

--- a/src/pages/attendance/attendance.css
+++ b/src/pages/attendance/attendance.css
@@ -80,6 +80,10 @@
   grid-template-columns: 1fr;
 }
 
+.two-cards-row.admin-wide {
+  grid-template-columns: 1fr;
+}
+
 .set-work-days-section {
   padding: 24px;
 }

--- a/src/pages/attendance/index.tsx
+++ b/src/pages/attendance/index.tsx
@@ -190,7 +190,7 @@ export function Attendance() {
           </section>
         )}
 
-        <div className={`two-cards-row ${!isAdmin ? 'single' : ''}`}>
+        <div className={`two-cards-row ${isAdmin ? 'admin-wide' : 'single'}`}>
           <section className="set-work-days-section glass">
             <SetWorkDaysPersonal />
           </section>

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -22,6 +22,11 @@ const teamLabels: Record<string, string> = {
   SECURITY: 'Security',
 }
 
+const statusLabels: Record<string, string> = {
+  ACTIVE: '활성',
+  INACTIVE: '비활성',
+}
+
 const ALL_ROLES: UserRole[] = ['MEMBER', 'TEAM_LEAD', 'ADMIN']
 
 export function Members() {
@@ -67,6 +72,18 @@ export function Members() {
   }
 
   const handleDeactivate = async (id: string) => {
+    setSaving(true)
+    try {
+      await deactivateMember(id)
+      const updated = await getMembers()
+      loadMembers(updated)
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '비활성화에 실패했습니다')
+    }
+    setSaving(false)
+  }
+
+  const handleExpel = async (id: string) => {
     const member = state.users.find((item) => item.id === id)
     if (!window.confirm(`${member?.name ?? '선택한 멤버'}를 퇴출하시겠습니까?`)) {
       return
@@ -78,7 +95,7 @@ export function Members() {
       const updated = await getMembers()
       loadMembers(updated)
     } catch (err) {
-      setErrorMessage(err instanceof Error ? err.message : '비활성화에 실패했습니다')
+      setErrorMessage(err instanceof Error ? err.message : '퇴출에 실패했습니다')
     }
     setSaving(false)
   }
@@ -160,6 +177,7 @@ export function Members() {
                 <th>Profile</th>
                 <th>Current Team</th>
                 <th>Role</th>
+                {isAdmin && <th>상태</th>}
                 {isAdmin && <th>Actions</th>}
               </tr>
             </thead>
@@ -175,19 +193,35 @@ export function Members() {
                     </span>
                   </td>
                   {isAdmin && (
+                    <td>
+                      <div className="member-status-cell">
+                        <span className={`member-status-tag ${u.status ?? 'ACTIVE'}`}>
+                          {statusLabels[u.status ?? 'ACTIVE'] ?? (u.status ?? 'ACTIVE')}
+                        </span>
+                        {u.status === 'INACTIVE' ? (
+                          <button className="action-btn activate-btn" disabled={saving} onClick={() => handleActivate(u.id)}>
+                            활성화
+                          </button>
+                        ) : (
+                          <button className="action-btn mute-btn" disabled={saving} onClick={() => handleDeactivate(u.id)}>
+                            비활성화
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  )}
+                  {isAdmin && (
                     <td className="actions-cell">
                       <button className="action-btn" onClick={() => handleOpenChangeRole(u.id, u.name, u.role)}>
                         Change Role <ChevronDown size={14} />
                       </button>
-                      {u.status === 'INACTIVE' ? (
-                        <button className="action-btn activate-btn" disabled={saving} onClick={() => handleActivate(u.id)}>
-                          복구
-                        </button>
-                      ) : (
-                        <button className="action-btn deactivate-btn" disabled={saving} onClick={() => handleDeactivate(u.id)}>
-                          퇴출
-                        </button>
-                      )}
+                      <button
+                        className="action-btn deactivate-btn"
+                        disabled={saving || u.status === 'INACTIVE'}
+                        onClick={() => handleExpel(u.id)}
+                      >
+                        {u.status === 'INACTIVE' ? '퇴출됨' : '퇴출'}
+                      </button>
                     </td>
                   )}
                 </tr>

--- a/src/pages/members/members.css
+++ b/src/pages/members/members.css
@@ -203,6 +203,49 @@
   border-radius: 6px;
 }
 
+.member-status-cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.member-status-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 64px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.member-status-tag.ACTIVE {
+  background: rgba(34, 197, 94, 0.16);
+  color: #86efac;
+}
+
+.member-status-tag.INACTIVE {
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--text-secondary);
+}
+
+.action-btn.activate-btn {
+  background: rgba(34, 197, 94, 0.12);
+  color: #86efac;
+}
+
+.action-btn.mute-btn {
+  background: rgba(234, 179, 8, 0.14);
+  color: #facc15;
+}
+
+.action-btn.deactivate-btn {
+  background: rgba(239, 68, 68, 0.14);
+  color: #fca5a5;
+}
+
 .stats-sidebar {
   padding: 24px;
   height: fit-content;


### PR DESCRIPTION
## 작업 내용
- 관리자 출퇴근 페이지의 근무 일정 설정이 넓게 가로로 보이도록 레이아웃을 조정했습니다.
- 관리자/멤버 관리 화면에서 상태(활성/비활성)와 퇴출 액션을 분리했습니다.
- 관련 관리자 화면 테스트를 보강했습니다.

## 변경 이유
- 관리자 화면의 근무 일정 설정이 세로로 길게 쌓여 가독성이 떨어졌습니다.
- 멤버 관리 액션에서 상태 변경과 퇴출 의미가 섞여 있어 UX가 모호했습니다.

## 상세 변경 사항
### 주요 변경
- [x] 관리자 출퇴근 페이지 근무 일정 설정을 가로 중심 레이아웃으로 조정
- [x] 멤버 관리 화면에 상태 컬럼과 활성화/비활성화 액션 분리
- [x] 퇴출 액션을 별도 버튼으로 유지하고 관련 테스트 보강

### 추가 메모
- 현재 백엔드 스펙상 퇴출과 비활성화가 같은 endpoint를 사용하므로, UI에서는 의미를 분리하되 실제 반영은 동일한 soft-deactivate 흐름입니다.

## 테스트
- [x] `npm run test:run`
- [x] `npm run build`
- [ ] 브라우저에서 주요 동작 확인

## 리뷰 포인트
- 관리자 출퇴근 페이지에서 근무 일정 설정이 가로로 더 빠르게 읽히는지
- 멤버 관리 화면에서 상태 변경과 퇴출 액션이 분리되어 이해되는지

## 관련 이슈
- closes #159
