### PR TITLE
release: v0.1.8

### DIFF
--- a/src/features/attendance/ui/SetWorkDaysPersonal.tsx
+++ b/src/features/attendance/ui/SetWorkDaysPersonal.tsx
@@ -3,7 +3,7 @@ import { useWorkSchedule } from '../model/useWorkSchedule'
 import type { WeekPattern } from '../model/useWorkSchedule'
 import './SetWorkDaysPersonal.css'
 
-const DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+const DAY_NAMES = ['월', '화', '수', '목', '금', '토', '일']
 const WEEK_PATTERN_OPTIONS: { value: WeekPattern; label: string }[] = [
   { value: 'EVERY', label: '매주' },
   { value: 'FIRST', label: '1주차' },

--- a/src/features/attendance/ui/__tests__/SetWorkDaysPersonal.test.tsx
+++ b/src/features/attendance/ui/__tests__/SetWorkDaysPersonal.test.tsx
@@ -53,8 +53,8 @@ describe('SetWorkDaysPersonal', () => {
   it('7개의 요일 이름이 렌더링된다', async () => {
     render(<SetWorkDaysPersonal />, { wrapper })
     await waitFor(() => {
-      expect(screen.getByText('Mon')).toBeInTheDocument()
-      expect(screen.getByText('Sun')).toBeInTheDocument()
+      expect(screen.getByText('월')).toBeInTheDocument()
+      expect(screen.getByText('일')).toBeInTheDocument()
     })
   })
 

--- a/src/pages/attendance/__tests__/Attendance.test.tsx
+++ b/src/pages/attendance/__tests__/Attendance.test.tsx
@@ -37,13 +37,13 @@ describe('Attendance 페이지', () => {
 
   it('관리자에게 Export CSV 버튼이 표시된다', () => {
     render(<Attendance />)
-    expect(screen.getByText('Export CSV')).toBeInTheDocument()
+    expect(screen.getByText('CSV 내보내기')).toBeInTheDocument()
   })
 
   it('필터 탭이 렌더링된다', () => {
     render(<Attendance />)
-    expect(screen.getByText('This Week')).toBeInTheDocument()
-    expect(screen.getByText('This Month')).toBeInTheDocument()
+    expect(screen.getByText('이번 주')).toBeInTheDocument()
+    expect(screen.getByText('이번 달')).toBeInTheDocument()
   })
 
   it('관리자에게 팀 근무 일정 패널이 표시된다', () => {
@@ -66,7 +66,7 @@ describe('Attendance 페이지', () => {
     })
   })
 
-  it('Attendance Records의 Scheduled Days에 멤버 근무 일정이 반영된다', async () => {
+  it('출퇴근 기록의 근무 요일에 멤버 근무 일정이 반영된다', async () => {
     server.use(
       http.get('/api/v1/attendances', () =>
         HttpResponse.json({

--- a/src/pages/attendance/attendance.css
+++ b/src/pages/attendance/attendance.css
@@ -86,23 +86,29 @@
 .team-status-section {
   padding: 20px 24px;
   border-radius: 14px;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .team-schedule-section {
   padding: 20px 24px;
   border-radius: 14px;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .attendance-content {
   display: flex;
   flex-direction: column;
   gap: 24px;
+  min-width: 0;
 }
 
 .two-cards-row {
   display: grid;
   grid-template-columns: 1fr 1.5fr;
   gap: 24px;
+  min-width: 0;
 }
 
 .two-cards-row.single {
@@ -113,12 +119,21 @@
   grid-template-columns: 1fr;
 }
 
+.two-cards-row > * {
+  min-width: 0;
+  width: 100%;
+}
+
 .set-work-days-section {
   padding: 24px;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .records-section {
   padding: 24px;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .records-section h3 {
@@ -128,6 +143,8 @@
 
 .records-table-wrap {
   overflow-x: auto;
+  max-width: 100%;
+  width: 100%;
   padding-bottom: 6px;
   scrollbar-width: thin;
 }
@@ -136,6 +153,14 @@
   width: 100%;
   border-collapse: collapse;
   min-width: 720px;
+}
+
+.set-work-days-section .set-work-days-personal {
+  min-width: 0;
+}
+
+.set-work-days-section .day-schedule-grid {
+  max-width: 100%;
 }
 
 .records-table th,
@@ -211,6 +236,7 @@
   margin-top: 16px;
   font-size: 0.875rem;
   color: var(--text-secondary);
+  min-width: 0;
 }
 
 .pagination button {
@@ -222,6 +248,7 @@
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 20px;
+  min-width: 0;
 }
 
 .stat-card {

--- a/src/pages/attendance/index.tsx
+++ b/src/pages/attendance/index.tsx
@@ -18,13 +18,13 @@ import { getTeams } from '../../shared/api/teamsApi'
 import './attendance.css'
 
 const DAY_LABELS: Record<string, string> = {
-  MONDAY: 'Mon',
-  TUESDAY: 'Tue',
-  WEDNESDAY: 'Wed',
-  THURSDAY: 'Thu',
-  FRIDAY: 'Fri',
-  SATURDAY: 'Sat',
-  SUNDAY: 'Sun',
+  MONDAY: '월',
+  TUESDAY: '화',
+  WEDNESDAY: '수',
+  THURSDAY: '목',
+  FRIDAY: '금',
+  SATURDAY: '토',
+  SUNDAY: '일',
 }
 
 const ORDERED_WORK_DAYS = [
@@ -145,19 +145,19 @@ export function Attendance() {
           {isAdmin && (
             <button className="export-btn glass" onClick={handleExport}>
               <Download size={18} />
-              Export CSV
+              CSV 내보내기
             </button>
           )}
           <div className="date-range glass">{todayStr}</div>
           <div className="filter-tabs">
             <button className={filter === 'week' ? 'active' : ''} onClick={() => setFilter('week')}>
-              This Week
+              이번 주
             </button>
             <button className={filter === 'month' ? 'active' : ''} onClick={() => setFilter('month')}>
-              This Month
+              이번 달
             </button>
             <button className={filter === 'custom' ? 'active' : ''} onClick={() => setFilter('custom')}>
-              Custom
+              직접 선택
             </button>
           </div>
           {filter === 'custom' && (
@@ -196,17 +196,17 @@ export function Attendance() {
           </section>
           {isAdmin && (
             <section className="records-section glass">
-              <h3>Attendance Records</h3>
+              <h3>출퇴근 기록</h3>
               <div className="records-table-wrap">
                 <table className="records-table">
                   <thead>
                     <tr>
-                      <th>Member ↕</th>
-                      <th>Scheduled Days</th>
-                      <th>Check-in</th>
-                      <th>Check-out</th>
-                      <th>Date</th>
-                      <th>Status</th>
+                      <th>멤버 ↕</th>
+                      <th>근무 요일</th>
+                      <th>출근</th>
+                      <th>퇴근</th>
+                      <th>날짜</th>
+                      <th>상태</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -247,7 +247,7 @@ export function Attendance() {
               </div>
               <div className="pagination">
                 <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}><ChevronLeft size={18} /></button>
-                <span>Page {page} of {totalPages}</span>
+                <span>{page} / {totalPages} 페이지</span>
                 <button disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}><ChevronRight size={18} /></button>
               </div>
             </section>

--- a/src/pages/chat/chat.css
+++ b/src/pages/chat/chat.css
@@ -1,7 +1,8 @@
 .chat-page {
   display: flex;
-  min-height: 100%;
-  height: 100%;
+  min-height: 0;
+  height: clamp(620px, calc(100dvh - 180px), 860px);
+  max-height: calc(100dvh - 180px);
   gap: 0;
   border-radius: 28px;
   border: 1px solid var(--border-color);
@@ -10,9 +11,14 @@
   overflow: hidden;
 }
 
+.chat-page > * {
+  min-width: 0;
+}
+
 .chat-sidebar {
   width: 280px;
   flex-shrink: 0;
+  min-height: 0;
   overflow-y: auto;
   padding: 20px;
   background: var(--bg-elevated);
@@ -49,6 +55,7 @@
 
 .search-wrap input {
   flex: 1;
+  min-width: 0;
   background: none;
   border: none;
   color: var(--text-primary);
@@ -72,6 +79,7 @@
 }
 
 .channel-item {
+  min-width: 0;
   padding: 12px;
   border-radius: 14px;
   cursor: pointer;
@@ -92,6 +100,9 @@
 .channel-name {
   display: block;
   font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .channel-last {
@@ -99,12 +110,16 @@
   font-size: 0.8rem;
   color: var(--text-secondary);
   margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .dm-item {
   display: flex;
   align-items: center;
   gap: 10px;
+  min-width: 0;
   padding: 10px 12px;
   border-radius: 14px;
   cursor: pointer;
@@ -134,6 +149,9 @@
 
 .dm-name {
   font-size: 0.9rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .dm-copy {
@@ -152,6 +170,7 @@
 .dm-status {
   font-size: 0.75rem;
   color: var(--text-secondary);
+  flex-shrink: 0;
 }
 
 .dm-status.online {
@@ -164,6 +183,7 @@
   flex-direction: column;
   min-width: 0;
   min-height: 0;
+  height: 100%;
   background: rgba(16, 20, 36, 0.45);
 }
 
@@ -172,6 +192,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
   background: rgba(255, 255, 255, 0.02);
   border-bottom: 1px solid var(--border-color);
   box-shadow: none;
@@ -180,12 +202,21 @@
 .chat-header h3 {
   font-size: 1.1rem;
   margin: 0 0 2px 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .chat-room-meta {
   display: flex;
   align-items: center;
   gap: 12px;
+  min-width: 0;
+  flex: 1;
+}
+
+.chat-room-meta > div {
+  min-width: 0;
 }
 
 .chat-back-btn {
@@ -203,11 +234,16 @@
 .members-count {
   font-size: 0.85rem;
   color: var(--text-secondary);
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .chat-header-actions {
   display: flex;
   gap: 8px;
+  flex-shrink: 0;
 }
 
 .chat-header-actions button {
@@ -412,6 +448,7 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+  flex-shrink: 0;
   background: rgba(15, 18, 32, 0.72);
   border-top: 1px solid var(--border-color);
   box-shadow: none;
@@ -621,6 +658,7 @@
     display: block;
     min-height: calc(100vh - 164px);
     height: auto;
+    max-height: none;
     border-radius: 20px;
   }
 

--- a/src/pages/chat/index.tsx
+++ b/src/pages/chat/index.tsx
@@ -8,6 +8,17 @@ import { getMembers } from '../../shared/api/membersApi'
 import './chat.css'
 
 const EMOJIS = ['😊', '👍', '❤️', '😂', '😢', '😍', '🔥', '✨', '🎉', '🙏', '👋', '💯', '✅', '❌', '⭐', '💪']
+const CHANNEL_LABELS: Record<string, string> = {
+  General: '전체 공지',
+  'Design Team': '디자인팀',
+  'Dev Team': '개발팀',
+}
+const TEAM_LABELS: Record<string, string> = {
+  BACKEND: '백엔드',
+  FRONTEND: '프론트엔드',
+  AI: 'AI',
+  SECURITY: '보안',
+}
 
 function formatTime(date: Date): string {
   const now = new Date()
@@ -253,42 +264,42 @@ export function Chat() {
 
   const roomTitle = isDirectRoom
     ? activeDirectUser?.name ?? '대화방'
-    : `# ${activeChannel?.name || 'Design Team'}`
+    : `# ${CHANNEL_LABELS[activeChannel?.name ?? ''] ?? activeChannel?.name ?? '디자인팀'}`
 
   const roomMeta = isDirectRoom
-    ? `${activeDirectUser?.team ?? '알 수 없는 팀'} · ${activeDirectUser?.online ? '대화 가능' : '현재 자리 비움'}`
-    : '23 members'
+    ? `${TEAM_LABELS[activeDirectUser?.team ?? ''] ?? activeDirectUser?.team ?? '알 수 없는 팀'} · ${activeDirectUser?.online ? '대화 가능' : '현재 자리 비움'}`
+    : '23명 참여 중'
 
   return (
     <div className={`chat-page ${isMobileRoomOpen ? 'room-open-mobile' : 'list-open-mobile'}`}>
       <aside className="chat-sidebar glass">
         <div className="chat-list-head">
-          <h2>Messages</h2>
+          <h2>대화 목록</h2>
           <p>대화할 채널이나 대상을 먼저 선택한 뒤 대화방으로 들어갑니다.</p>
         </div>
         <div className="search-wrap">
           <Search size={18} />
           <input
-            placeholder="채널 또는 대상을 검색하세요."
+            placeholder="채널이나 대상을 검색하세요."
             value={roomQuery}
             onChange={(e) => setRoomQuery(e.target.value)}
           />
         </div>
         <section>
-          <h4>CHANNELS</h4>
+          <h4>채널</h4>
           {filteredChannels.map((ch) => (
             <div
               key={ch.id}
               className={`channel-item ${ch.id === activeChannelId ? 'active' : ''}`}
               onClick={() => openRoom(ch.id)}
             >
-              <span className="channel-name"># {ch.name}</span>
+              <span className="channel-name"># {CHANNEL_LABELS[ch.name] ?? ch.name}</span>
               <span className="channel-last">{ch.lastMessage}</span>
             </div>
           ))}
         </section>
         <section>
-          <h4>DIRECT MESSAGES</h4>
+          <h4>개인 대화</h4>
           {filteredDirectRooms.map((u) => (
             <div
               key={u.id}
@@ -298,10 +309,10 @@ export function Chat() {
               <span className="dm-avatar">{u.name[0]}</span>
               <div className="dm-copy">
                 <span className="dm-name">{u.name}</span>
-                <span className="dm-room-hint">{u.team}</span>
+                <span className="dm-room-hint">{TEAM_LABELS[u.team] ?? u.team}</span>
               </div>
               <span className={`dm-status ${u.online ? 'online' : 'offline'}`}>
-                • {u.online ? 'online' : 'away'}
+                • {u.online ? '온라인' : '자리 비움'}
               </span>
             </div>
           ))}
@@ -381,7 +392,7 @@ export function Chat() {
             />
             <button className="send-btn" onClick={handleSend}>
               <Send size={18} />
-              Send
+              보내기
             </button>
           </div>
           <div className="format-toolbar">


### PR DESCRIPTION
## 릴리즈 내용
- 출퇴근 페이지의 근무 일정 설정과 출퇴근 기록 카드가 부모 폭 안에서 줄어들고 내부에서만 가로 스크롤되도록 정리했습니다.
- 블록끼리 겹치지 않도록 출퇴근/채팅 레이아웃에 min-width와 내부 스크롤 기준을 보강했습니다.
- 채팅과 출퇴근 화면에 남아 있던 주요 영문 텍스트를 한글로 정리했습니다.

## 포함된 develop PR
- #170

## 테스트
- npm run test:run -- src/pages/attendance/__tests__/Attendance.test.tsx src/features/attendance/ui/__tests__/SetWorkDaysPersonal.test.tsx src/shared/api/__tests__/chatApi.test.ts
- npm run build