### PR TITLE
[refactor] #162 - 전역 모바일 반응형 정리

### DIFF
--- a/src/features/attendance/ui/SetWorkDaysPersonal.css
+++ b/src/features/attendance/ui/SetWorkDaysPersonal.css
@@ -91,6 +91,7 @@
   gap: 14px;
   overflow-x: auto;
   padding-bottom: 6px;
+  scroll-snap-type: x proximity;
 }
 
 .day-col {
@@ -104,6 +105,7 @@
   transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
   min-height: 240px;
   min-width: 170px;
+  scroll-snap-align: start;
 }
 
 .day-col.active {
@@ -315,17 +317,85 @@
   }
 }
 
+@media (max-width: 960px) {
+  .member-info {
+    width: 100%;
+  }
+
+  .day-schedule-grid {
+    grid-template-columns: repeat(7, minmax(150px, 1fr));
+  }
+}
+
 @media (max-width: 640px) {
   .schedule-summary {
     padding: 14px 16px;
+    align-items: flex-start;
+  }
+
+  .day-schedule-grid {
+    grid-template-columns: repeat(7, minmax(138px, 1fr));
+    gap: 10px;
   }
 
   .day-col {
     padding: 16px;
     min-height: 0;
+    min-width: 138px;
+    border-radius: 18px;
   }
 
   .day-times {
     grid-template-columns: 1fr;
+  }
+
+  .week-pattern-options {
+    gap: 6px;
+  }
+
+  .week-pattern-chip {
+    padding: 7px 10px;
+    font-size: 0.76rem;
+  }
+
+  .save-btn {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .set-work-days-personal h3 {
+    font-size: 1rem;
+  }
+
+  .set-work-days-personal .desc,
+  .schedule-summary p,
+  .day-off-label span {
+    font-size: 0.8rem;
+  }
+
+  .day-schedule-grid {
+    grid-template-columns: repeat(7, minmax(132px, 1fr));
+  }
+
+  .day-col {
+    padding: 14px;
+    min-width: 132px;
+    gap: 14px;
+  }
+
+  .toggle {
+    width: 44px;
+    height: 26px;
+  }
+
+  .toggle::after {
+    width: 18px;
+    height: 18px;
+  }
+
+  .toggle.on::after {
+    transform: translateX(18px);
   }
 }

--- a/src/pages/admin/admin.css
+++ b/src/pages/admin/admin.css
@@ -110,6 +110,13 @@
 .admin-members-table {
   width: 100%;
   border-collapse: collapse;
+  min-width: 760px;
+}
+
+.admin-table-wrap {
+  overflow-x: auto;
+  padding-bottom: 6px;
+  scrollbar-width: thin;
 }
 
 .admin-members-table th {
@@ -373,9 +380,51 @@
 
 /* ── 반응형 ── */
 @media (max-width: 768px) {
+  .admin-page {
+    gap: 20px;
+  }
+
+  .admin-header {
+    align-items: flex-start;
+  }
+
+  .admin-header-actions,
+  .admin-export-btn {
+    width: 100%;
+  }
+
+  .admin-export-btn {
+    justify-content: center;
+  }
+
+  .admin-tabs {
+    width: 100%;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    scrollbar-width: none;
+  }
+
+  .admin-tabs::-webkit-scrollbar {
+    display: none;
+  }
+
+  .admin-tab-btn {
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+
+  .admin-tab-content {
+    padding: 18px;
+  }
+
   .admin-members-table th:nth-child(2),
   .admin-members-table td:nth-child(2) {
     display: none;
+  }
+
+  .admin-members-table th,
+  .admin-members-table td {
+    white-space: nowrap;
   }
 
   .admin-actions-cell {
@@ -386,5 +435,24 @@
   .admin-status-cell {
     flex-direction: column;
     align-items: flex-start;
+  }
+}
+
+@media (max-width: 480px) {
+  .admin-title-row h1 {
+    font-size: 1.35rem;
+  }
+
+  .admin-tab-content {
+    padding: 16px;
+    border-radius: 20px;
+  }
+
+  .admin-modal {
+    padding: 22px 18px;
+  }
+
+  .admin-modal-actions {
+    flex-direction: column;
   }
 }

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -187,81 +187,83 @@ export function Admin() {
       {tab === 'members' && (
         <div className="admin-tab-content glass">
           <h3 className="admin-section-title">멤버 목록</h3>
-          <table className="admin-members-table">
-            <thead>
-              <tr>
-                <th>이름</th>
-                <th>팀</th>
-                <th>역할</th>
-                <th>상태</th>
-                <th>관리</th>
-              </tr>
-            </thead>
-            <tbody>
-              {members.map((u) => (
-                <tr key={u.id}>
-                  <td>
-                    <span className="admin-avatar">{u.name[0]}</span>
-                    {u.name}
-                  </td>
-                  <td>
-                    <span className={`admin-team-tag ${u.team}`}>
-                      {teamLabels[u.team] ?? u.team}
-                    </span>
-                  </td>
-                  <td>
-                    <span className={`admin-role-tag ${u.role}`}>
-                      {u.role === 'ADMIN' && <Crown size={12} />}
-                      {roleLabels[u.role] ?? u.role}
-                    </span>
-                  </td>
-                  <td>
-                    <div className="admin-status-cell">
-                      <span className={`admin-status-tag ${u.status ?? 'ACTIVE'}`}>
-                        {statusLabels[u.status ?? 'ACTIVE'] ?? (u.status ?? 'ACTIVE')}
-                      </span>
-                      {u.status === 'INACTIVE' ? (
-                        <button
-                          type="button"
-                          className="admin-action-btn activate-btn"
-                          disabled={saving}
-                          onClick={() => handleActivate(u.id)}
-                        >
-                          활성화
-                        </button>
-                      ) : (
-                        <button
-                          type="button"
-                          className="admin-action-btn mute-btn"
-                          disabled={saving}
-                          onClick={() => handleDeactivate(u.id)}
-                        >
-                          비활성화
-                        </button>
-                      )}
-                    </div>
-                  </td>
-                  <td className="admin-actions-cell">
-                    <button
-                      type="button"
-                      className="admin-action-btn"
-                      onClick={() => handleOpenRoleChange(u.id, u.name, u.role)}
-                    >
-                      역할 변경 <ChevronDown size={13} />
-                    </button>
-                    <button
-                      type="button"
-                      className="admin-action-btn deactivate-btn"
-                      disabled={saving || u.status === 'INACTIVE'}
-                      onClick={() => handleExpel(u.id)}
-                    >
-                      {u.status === 'INACTIVE' ? '퇴출됨' : '퇴출'}
-                    </button>
-                  </td>
+          <div className="admin-table-wrap">
+            <table className="admin-members-table">
+              <thead>
+                <tr>
+                  <th>이름</th>
+                  <th>팀</th>
+                  <th>역할</th>
+                  <th>상태</th>
+                  <th>관리</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {members.map((u) => (
+                  <tr key={u.id}>
+                    <td>
+                      <span className="admin-avatar">{u.name[0]}</span>
+                      {u.name}
+                    </td>
+                    <td>
+                      <span className={`admin-team-tag ${u.team}`}>
+                        {teamLabels[u.team] ?? u.team}
+                      </span>
+                    </td>
+                    <td>
+                      <span className={`admin-role-tag ${u.role}`}>
+                        {u.role === 'ADMIN' && <Crown size={12} />}
+                        {roleLabels[u.role] ?? u.role}
+                      </span>
+                    </td>
+                    <td>
+                      <div className="admin-status-cell">
+                        <span className={`admin-status-tag ${u.status ?? 'ACTIVE'}`}>
+                          {statusLabels[u.status ?? 'ACTIVE'] ?? (u.status ?? 'ACTIVE')}
+                        </span>
+                        {u.status === 'INACTIVE' ? (
+                          <button
+                            type="button"
+                            className="admin-action-btn activate-btn"
+                            disabled={saving}
+                            onClick={() => handleActivate(u.id)}
+                          >
+                            활성화
+                          </button>
+                        ) : (
+                          <button
+                            type="button"
+                            className="admin-action-btn mute-btn"
+                            disabled={saving}
+                            onClick={() => handleDeactivate(u.id)}
+                          >
+                            비활성화
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                    <td className="admin-actions-cell">
+                      <button
+                        type="button"
+                        className="admin-action-btn"
+                        onClick={() => handleOpenRoleChange(u.id, u.name, u.role)}
+                      >
+                        역할 변경 <ChevronDown size={13} />
+                      </button>
+                      <button
+                        type="button"
+                        className="admin-action-btn deactivate-btn"
+                        disabled={saving || u.status === 'INACTIVE'}
+                        onClick={() => handleExpel(u.id)}
+                      >
+                        {u.status === 'INACTIVE' ? '퇴출됨' : '퇴출'}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
       )}
 

--- a/src/pages/ai-chat/ai-chat.css
+++ b/src/pages/ai-chat/ai-chat.css
@@ -142,4 +142,48 @@
   .ai-chat-area {
     padding: 18px;
   }
+
+  .msg-bubble {
+    max-width: 100%;
+  }
+
+  .input-area {
+    flex-direction: column;
+  }
+
+  .input-area .send-btn {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .ai-title {
+    align-items: flex-start;
+    text-align: left;
+    justify-content: flex-start;
+  }
+
+  .ai-title h1 {
+    font-size: 1.25rem;
+  }
+
+  .ai-header {
+    text-align: left;
+    padding-inline: 0;
+  }
+
+  .ai-chat-area {
+    padding: 14px;
+    border-radius: 20px;
+  }
+
+  .suggestions {
+    padding: 14px;
+  }
+
+  .input-area input,
+  .input-area .send-btn {
+    padding: 12px 14px;
+  }
 }

--- a/src/pages/attendance/attendance.css
+++ b/src/pages/attendance/attendance.css
@@ -1,5 +1,6 @@
 .attendance-page {
   max-width: 1400px;
+  width: 100%;
 }
 
 .attendance-header {
@@ -22,6 +23,34 @@
   align-items: center;
   gap: 12px;
   flex-wrap: wrap;
+}
+
+.custom-date-filter {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.date-input {
+  min-height: 40px;
+  padding: 9px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font-size: 0.9rem;
+}
+
+.filter-apply-btn {
+  min-height: 40px;
+  padding: 10px 16px;
+  border-radius: 12px;
+  background: rgba(124, 58, 237, 0.18);
+  border: 1px solid rgba(138, 114, 216, 0.22);
+  color: var(--text-primary);
+  font-size: 0.88rem;
+  font-weight: 600;
 }
 
 .export-btn {
@@ -99,11 +128,14 @@
 
 .records-table-wrap {
   overflow-x: auto;
+  padding-bottom: 6px;
+  scrollbar-width: thin;
 }
 
 .records-table {
   width: 100%;
   border-collapse: collapse;
+  min-width: 720px;
 }
 
 .records-table th,
@@ -111,6 +143,7 @@
   padding: 12px 14px;
   text-align: left;
   border-bottom: 1px solid var(--border-color);
+  white-space: nowrap;
 }
 
 .records-table th {
@@ -229,5 +262,108 @@
 @media (max-width: 900px) {
   .summary-stats {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  .team-status-section,
+  .team-schedule-section,
+  .set-work-days-section,
+  .records-section,
+  .my-history-section,
+  .leave-section-wrap {
+    padding: 20px;
+  }
+}
+
+@media (max-width: 720px) {
+  .attendance-header {
+    margin-bottom: 20px;
+  }
+
+  .attendance-header h1 {
+    font-size: 1.55rem;
+  }
+
+  .header-actions {
+    width: 100%;
+    align-items: stretch;
+  }
+
+  .export-btn,
+  .date-range,
+  .custom-date-filter,
+  .filter-tabs {
+    width: 100%;
+  }
+
+  .export-btn,
+  .date-range {
+    justify-content: center;
+  }
+
+  .filter-tabs {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+  }
+
+  .filter-tabs button,
+  .date-input,
+  .filter-apply-btn {
+    width: 100%;
+  }
+
+  .custom-date-filter {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .team-status-section,
+  .team-schedule-section,
+  .set-work-days-section,
+  .records-section,
+  .my-history-section,
+  .leave-section-wrap {
+    padding: 18px;
+  }
+
+  .pagination {
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 560px) {
+  .attendance-header h1 {
+    font-size: 1.4rem;
+  }
+
+  .team-status-section,
+  .team-schedule-section,
+  .set-work-days-section,
+  .records-section,
+  .my-history-section,
+  .leave-section-wrap,
+  .stat-card {
+    padding: 16px;
+  }
+
+  .records-table {
+    min-width: 620px;
+  }
+
+  .records-table th,
+  .records-table td {
+    padding: 10px 12px;
+  }
+
+  .record-avatar {
+    width: 24px;
+    height: 24px;
+    margin-right: 8px;
+    font-size: 0.72rem;
+  }
+
+  .summary-stats {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/pages/calendar/calendar.css
+++ b/src/pages/calendar/calendar.css
@@ -855,12 +855,71 @@
   .calendar-page {
     flex-direction: column;
     height: auto;
+    max-height: none;
+    margin: -16px;
+  }
+
+  .calendar-main {
+    padding: 18px 16px 24px;
+  }
+
+  .fullcalendar-wrapper {
+    max-width: 100%;
+  }
+
+  .fullcalendar-wrapper .fc-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .fullcalendar-wrapper .fc-toolbar-title {
+    font-size: 1.05rem;
+    text-align: center;
+  }
+
+  .fullcalendar-wrapper .fc-header-toolbar {
+    margin-bottom: 1rem;
   }
 
   .tasks-sidebar {
     width: 100%;
     border-left: none;
     border-top: 1px solid rgba(255, 255, 255, 0.05);
+    padding: 18px 16px 24px;
+  }
+}
+
+@media (max-width: 640px) {
+  .calendar-page {
+    margin: -14px;
   }
 
+  .edit-task-modal,
+  .add-task-modal,
+  .context-menu-modal {
+    min-width: 0;
+    width: calc(100vw - 24px);
+    max-width: 420px;
+  }
+
+  .add-event-datetime {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .add-event-datetime .add-task-date {
+    flex: 1 1 auto;
+  }
+
+  .tasks-tabs {
+    gap: 12px;
+    font-size: 0.88rem;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .tasks-tabs::-webkit-scrollbar {
+    display: none;
+  }
 }

--- a/src/pages/chat/chat.css
+++ b/src/pages/chat/chat.css
@@ -545,14 +545,92 @@
     flex-direction: column;
     min-height: 100%;
     height: auto;
+    border-radius: 20px;
   }
 
   .chat-sidebar {
     width: 100%;
-    max-height: 240px;
+    max-height: 220px;
+    padding: 16px;
   }
 
   .chat-main {
-    min-height: 400px;
+    min-height: 60vh;
+  }
+
+  .chat-header {
+    padding: 16px;
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+
+  .chat-messages {
+    padding: 16px;
+  }
+
+  .msg-content {
+    max-width: 100%;
+  }
+
+  .chat-input-area {
+    padding: 14px 16px 18px;
+  }
+
+  .input-row {
+    flex-wrap: wrap;
+    align-items: stretch;
+  }
+
+  .format-toolbar {
+    width: 100%;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .format-toolbar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .chat-input-area .chat-input {
+    width: 100%;
+  }
+
+  .send-btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .emoji-picker {
+    grid-template-columns: repeat(6, 1fr);
+  }
+
+  .link-modal {
+    min-width: 0;
+    width: calc(100vw - 32px);
+    max-width: 420px;
+    padding: 18px;
+  }
+}
+
+@media (max-width: 480px) {
+  .chat-page {
+    border-radius: 18px;
+  }
+
+  .search-wrap,
+  .chat-header,
+  .chat-input-area .chat-input {
+    border-radius: 12px;
+  }
+
+  .msg {
+    gap: 10px;
+    margin-bottom: 16px;
+  }
+
+  .msg-avatar {
+    width: 34px;
+    height: 34px;
+    font-size: 0.78rem;
   }
 }

--- a/src/pages/dashboard/dashboard.css
+++ b/src/pages/dashboard/dashboard.css
@@ -1,7 +1,7 @@
 .dashboard {
   max-width: 1200px;
   min-height: calc(100vh - 180px);
-  height: calc(100vh - 180px);
+  height: auto;
   display: flex;
   flex-direction: column;
 }
@@ -376,13 +376,23 @@
 }
 
 @media (max-width: 640px) {
+  .dashboard {
+    min-height: auto;
+  }
+
   .dashboard-grid {
     grid-template-columns: 1fr;
+    gap: 16px;
   }
 
   .clock-outer {
     width: 144px;
     height: 144px;
+  }
+
+  .card {
+    padding: 18px;
+    border-radius: 20px;
   }
 }
 
@@ -440,6 +450,7 @@
 @media (max-width: 900px) {
   .dashboard {
     height: auto;
+    min-height: auto;
   }
 
   .dashboard-grid {

--- a/src/pages/drive/drive.css
+++ b/src/pages/drive/drive.css
@@ -382,6 +382,7 @@
 
   .drive-header-actions {
     width: 100%;
+    justify-content: flex-start;
   }
 
   .upload-btn {
@@ -396,5 +397,25 @@
 
   .file-side {
     justify-content: space-between;
+  }
+}
+
+@media (max-width: 480px) {
+  .drive-page {
+    gap: 18px;
+  }
+
+  .drive-side-panel,
+  .drive-content {
+    padding: 18px;
+  }
+
+  .drive-side-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .drive-access-badge {
+    width: 100%;
+    justify-content: center;
   }
 }

--- a/src/pages/members/members.css
+++ b/src/pages/members/members.css
@@ -1,5 +1,6 @@
 .members-page {
   max-width: 1400px;
+  width: 100%;
 }
 
 .members-header {
@@ -109,6 +110,7 @@
 .members-table {
   width: 100%;
   border-collapse: collapse;
+  min-width: 760px;
 }
 
 .members-table th,
@@ -190,6 +192,13 @@
 .actions {
   display: flex;
   gap: 8px;
+}
+
+.actions-cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
 .action-btn {
@@ -469,4 +478,77 @@
   border-color: var(--purple, #9680cc);
   color: var(--purple, #9680cc);
   background: rgba(150, 128, 204, 0.15);
+}
+
+@media (max-width: 900px) {
+  .members-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .invite-btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .members-page .search-wrap {
+    max-width: none;
+  }
+
+  .table-section,
+  .stats-sidebar {
+    padding: 18px;
+  }
+
+  .filter-btns {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    padding-bottom: 2px;
+    scrollbar-width: none;
+  }
+
+  .filter-btns::-webkit-scrollbar {
+    display: none;
+  }
+
+  .filter-btns button {
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+}
+
+@media (max-width: 640px) {
+  .members-header h1 {
+    font-size: 1.45rem;
+    flex-wrap: wrap;
+  }
+
+  .members-table th,
+  .members-table td {
+    white-space: nowrap;
+    padding: 10px 12px;
+  }
+
+  .table-section,
+  .stats-sidebar {
+    padding: 16px;
+  }
+
+  .invite-modal,
+  .change-role-modal {
+    width: calc(100vw - 24px);
+    min-width: 0;
+    padding: 20px 18px;
+  }
+
+  .role-btns,
+  .modal-actions {
+    flex-wrap: wrap;
+  }
+
+  .modal-actions .cancel-btn,
+  .modal-actions .confirm-btn {
+    width: 100%;
+    justify-content: center;
+  }
 }

--- a/src/pages/settings/settings.css
+++ b/src/pages/settings/settings.css
@@ -552,11 +552,48 @@
 }
 
 @media (max-width: 640px) {
+  .settings-page {
+    gap: 18px;
+  }
+
   .settings-content {
     padding: 22px 18px;
   }
 
   .profile-avatar-row {
+    flex-direction: column;
     align-items: flex-start;
+  }
+
+  .settings-nav {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .settings-nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  .settings-nav-item {
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+
+  .setting-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .settings-content .save-btn,
+  .danger-zone .danger-btn,
+  .danger-zone .danger-confirm-btn,
+  .danger-zone .danger-cancel-btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .danger-zone-head {
+    flex-direction: column;
   }
 }

--- a/src/widgets/Layout/Layout.css
+++ b/src/widgets/Layout/Layout.css
@@ -149,7 +149,7 @@
   margin-left: var(--sidebar-width);
   padding: 24px 28px 28px;
   min-height: 100vh;
-  height: 100vh;
+  height: auto;
   display: flex;
   flex-direction: column;
   overflow-y: auto;
@@ -265,6 +265,16 @@
   transform: translateY(-1px);
 }
 
+@media (max-width: 1024px) {
+  .main-content {
+    padding: 20px 20px 24px;
+  }
+
+  .content-topbar {
+    margin-bottom: 20px;
+  }
+}
+
 @media (max-width: 768px) {
   .sidebar {
     width: 100%;
@@ -276,6 +286,7 @@
     padding: 8px 4px;
     border-right: none;
     border-top: 1px solid var(--border-color);
+    padding-bottom: calc(8px + env(safe-area-inset-bottom));
   }
 
   .logo-panel,
@@ -286,14 +297,22 @@
   .nav {
     flex-direction: row;
     flex: 1;
-    justify-content: space-around;
+    justify-content: flex-start;
     padding: 0;
+    overflow-x: auto;
+    gap: 4px;
+    scrollbar-width: none;
+  }
+
+  .nav::-webkit-scrollbar {
+    display: none;
   }
 
   .nav-item {
-    flex: 1;
+    flex: 0 0 auto;
+    min-width: 52px;
     justify-content: center;
-    padding: 12px 10px;
+    padding: 10px 12px;
   }
 
   .nav-item:hover {
@@ -306,16 +325,37 @@
 
   .main-content {
     margin-left: 0;
-    margin-bottom: 78px;
-    padding: 16px 16px 24px;
+    margin-bottom: 82px;
+    padding: 16px 14px calc(24px + env(safe-area-inset-bottom));
+    min-height: auto;
   }
 
   .content-topbar {
     padding-inline: 0;
     padding-bottom: 14px;
+    margin-bottom: 16px;
   }
 
   .content-topbar h1 {
     font-size: 1.45rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .main-content {
+    padding: 14px 12px calc(20px + env(safe-area-inset-bottom));
+  }
+
+  .content-topbar {
+    padding-bottom: 12px;
+  }
+
+  .content-kicker {
+    margin-bottom: 4px;
+    font-size: 0.72rem;
+  }
+
+  .content-topbar h1 {
+    font-size: 1.38rem;
   }
 }


### PR DESCRIPTION
## 관련 이슈
- #162

## 작업 내용
- 전역 레이아웃과 하단 모바일 내비게이션 간격을 정리했습니다.
- 출퇴근, 관리자, 멤버 화면의 표와 근무 일정 영역을 모바일에서도 읽기 쉽게 다듬었습니다.
- 설정, 채팅, 캘린더, 드라이브, AI 화면의 작은 화면 대응을 보강했습니다.

## 테스트
- npm run test:run
- npm run build

## 체크리스트
- [x] 테스트 코드 및 기존 기능 영향 확인
- [x] 모바일 화면 기준 레이아웃 점검
- [x] develop 대상으로 PR 생성