### PR TITLE
release: v0.1.7

### DIFF
--- a/src/features/attendance/ui/SetWorkDaysPersonal.css
+++ b/src/features/attendance/ui/SetWorkDaysPersonal.css
@@ -58,7 +58,7 @@
 .schedule-summary {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 14px;
   flex-wrap: wrap;
   padding: 16px 18px;
@@ -69,9 +69,12 @@
 
 .schedule-summary p {
   margin: 0;
+  flex: 1;
+  min-width: 0;
   color: var(--text-secondary);
   font-size: 0.83rem;
   line-height: 1.6;
+  overflow-wrap: anywhere;
 }
 
 .summary-chip {
@@ -289,8 +292,11 @@
   font-size: 0.85rem;
 }
 
-.save-btn {
+.schedule-save-btn {
   align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   padding: 12px 24px;
   background: var(--gradient-purple);
   color: var(--text-on-accent);
@@ -301,12 +307,12 @@
   transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
-.save-btn:disabled {
+.schedule-save-btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
 }
 
-.save-btn:hover:not(:disabled) {
+.schedule-save-btn:hover:not(:disabled) {
   opacity: 0.92;
   transform: translateY(-1px);
 }
@@ -358,7 +364,7 @@
     font-size: 0.76rem;
   }
 
-  .save-btn {
+  .schedule-save-btn {
     width: 100%;
     justify-content: center;
   }

--- a/src/features/attendance/ui/SetWorkDaysPersonal.tsx
+++ b/src/features/attendance/ui/SetWorkDaysPersonal.tsx
@@ -118,7 +118,7 @@ export function SetWorkDaysPersonal() {
 
       {error && <p className="schedule-error">{error}</p>}
 
-      <button className="save-btn" onClick={saveSchedule} disabled={isSaving}>
+      <button className="schedule-save-btn" onClick={saveSchedule} disabled={isSaving}>
         {isSaving ? '저장 중...' : '저장'}
       </button>
     </div>

--- a/src/features/auth/api/__tests__/authClient.test.ts
+++ b/src/features/auth/api/__tests__/authClient.test.ts
@@ -13,6 +13,12 @@ const server = setupServer(
         data: { accessToken: 'mock-token', refreshToken: 'refresh-token', tokenType: 'Bearer' },
       })
     }
+    if (body.email === 'inactive@yanus.kr' && body.password === 'password') {
+      return HttpResponse.json(
+        { code: 'MEMBER_INACTIVE', message: '비활성화된 계정입니다', data: null },
+        { status: 403 },
+      )
+    }
     return HttpResponse.json(
       { code: 'UNAUTHORIZED', message: '이메일 또는 비밀번호가 올바르지 않습니다', data: null },
       { status: 401 },
@@ -52,7 +58,13 @@ describe('authClient', () => {
     })
 
     it('잘못된 자격증명이면 에러를 던진다', async () => {
-      await expect(login('wrong@test.com', 'wrong')).rejects.toThrow()
+      await expect(login('wrong@test.com', 'wrong')).rejects.toThrow('이메일 또는 비밀번호가 올바르지 않습니다')
+    })
+
+    it('비활성 계정이면 전용 안내 문구를 반환한다', async () => {
+      await expect(login('inactive@yanus.kr', 'password')).rejects.toThrow(
+        '비활성화된 계정입니다. 관리자에게 문의해 주세요',
+      )
     })
   })
 

--- a/src/features/auth/api/authClient.ts
+++ b/src/features/auth/api/authClient.ts
@@ -1,4 +1,5 @@
 import { baseClient } from '../../../shared/api/baseClient'
+import { ApiError } from '../../../shared/api/baseClient'
 import type { User } from '../../../entities/user/model/types'
 
 export interface RegisterPayload {
@@ -18,11 +19,18 @@ interface MeResponse {
 }
 
 export async function login(email: string, password: string): Promise<string> {
-  const data = await baseClient.post<{ accessToken: string; refreshToken: string; tokenType: string }>(
-    '/api/v1/auth/login',
-    { email, password },
-  )
-  return data.accessToken
+  try {
+    const data = await baseClient.post<{ accessToken: string; refreshToken: string; tokenType: string }>(
+      '/api/v1/auth/login',
+      { email, password },
+    )
+    return data.accessToken
+  } catch (err) {
+    if (err instanceof ApiError && err.code === 'MEMBER_INACTIVE') {
+      throw new Error('비활성화된 계정입니다. 관리자에게 문의해 주세요')
+    }
+    throw err
+  }
 }
 
 export async function register(payload: RegisterPayload): Promise<void> {

--- a/src/features/chat/model/ChatProvider.tsx
+++ b/src/features/chat/model/ChatProvider.tsx
@@ -36,6 +36,8 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [activeChannelId, setActiveChannelId] = useState('1')
 
+  const isDirectChannel = useCallback((channelId: string) => channelId.startsWith('dm-'), [])
+
   useEffect(() => {
     getChannels()
       .then((data: ApiChannel[]) => {
@@ -46,7 +48,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   }, [])
 
   useEffect(() => {
-    if (!activeChannelId) return
+    if (!activeChannelId || isDirectChannel(activeChannelId)) return
     getMessages(activeChannelId)
       .then((data: ApiMessage[]) => {
         setMessages((prev) => [
@@ -55,7 +57,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         ])
       })
       .catch(() => {})
-  }, [activeChannelId])
+  }, [activeChannelId, isDirectChannel])
 
   const addMessage = useCallback(
     (channelId: string, content?: string, files?: { name: string; url: string; type: string }[]) => {
@@ -73,9 +75,12 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         timestamp: new Date(),
       }
       setMessages((prev) => [...prev, optimistic])
+      if (isDirectChannel(channelId)) {
+        return
+      }
       apiSendMessage(channelId, content ?? '', type).catch(() => {})
     },
-    [state.currentUser?.id, state.currentUser?.name]
+    [isDirectChannel, state.currentUser?.id, state.currentUser?.name]
   )
 
   const getMessagesByChannel = useCallback(

--- a/src/features/chat/model/__tests__/ChatProvider.test.tsx
+++ b/src/features/chat/model/__tests__/ChatProvider.test.tsx
@@ -90,6 +90,16 @@ describe('ChatProvider', () => {
       })
       expect(result.current.messages.length).toBe(before + 1)
     })
+
+    it('개인 대화방에도 메시지를 추가할 수 있다', () => {
+      const { result } = renderHook(() => useChat(), { wrapper })
+      act(() => {
+        result.current.setActiveChannelId('dm-2')
+        result.current.addMessage('dm-2', '개인 메시지')
+      })
+      const directMessages = result.current.getMessagesByChannel('dm-2')
+      expect(directMessages.at(-1)?.content).toBe('개인 메시지')
+    })
   })
 
   describe('getMessagesByChannel', () => {

--- a/src/pages/chat/chat.css
+++ b/src/pages/chat/chat.css
@@ -22,7 +22,18 @@
 .chat-sidebar h2 {
   font-size: 1.2rem;
   font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.chat-list-head {
   margin-bottom: 16px;
+}
+
+.chat-list-head p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.84rem;
+  line-height: 1.5;
 }
 
 .search-wrap {
@@ -105,6 +116,10 @@
   background: var(--nav-hover);
 }
 
+.dm-item.active {
+  background: var(--nav-active);
+}
+
 .dm-avatar {
   width: 28px;
   height: 28px;
@@ -118,8 +133,20 @@
 }
 
 .dm-name {
-  flex: 1;
   font-size: 0.9rem;
+}
+
+.dm-copy {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.dm-room-hint {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
 }
 
 .dm-status {
@@ -155,24 +182,42 @@
   margin: 0 0 2px 0;
 }
 
+.chat-room-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.chat-back-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+}
+
 .members-count {
   font-size: 0.85rem;
   color: var(--text-secondary);
 }
 
-.header-actions {
+.chat-header-actions {
   display: flex;
   gap: 8px;
 }
 
-.header-actions button {
+.chat-header-actions button {
   padding: 8px;
   color: var(--text-secondary);
   border-radius: 10px;
   background: transparent;
 }
 
-.header-actions button:hover {
+.chat-header-actions button:hover {
   background: var(--nav-hover);
   color: var(--text-primary);
 }
@@ -184,6 +229,37 @@
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.01) 0%, rgba(255, 255, 255, 0) 100%),
     radial-gradient(circle at top right, rgba(212, 74, 153, 0.08), transparent 30%);
+}
+
+.chat-empty-room {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 420px;
+  margin: 16px auto 0;
+  padding: 18px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border-color);
+  text-align: center;
+}
+
+.chat-empty-room strong,
+.chat-empty-room p {
+  margin: 0;
+}
+
+.chat-empty-room p {
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.chat-empty-search {
+  padding: 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text-secondary);
+  font-size: 0.85rem;
 }
 
 .msg {
@@ -542,26 +618,44 @@
 
 @media (max-width: 768px) {
   .chat-page {
-    flex-direction: column;
-    min-height: 100%;
+    display: block;
+    min-height: calc(100vh - 164px);
     height: auto;
     border-radius: 20px;
   }
 
   .chat-sidebar {
     width: 100%;
-    max-height: 220px;
+    max-height: none;
     padding: 16px;
+    border-right: none;
   }
 
   .chat-main {
     min-height: 60vh;
   }
 
+  .chat-page.list-open-mobile .chat-main {
+    display: none;
+  }
+
+  .chat-page.room-open-mobile .chat-sidebar {
+    display: none;
+  }
+
   .chat-header {
     padding: 16px;
-    flex-wrap: wrap;
-    align-items: flex-start;
+    align-items: center;
+  }
+
+  .chat-header-actions {
+    width: auto;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .chat-room-meta {
+    min-width: 0;
   }
 
   .chat-messages {
@@ -596,7 +690,7 @@
   }
 
   .send-btn {
-    width: 100%;
+    flex: 0 0 auto;
     justify-content: center;
   }
 
@@ -623,6 +717,32 @@
     border-radius: 12px;
   }
 
+  .chat-sidebar,
+  .chat-messages,
+  .chat-input-area {
+    padding-inline: 14px;
+  }
+
+  .chat-header {
+    padding: 14px;
+    flex-wrap: nowrap;
+  }
+
+  .chat-header h3 {
+    font-size: 1rem;
+  }
+
+  .chat-header-actions button,
+  .chat-back-btn {
+    width: 34px;
+    height: 34px;
+    padding: 0;
+  }
+
+  .members-count {
+    font-size: 0.8rem;
+  }
+
   .msg {
     gap: 10px;
     margin-bottom: 16px;
@@ -632,5 +752,13 @@
     width: 34px;
     height: 34px;
     font-size: 0.78rem;
+  }
+
+  .input-row {
+    flex-direction: column;
+  }
+
+  .send-btn {
+    width: 100%;
   }
 }

--- a/src/pages/chat/index.tsx
+++ b/src/pages/chat/index.tsx
@@ -1,9 +1,10 @@
 import { useState, useRef, useEffect } from 'react'
 import ReactMarkdown from 'react-markdown'
-import { Search, Send, Paperclip, Smile, Bold, Italic, Strikethrough, Link as LinkIcon, List, ListOrdered, Code, X } from 'lucide-react'
+import { Search, Send, Paperclip, Smile, Bold, Italic, Strikethrough, Link as LinkIcon, List, ListOrdered, Code, X, ArrowLeft } from 'lucide-react'
 import { useApp } from '../../features/auth/model'
 import { useChat } from '../../features/chat/model'
 import type { ChatMessage } from '../../features/chat/model'
+import { getMembers } from '../../shared/api/membersApi'
 import './chat.css'
 
 const EMOJIS = ['😊', '👍', '❤️', '😂', '😢', '😍', '🔥', '✨', '🎉', '🙏', '👋', '💯', '✅', '❌', '⭐', '💪']
@@ -79,23 +80,54 @@ function MessageItem({ msg, isOwn }: { msg: ChatMessage; isOwn: boolean }) {
 }
 
 export function Chat() {
-  const { state } = useApp()
+  const { state, loadMembers } = useApp()
   const { channels, activeChannelId, setActiveChannelId, addMessage, getMessagesByChannel } = useChat()
   const [message, setMessage] = useState('')
   const [attachedFiles, setAttachedFiles] = useState<{ name: string; url: string; type: string }[]>([])
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
   const [showLinkModal, setShowLinkModal] = useState(false)
   const [linkUrl, setLinkUrl] = useState('')
+  const [roomQuery, setRoomQuery] = useState('')
+  const [isMobile, setIsMobile] = useState(() => window.innerWidth <= 768)
+  const [isMobileRoomOpen, setIsMobileRoomOpen] = useState(() => window.innerWidth > 768)
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const emojiPickerRef = useRef<HTMLButtonElement>(null)
 
   const activeChannel = channels.find((c) => c.id === activeChannelId)
+  const currentUserId = state.currentUser?.id ?? ''
+  const directRooms = state.users.filter((user) => user.id !== currentUserId)
+  const activeDirectUser = directRooms.find((user) => `dm-${user.id}` === activeChannelId)
+  const isDirectRoom = activeChannelId.startsWith('dm-')
   const messages = getMessagesByChannel(activeChannelId)
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
+
+  useEffect(() => {
+    if (state.users.length > 0) return
+    getMembers()
+      .then(loadMembers)
+      .catch(() => {})
+  }, [loadMembers, state.users.length])
+
+  useEffect(() => {
+    const onResize = () => {
+      const mobile = window.innerWidth <= 768
+      setIsMobile(mobile)
+      setIsMobileRoomOpen((prev) => (mobile ? prev && !!activeChannelId : true))
+    }
+
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [activeChannelId])
+
+  useEffect(() => {
+    if (!isMobile) {
+      setIsMobileRoomOpen(true)
+    }
+  }, [isMobile])
 
   useEffect(() => {
     if (!showEmojiPicker) return
@@ -202,23 +234,53 @@ export function Chat() {
     })
   }
 
-  const currentUserId = state.currentUser?.id ?? ''
+  const filteredChannels = channels.filter((channel) =>
+    channel.name.toLowerCase().includes(roomQuery.toLowerCase()) ||
+    (channel.lastMessage ?? '').toLowerCase().includes(roomQuery.toLowerCase()),
+  )
+
+  const filteredDirectRooms = directRooms.filter((user) =>
+    user.name.toLowerCase().includes(roomQuery.toLowerCase()) ||
+    user.team.toLowerCase().includes(roomQuery.toLowerCase()),
+  )
+
+  const openRoom = (id: string) => {
+    setActiveChannelId(id)
+    if (isMobile) {
+      setIsMobileRoomOpen(true)
+    }
+  }
+
+  const roomTitle = isDirectRoom
+    ? activeDirectUser?.name ?? '대화방'
+    : `# ${activeChannel?.name || 'Design Team'}`
+
+  const roomMeta = isDirectRoom
+    ? `${activeDirectUser?.team ?? '알 수 없는 팀'} · ${activeDirectUser?.online ? '대화 가능' : '현재 자리 비움'}`
+    : '23 members'
 
   return (
-    <div className="chat-page">
+    <div className={`chat-page ${isMobileRoomOpen ? 'room-open-mobile' : 'list-open-mobile'}`}>
       <aside className="chat-sidebar glass">
-        <h2>Messages</h2>
+        <div className="chat-list-head">
+          <h2>Messages</h2>
+          <p>대화할 채널이나 대상을 먼저 선택한 뒤 대화방으로 들어갑니다.</p>
+        </div>
         <div className="search-wrap">
           <Search size={18} />
-          <input placeholder="Search messages." />
+          <input
+            placeholder="채널 또는 대상을 검색하세요."
+            value={roomQuery}
+            onChange={(e) => setRoomQuery(e.target.value)}
+          />
         </div>
         <section>
           <h4>CHANNELS</h4>
-          {channels.map((ch) => (
+          {filteredChannels.map((ch) => (
             <div
               key={ch.id}
               className={`channel-item ${ch.id === activeChannelId ? 'active' : ''}`}
-              onClick={() => setActiveChannelId(ch.id)}
+              onClick={() => openRoom(ch.id)}
             >
               <span className="channel-name"># {ch.name}</span>
               <span className="channel-last">{ch.lastMessage}</span>
@@ -227,32 +289,56 @@ export function Chat() {
         </section>
         <section>
           <h4>DIRECT MESSAGES</h4>
-          {state.users.map((u) => (
-            <div key={u.id} className="dm-item">
+          {filteredDirectRooms.map((u) => (
+            <div
+              key={u.id}
+              className={`dm-item ${activeChannelId === `dm-${u.id}` ? 'active' : ''}`}
+              onClick={() => openRoom(`dm-${u.id}`)}
+            >
               <span className="dm-avatar">{u.name[0]}</span>
-              <span className="dm-name">{u.name}</span>
+              <div className="dm-copy">
+                <span className="dm-name">{u.name}</span>
+                <span className="dm-room-hint">{u.team}</span>
+              </div>
               <span className={`dm-status ${u.online ? 'online' : 'offline'}`}>
                 • {u.online ? 'online' : 'away'}
               </span>
             </div>
           ))}
+          {filteredChannels.length === 0 && filteredDirectRooms.length === 0 && (
+            <div className="chat-empty-search">검색 결과가 없습니다.</div>
+          )}
         </section>
       </aside>
       <div className="chat-main">
         <header className="chat-header glass">
-          <div>
-            <h3># {activeChannel?.name || 'Design Team'}</h3>
-            <span className="members-count">23 members</span>
+          <div className="chat-room-meta">
+            {isMobile && isMobileRoomOpen && (
+              <button type="button" className="chat-back-btn" onClick={() => setIsMobileRoomOpen(false)}>
+                <ArrowLeft size={18} />
+              </button>
+            )}
+            <div>
+              <h3>{roomTitle}</h3>
+              <span className="members-count">{roomMeta}</span>
+            </div>
           </div>
-          <div className="header-actions">
+          <div className="chat-header-actions">
             <button><Search size={18} /></button>
             <button>⋮</button>
           </div>
         </header>
         <div className="chat-messages">
-          {messages.map((msg) => (
-            <MessageItem key={msg.id} msg={msg} isOwn={msg.userId === currentUserId} />
-          ))}
+          {messages.length === 0 ? (
+            <div className="chat-empty-room">
+              <strong>{isDirectRoom ? `${activeDirectUser?.name ?? '상대방'}에게 첫 메시지를 보내보세요.` : '아직 대화가 없습니다.'}</strong>
+              <p>대상을 고른 뒤 바로 대화를 시작할 수 있도록 방 구조를 정리했습니다.</p>
+            </div>
+          ) : (
+            messages.map((msg) => (
+              <MessageItem key={msg.id} msg={msg} isOwn={msg.userId === currentUserId} />
+            ))
+          )}
           <div ref={messagesEndRef} />
         </div>
         <div className="chat-input-area glass">

--- a/src/pages/login/__tests__/Login.test.tsx
+++ b/src/pages/login/__tests__/Login.test.tsx
@@ -86,6 +86,15 @@ describe('Login 페이지', () => {
     expect(await screen.findByText('이메일 또는 비밀번호가 올바르지 않습니다')).toBeInTheDocument()
   })
 
+  it('비활성 계정이면 전용 안내 메시지를 표시한다', async () => {
+    mockLogin.mockRejectedValue(new Error('비활성화된 계정입니다. 관리자에게 문의해 주세요'))
+    renderLogin()
+    await userEvent.type(screen.getByLabelText('이메일'), 'inactive@yanus.kr')
+    await userEvent.type(screen.getByLabelText('비밀번호'), 'password123')
+    await userEvent.click(screen.getByRole('button', { name: '로그인' }))
+    expect(await screen.findByText('비활성화된 계정입니다. 관리자에게 문의해 주세요')).toBeInTheDocument()
+  })
+
   it('로딩 중에는 버튼이 비활성화된다', async () => {
     mockLogin.mockImplementation(() => new Promise(() => {})) // 무한 대기
     renderLogin()

--- a/src/pages/members/members.css
+++ b/src/pages/members/members.css
@@ -93,13 +93,16 @@
 
 .members-content {
   display: grid;
-  grid-template-columns: 1fr 320px;
+  grid-template-columns: minmax(0, 1fr) 320px;
   gap: 24px;
+  align-items: start;
 }
 
 .table-section {
   padding: 24px;
   overflow-x: auto;
+  overflow-y: hidden;
+  min-width: 0;
 }
 
 .table-section h3 {
@@ -258,6 +261,7 @@
 .stats-sidebar {
   padding: 24px;
   height: fit-content;
+  min-width: 0;
 }
 
 .stats-sidebar h3 {

--- a/src/shared/api/__tests__/baseClient.test.ts
+++ b/src/shared/api/__tests__/baseClient.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
 import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
-import { baseClient, ApiError } from '../baseClient'
+import { baseClient } from '../baseClient'
 
 const server = setupServer()
 
@@ -30,9 +30,16 @@ describe('baseClient', () => {
 
   it('401 응답 시 ApiError를 던진다', async () => {
     server.use(
-      http.get('/test-401', () => HttpResponse.json({ message: '인증 실패' }, { status: 401 })),
+      http.get('/test-401', () =>
+        HttpResponse.json({ code: 'UNAUTHORIZED', message: '인증 실패', data: null }, { status: 401 }),
+      ),
     )
-    await expect(baseClient.get('/test-401')).rejects.toThrow(ApiError)
+    await expect(baseClient.get('/test-401')).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 401,
+      code: 'UNAUTHORIZED',
+      message: '인증 실패',
+    })
   })
 
   it('4xx 응답 시 ApiError를 던진다', async () => {

--- a/src/shared/api/baseClient.ts
+++ b/src/shared/api/baseClient.ts
@@ -22,6 +22,7 @@ function handleUnauthorized() {
 }
 
 async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const hasAuthToken = Boolean(localStorage.getItem('accessToken'))
   const res = await fetch(`${BASE_URL}${path}`, {
     ...options,
     headers: {
@@ -30,11 +31,6 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
       ...options.headers,
     },
   })
-
-  if (res.status === 401) {
-    handleUnauthorized()
-    throw new ApiError(401, '인증이 만료되었습니다')
-  }
 
   if (!res.ok) {
     let message = `요청 실패: ${res.status}`
@@ -45,6 +41,9 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
       if (data.code) code = data.code
     } catch {
       // Ignore non-JSON error bodies and keep the fallback message.
+    }
+    if (res.status === 401 && hasAuthToken) {
+      handleUnauthorized()
     }
     throw new ApiError(res.status, message, code)
   }
@@ -63,26 +62,32 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
 }
 
 async function requestBlob(path: string): Promise<Blob> {
+  const hasAuthToken = Boolean(localStorage.getItem('accessToken'))
   const res = await fetch(`${BASE_URL}${path}`, {
     headers: getAuthHeaders(),
   })
   if (res.status === 401) {
-    handleUnauthorized()
-    throw new ApiError(401, '인증이 만료되었습니다')
+    if (hasAuthToken) {
+      handleUnauthorized()
+    }
+    throw new ApiError(401, '인증이 필요합니다', 'UNAUTHORIZED')
   }
   if (!res.ok) throw new ApiError(res.status, `다운로드 실패: ${res.status}`)
   return res.blob()
 }
 
 async function requestUpload<T>(path: string, formData: FormData): Promise<T> {
+  const hasAuthToken = Boolean(localStorage.getItem('accessToken'))
   const res = await fetch(`${BASE_URL}${path}`, {
     method: 'POST',
     headers: getAuthHeaders(), // Content-Type 미설정 → 브라우저가 multipart boundary 자동 지정
     body: formData,
   })
   if (res.status === 401) {
-    handleUnauthorized()
-    throw new ApiError(401, '인증이 만료되었습니다')
+    if (hasAuthToken) {
+      handleUnauthorized()
+    }
+    throw new ApiError(401, '인증이 필요합니다', 'UNAUTHORIZED')
   }
   if (!res.ok) {
     let message = `업로드 실패: ${res.status}`

--- a/src/shared/api/mock/handlers/auth.ts
+++ b/src/shared/api/mock/handlers/auth.ts
@@ -2,9 +2,10 @@ import { http, HttpResponse } from 'msw'
 import type { User } from '../../../../entities/user/model/types'
 
 const INITIAL_USERS: User[] = [
-  { id: '1', name: '김리더', email: 'admin@yanus.kr', team: 'BACKEND', role: 'ADMIN', online: true },
-  { id: '2', name: '박팀장', email: 'lead@yanus.kr', team: 'FRONTEND', role: 'TEAM_LEAD', online: true },
-  { id: '3', name: '이멤버', email: 'user@yanus.kr', team: 'AI', role: 'MEMBER', online: false },
+  { id: '1', name: '김리더', email: 'admin@yanus.kr', team: 'BACKEND', role: 'ADMIN', status: 'ACTIVE', online: true },
+  { id: '2', name: '박팀장', email: 'lead@yanus.kr', team: 'FRONTEND', role: 'TEAM_LEAD', status: 'ACTIVE', online: true },
+  { id: '3', name: '이멤버', email: 'user@yanus.kr', team: 'AI', role: 'MEMBER', status: 'ACTIVE', online: false },
+  { id: '5', name: '정보안', email: 'sec@yanus.kr', team: 'SECURITY', role: 'MEMBER', status: 'INACTIVE', online: false },
 ]
 
 let mockUsers = [...INITIAL_USERS]
@@ -13,6 +14,7 @@ const INITIAL_CREDENTIALS: Record<string, { userId: string; password: string }> 
   'admin@yanus.kr': { userId: '1', password: 'password' },
   'lead@yanus.kr': { userId: '2', password: 'password' },
   'user@yanus.kr': { userId: '3', password: 'password' },
+  'sec@yanus.kr': { userId: '5', password: 'password' },
 }
 
 let validCredentials: Record<string, { userId: string; password: string }> = { ...INITIAL_CREDENTIALS }
@@ -43,6 +45,15 @@ export const authHandlers = [
         { status: 401 },
       )
     }
+
+    const member = mockUsers.find((user) => user.id === match.userId)
+    if (member?.status === 'INACTIVE') {
+      return HttpResponse.json(
+        { code: 'MEMBER_INACTIVE', message: '비활성화된 계정입니다', data: null },
+        { status: 403 },
+      )
+    }
+
     return HttpResponse.json({
       code: 'SUCCESS',
       message: 'ok',


### PR DESCRIPTION
## 릴리즈 내용
- 비활성 계정 로그인 시 전용 안내 문구가 보이도록 인증 에러 처리를 보강했습니다.
- 채팅 헤더, 근무 일정 저장 버튼, 멤버 표에서 발생하던 CSS 충돌을 정리했습니다.
- 채팅을 대상 또는 방을 먼저 고른 뒤 입장하는 구조로 개선하고 모바일에서 목록/대화방 전환을 분리했습니다.

## 포함된 develop PR
- #167

## 검증
- npm run test:run -- src/features/chat/model/__tests__/ChatProvider.test.tsx src/features/auth/api/__tests__/authClient.test.ts src/pages/login/__tests__/Login.test.tsx src/features/attendance/ui/__tests__/SetWorkDaysPersonal.test.tsx src/shared/api/__tests__/baseClient.test.ts
- npm run build