### PR TITLE
release: v0.1.9

### DIFF
--- a/src/features/attendance/ui/SetWorkDaysPersonal.css
+++ b/src/features/attendance/ui/SetWorkDaysPersonal.css
@@ -219,7 +219,7 @@
   color: var(--text-primary);
   font-size: 0.88rem;
   width: 100%;
-  color-scheme: dark;
+  color-scheme: dark light;
   transition: border-color 0.2s ease, background 0.2s ease;
 }
 
@@ -257,6 +257,10 @@
   font-size: 0.78rem;
   font-weight: 600;
   color: var(--text-secondary);
+}
+
+:root[data-theme='light'] .time-field input {
+  color-scheme: light;
 }
 
 .week-pattern-options {

--- a/src/features/attendance/ui/TeamAttendanceStatus.css
+++ b/src/features/attendance/ui/TeamAttendanceStatus.css
@@ -163,3 +163,11 @@
   font-size: 0.85rem;
   padding: 32px 0;
 }
+
+:root[data-theme='light'] .summary-item.left {
+  background: rgba(84, 102, 146, 0.1);
+}
+
+:root[data-theme='light'] .attend-member-card {
+  background: rgba(84, 102, 146, 0.04);
+}

--- a/src/features/attendance/ui/TeamAttendanceStatus.tsx
+++ b/src/features/attendance/ui/TeamAttendanceStatus.tsx
@@ -30,10 +30,10 @@ const STATUS_LABEL: Record<AttendStatus, string> = {
 }
 
 const TEAM_LABEL: Record<string, string> = {
-  BACKEND: 'Backend',
-  FRONTEND: 'Frontend',
+  BACKEND: '백엔드',
+  FRONTEND: '프론트엔드',
   AI: 'AI',
-  SECURITY: 'Security',
+  SECURITY: '보안',
 }
 
 const FILTER_TABS: { value: AttendStatus; label: string }[] = [

--- a/src/features/calendar/ui/EventDetailModal.tsx
+++ b/src/features/calendar/ui/EventDetailModal.tsx
@@ -72,7 +72,7 @@ export function EventDetailModal({
             <div className="event-detail-creator">
               작성자: {event.createdBy}
             </div>
-            <div className="edit-task-actions add-task-modal-actions">
+            <div className="edit-task-actions add-task-modal-actions event-detail-actions">
               {canEdit && <button className="cancel-btn" onClick={onEnterEditMode}>수정</button>}
               {canEdit && <button className="cancel-btn delete-btn" onClick={onDelete}>삭제</button>}
               <button className="add-btn" onClick={onClose}>닫기</button>

--- a/src/index.css
+++ b/src/index.css
@@ -46,30 +46,32 @@
 }
 
 :root[data-theme='light'] {
-  --bg-app: #f4f7fb;
-  --bg-app-rgb: 244, 247, 251;
-  --bg-card: rgba(255, 255, 255, 0.8);
+  --accent-purple-light: #6b4fc4;
+  --accent-purple-dark: #5d44b0;
+  --bg-app: #eef3fb;
+  --bg-app-rgb: 238, 243, 251;
+  --bg-card: rgba(255, 255, 255, 0.92);
   --bg-card-solid: #ffffff;
-  --bg-elevated: rgba(255, 255, 255, 0.92);
-  --bg-soft: rgba(101, 117, 160, 0.08);
-  --bg-soft-strong: rgba(101, 117, 160, 0.14);
-  --bg-input: rgba(246, 248, 252, 0.96);
-  --bg-sidebar: rgba(251, 252, 255, 0.86);
-  --bg-sidebar-solid: #fbfcff;
-  --bg-overlay: rgba(116, 135, 171, 0.16);
-  --surface-tint: rgba(138, 114, 216, 0.1);
-  --surface-tint-strong: rgba(138, 114, 216, 0.16);
-  --border-color: rgba(104, 124, 166, 0.18);
-  --border-strong: rgba(104, 124, 166, 0.28);
-  --text-primary: #1f2840;
-  --text-secondary: #5d6b89;
-  --text-muted: #8893ab;
+  --bg-elevated: rgba(255, 255, 255, 0.98);
+  --bg-soft: rgba(77, 92, 132, 0.1);
+  --bg-soft-strong: rgba(77, 92, 132, 0.18);
+  --bg-input: rgba(244, 247, 253, 0.98);
+  --bg-sidebar: rgba(248, 251, 255, 0.94);
+  --bg-sidebar-solid: #f8fbff;
+  --bg-overlay: rgba(73, 88, 126, 0.18);
+  --surface-tint: rgba(107, 79, 196, 0.1);
+  --surface-tint-strong: rgba(107, 79, 196, 0.16);
+  --border-color: rgba(84, 102, 146, 0.22);
+  --border-strong: rgba(84, 102, 146, 0.34);
+  --text-primary: #19243d;
+  --text-secondary: #4f5f7f;
+  --text-muted: #6f7d99;
   --text-on-accent: #ffffff;
-  --shadow-soft: 0 18px 40px rgba(126, 140, 176, 0.18);
-  --shadow-strong: 0 24px 64px rgba(116, 132, 167, 0.22);
-  --ring-color: rgba(138, 114, 216, 0.18);
-  --nav-hover: rgba(138, 114, 216, 0.08);
-  --nav-active: rgba(138, 114, 216, 0.14);
+  --shadow-soft: 0 18px 40px rgba(97, 114, 150, 0.16);
+  --shadow-strong: 0 24px 64px rgba(97, 114, 150, 0.24);
+  --ring-color: rgba(107, 79, 196, 0.2);
+  --nav-hover: rgba(107, 79, 196, 0.1);
+  --nav-active: rgba(107, 79, 196, 0.16);
 }
 
 * {
@@ -98,6 +100,19 @@ body::before {
     linear-gradient(135deg, rgba(114, 184, 232, 0.04), transparent 32%, rgba(212, 74, 153, 0.05) 100%);
   pointer-events: none;
   z-index: 0;
+}
+
+:root[data-theme='light'] body {
+  background:
+    radial-gradient(circle at top left, rgba(114, 184, 232, 0.22), transparent 26%),
+    radial-gradient(circle at top right, rgba(212, 74, 153, 0.14), transparent 22%),
+    linear-gradient(180deg, rgba(var(--bg-app-rgb), 0.98) 0%, rgba(var(--bg-app-rgb), 1) 100%);
+}
+
+:root[data-theme='light'] body::before {
+  background:
+    radial-gradient(ellipse 68% 42% at 50% -10%, rgba(107, 79, 196, 0.1), transparent),
+    linear-gradient(135deg, rgba(114, 184, 232, 0.06), transparent 34%, rgba(212, 74, 153, 0.05) 100%);
 }
 
 #root {
@@ -169,6 +184,11 @@ a svg,
   border: 1px solid var(--border-color);
   border-radius: 20px;
   box-shadow: var(--shadow-soft);
+}
+
+:root[data-theme='light'] .glass,
+:root[data-theme='light'] .surface-card {
+  box-shadow: 0 16px 36px rgba(97, 114, 150, 0.12);
 }
 
 .section-heading {

--- a/src/pages/admin/__tests__/Admin.test.tsx
+++ b/src/pages/admin/__tests__/Admin.test.tsx
@@ -57,7 +57,7 @@ function renderAdmin() {
 describe('Admin 페이지', () => {
   it('페이지 제목이 렌더링된다', () => {
     renderAdmin()
-    expect(screen.getByText('관리자 대시보드')).toBeInTheDocument()
+    expect(screen.getByText('출근 현황과 멤버 상태를 한 곳에서 관리합니다.')).toBeInTheDocument()
   })
 
   it('출근 현황 탭이 기본으로 활성화된다', () => {

--- a/src/pages/admin/admin.css
+++ b/src/pages/admin/admin.css
@@ -17,14 +17,16 @@
 
 .admin-title-row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 10px;
+  min-width: 0;
 }
 
-.admin-title-row h1 {
-  font-size: 1.6rem;
-  font-weight: 700;
-  color: var(--text-primary);
+.admin-title-row p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  max-width: 520px;
 }
 
 .admin-crown-icon {
@@ -124,8 +126,6 @@
   font-size: 0.78rem;
   font-weight: 600;
   color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
   padding: 10px 14px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
@@ -144,6 +144,18 @@
 
 .admin-members-table tr:hover td {
   background: rgba(255, 255, 255, 0.02);
+}
+
+:root[data-theme='light'] .admin-members-table th {
+  border-bottom-color: rgba(84, 102, 146, 0.14);
+}
+
+:root[data-theme='light'] .admin-members-table td {
+  border-bottom-color: rgba(84, 102, 146, 0.1);
+}
+
+:root[data-theme='light'] .admin-members-table tr:hover td {
+  background: rgba(84, 102, 146, 0.05);
 }
 
 .admin-avatar {
@@ -283,8 +295,8 @@
 }
 
 .admin-modal {
-  background: #1a1a2e;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: var(--bg-card-solid);
+  border: 1px solid var(--border-color);
   border-radius: 16px;
   padding: 28px;
   width: 360px;
@@ -439,10 +451,6 @@
 }
 
 @media (max-width: 480px) {
-  .admin-title-row h1 {
-    font-size: 1.35rem;
-  }
-
   .admin-tab-content {
     padding: 16px;
     border-radius: 20px;

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -15,15 +15,15 @@ type Tab = 'attendance' | 'members'
 
 const ALL_ROLES: UserRole[] = ['MEMBER', 'TEAM_LEAD', 'ADMIN']
 const roleLabels: Record<string, string> = {
-  ADMIN: 'Admin',
-  TEAM_LEAD: 'Team Lead',
-  MEMBER: 'Member',
+  ADMIN: '관리자',
+  TEAM_LEAD: '팀장',
+  MEMBER: '멤버',
 }
 const teamLabels: Record<string, string> = {
-  BACKEND: 'Backend',
-  FRONTEND: 'Frontend',
+  BACKEND: '백엔드',
+  FRONTEND: '프론트엔드',
   AI: 'AI',
-  SECURITY: 'Security',
+  SECURITY: '보안',
 }
 
 const statusLabels: Record<string, string> = {
@@ -146,7 +146,7 @@ export function Admin() {
       <header className="admin-header">
         <div className="admin-title-row">
           <Crown size={22} className="admin-crown-icon" />
-          <h1>관리자 대시보드</h1>
+          <p>출근 현황과 멤버 상태를 한 곳에서 관리합니다.</p>
         </div>
         <div className="admin-header-actions">
           {tab === 'attendance' && (

--- a/src/pages/ai-chat/ai-chat.css
+++ b/src/pages/ai-chat/ai-chat.css
@@ -19,15 +19,12 @@
   gap: 12px;
 }
 
-.ai-title h1 {
-  font-size: 1.5rem;
+.ai-title p {
+  font-size: 1rem;
   margin: 0;
-}
-
-.ai-desc {
   color: var(--text-secondary);
-  font-size: 0.9rem;
-  margin-top: 8px;
+  line-height: 1.6;
+  max-width: 420px;
 }
 
 .ai-chat-area {
@@ -164,8 +161,8 @@
     justify-content: flex-start;
   }
 
-  .ai-title h1 {
-    font-size: 1.25rem;
+  .ai-title p {
+    font-size: 0.92rem;
   }
 
   .ai-header {

--- a/src/pages/ai-chat/index.tsx
+++ b/src/pages/ai-chat/index.tsx
@@ -44,9 +44,8 @@ export function AIChat() {
       <header className="ai-header">
         <div className="ai-title">
           <Bot size={24} />
-          <h1>yANUs AI</h1>
+          <p>공유 문서를 바탕으로 답변하는 팀 어시스턴트입니다.</p>
         </div>
-        <p className="ai-desc">파일 드라이브 기반 AI 어시스턴트</p>
       </header>
 
       <div className="ai-chat-area glass">

--- a/src/pages/attendance/__tests__/Attendance.test.tsx
+++ b/src/pages/attendance/__tests__/Attendance.test.tsx
@@ -32,7 +32,7 @@ vi.mock('../../../features/leave/ui/LeaveSection', () => ({
 describe('Attendance 페이지', () => {
   it('출퇴근 헤더가 렌더링된다', () => {
     render(<Attendance />)
-    expect(screen.getByText('출퇴근')).toBeInTheDocument()
+    expect(screen.getByText('오늘 근무 현황과 개인 근무 일정을 한 화면에서 관리합니다.')).toBeInTheDocument()
   })
 
   it('관리자에게 Export CSV 버튼이 표시된다', () => {

--- a/src/pages/attendance/attendance.css
+++ b/src/pages/attendance/attendance.css
@@ -12,10 +12,16 @@
   margin-bottom: 24px;
 }
 
-.attendance-header h1 {
-  font-size: 1.75rem;
-  font-weight: 700;
+.attendance-header-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.attendance-header-copy p {
   margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  max-width: 560px;
 }
 
 .header-actions {
@@ -306,10 +312,6 @@
     margin-bottom: 20px;
   }
 
-  .attendance-header h1 {
-    font-size: 1.55rem;
-  }
-
   .header-actions {
     width: 100%;
     align-items: stretch;
@@ -360,8 +362,8 @@
 }
 
 @media (max-width: 560px) {
-  .attendance-header h1 {
-    font-size: 1.4rem;
+  .attendance-header-copy p {
+    font-size: 0.92rem;
   }
 
   .team-status-section,

--- a/src/pages/attendance/index.tsx
+++ b/src/pages/attendance/index.tsx
@@ -140,7 +140,9 @@ export function Attendance() {
         <Toast message={errorMessage} type="error" onClose={() => setErrorMessage(null)} />
       )}
       <header className="attendance-header">
-        <h1>출퇴근</h1>
+        <div className="attendance-header-copy">
+          <p>오늘 근무 현황과 개인 근무 일정을 한 화면에서 관리합니다.</p>
+        </div>
         <div className="header-actions">
           {isAdmin && (
             <button className="export-btn glass" onClick={handleExport}>

--- a/src/pages/calendar/calendar.css
+++ b/src/pages/calendar/calendar.css
@@ -315,15 +315,18 @@
 }
 
 .edit-task-modal {
-  background: rgba(30, 28, 40, 0.98);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: var(--bg-card-solid);
+  border: 1px solid var(--border-color);
   border-radius: 12px;
   padding: 20px;
-  min-width: 320px;
+  width: min(480px, calc(100vw - 32px));
+  max-width: calc(100vw - 32px);
+  min-width: 0;
+  box-shadow: var(--shadow-strong);
 }
 
 .add-task-modal {
-  min-width: 360px;
+  width: min(520px, calc(100vw - 32px));
 }
 
 .add-task-modal .add-task-inline {
@@ -333,7 +336,7 @@
 .add-task-modal-actions {
   margin-top: 16px;
   padding-top: 16px;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-top: 1px solid var(--border-color);
 }
 
 /* Context menu modal (할일/일정 선택) */
@@ -442,6 +445,12 @@
   display: flex;
   gap: 10px;
   justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.edit-task-actions button {
+  min-width: 88px;
+  white-space: nowrap;
 }
 
 .edit-task-actions .cancel-btn {
@@ -773,6 +782,9 @@
 
 .event-detail-view {
   padding: 12px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .event-detail-title {
@@ -828,7 +840,18 @@
   color: var(--text-secondary);
   margin-top: 8px;
   padding-top: 8px;
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--border-color);
+}
+
+.event-detail-actions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(92px, 1fr));
+  justify-content: stretch;
+}
+
+.event-detail-actions .cancel-btn,
+.event-detail-actions .add-btn {
+  width: 100%;
 }
 
 .add-task-modal-actions .delete-btn {
@@ -921,5 +944,9 @@
 
   .tasks-tabs::-webkit-scrollbar {
     display: none;
+  }
+
+  .event-detail-actions {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/pages/members/__tests__/Members.test.tsx
+++ b/src/pages/members/__tests__/Members.test.tsx
@@ -26,9 +26,9 @@ vi.mock('../../../features/auth/model', () => ({
 }))
 
 describe('Members 페이지', () => {
-  it('Member Management 제목이 렌더링된다', () => {
+  it('멤버 관리 안내 문구가 렌더링된다', () => {
     render(<Members />)
-    expect(screen.getByText('Member Management')).toBeInTheDocument()
+    expect(screen.getByText('멤버 상태와 역할을 한 곳에서 확인하고 관리합니다.')).toBeInTheDocument()
   })
 
   it('관리자에게 멤버 초대 버튼이 표시된다', () => {
@@ -44,8 +44,8 @@ describe('Members 페이지', () => {
     })
   })
 
-  it('관리자에게 Actions 컬럼이 표시된다', () => {
+  it('관리자에게 관리 컬럼이 표시된다', () => {
     render(<Members />)
-    expect(screen.getByText('Actions')).toBeInTheDocument()
+    expect(screen.getByText('관리')).toBeInTheDocument()
   })
 })

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -6,20 +6,20 @@ import type { UserRole } from '../../entities/user/model/types'
 import { Toast } from '../../shared/ui/Toast'
 import './members.css'
 
-const teams = ['All Teams', 'BACKEND', 'FRONTEND', 'AI', 'SECURITY']
-const roles = ['All Roles', 'ADMIN', 'TEAM_LEAD', 'MEMBER']
+const teams = ['전체 팀', 'BACKEND', 'FRONTEND', 'AI', 'SECURITY']
+const roles = ['전체 역할', 'ADMIN', 'TEAM_LEAD', 'MEMBER']
 
 const roleLabels: Record<string, string> = {
-  ADMIN: 'Admin',
-  TEAM_LEAD: 'Team Lead',
-  MEMBER: 'Member',
+  ADMIN: '관리자',
+  TEAM_LEAD: '팀장',
+  MEMBER: '멤버',
 }
 
 const teamLabels: Record<string, string> = {
-  BACKEND: 'Backend',
-  FRONTEND: 'Frontend',
+  BACKEND: '백엔드',
+  FRONTEND: '프론트엔드',
   AI: 'AI',
-  SECURITY: 'Security',
+  SECURITY: '보안',
 }
 
 const statusLabels: Record<string, string> = {
@@ -32,8 +32,8 @@ const ALL_ROLES: UserRole[] = ['MEMBER', 'TEAM_LEAD', 'ADMIN']
 export function Members() {
   const { state, isAdmin, loadMembers } = useApp()
   const [search, setSearch] = useState('')
-  const [teamFilter, setTeamFilter] = useState('All Teams')
-  const [roleFilter, setRoleFilter] = useState('All Roles')
+  const [teamFilter, setTeamFilter] = useState('전체 팀')
+  const [roleFilter, setRoleFilter] = useState('전체 역할')
   const [changeRoleFor, setChangeRoleFor] = useState<{ id: string; name: string } | null>(null)
   const [selectedRole, setSelectedRole] = useState<UserRole>('MEMBER')
   const [showInvite, setShowInvite] = useState(false)
@@ -48,8 +48,8 @@ export function Members() {
 
   const filtered = state.users.filter((u) => {
     const matchSearch = !search || u.name.toLowerCase().includes(search.toLowerCase())
-    const matchTeam = teamFilter === 'All Teams' || u.team === teamFilter
-    const matchRole = roleFilter === 'All Roles' || u.role === roleFilter
+    const matchTeam = teamFilter === '전체 팀' || u.team === teamFilter
+    const matchRole = roleFilter === '전체 역할' || u.role === roleFilter
     return matchSearch && matchTeam && matchRole
   })
 
@@ -132,10 +132,10 @@ export function Members() {
         <Toast message={errorMessage} type="error" onClose={() => setErrorMessage(null)} />
       )}
       <header className="members-header">
-        <h1>
-          {isAdmin ? 'Member Management' : '멤버 목록'}
-          {isAdmin && <span className="admin-badge">! Admin Only</span>}
-        </h1>
+        <div className="members-header-copy">
+          <p>멤버 상태와 역할을 한 곳에서 확인하고 관리합니다.</p>
+          {isAdmin && <span className="admin-badge">관리자 전용</span>}
+        </div>
         {isAdmin && (
           <button className="invite-btn glass" onClick={() => setShowInvite(true)}>
             <UserPlus size={16} />
@@ -147,38 +147,42 @@ export function Members() {
       <div className="filters-row">
         <div className="search-wrap glass">
           <Search size={18} />
-          <input placeholder="Search Members..." value={search} onChange={(e) => setSearch(e.target.value)} />
+          <input placeholder="멤버 이름 검색" value={search} onChange={(e) => setSearch(e.target.value)} />
         </div>
         <div className="filter-group">
-          <span className="filter-label">Team</span>
+          <span className="filter-label">팀</span>
           <div className="filter-btns">
             {teams.map((t) => (
-              <button key={t} className={teamFilter === t ? 'active' : ''} onClick={() => setTeamFilter(t)}>{t}</button>
+              <button key={t} className={teamFilter === t ? 'active' : ''} onClick={() => setTeamFilter(t)}>
+                {teamLabels[t] ?? t}
+              </button>
             ))}
           </div>
         </div>
         <div className="filter-group">
-          <span className="filter-label">Role</span>
+          <span className="filter-label">역할</span>
           <div className="filter-btns">
             {roles.map((r) => (
-              <button key={r} className={roleFilter === r ? 'active' : ''} onClick={() => setRoleFilter(r)}>{r}</button>
+              <button key={r} className={roleFilter === r ? 'active' : ''} onClick={() => setRoleFilter(r)}>
+                {roleLabels[r] ?? r}
+              </button>
             ))}
           </div>
         </div>
-        <div className="total-members glass">Total Members: {state.users.length}</div>
+        <div className="total-members glass">전체 멤버 {state.users.length}명</div>
       </div>
 
       <div className="members-content">
         <div className="table-section glass">
-          <h3>Member List Table.</h3>
+          <h3>멤버 목록</h3>
           <table className="members-table">
             <thead>
               <tr>
-                <th>Profile</th>
-                <th>Current Team</th>
-                <th>Role</th>
+                <th>프로필</th>
+                <th>팀</th>
+                <th>역할</th>
                 {isAdmin && <th>상태</th>}
-                {isAdmin && <th>Actions</th>}
+                {isAdmin && <th>관리</th>}
               </tr>
             </thead>
             <tbody>
@@ -213,7 +217,7 @@ export function Members() {
                   {isAdmin && (
                     <td className="actions-cell">
                       <button className="action-btn" onClick={() => handleOpenChangeRole(u.id, u.name, u.role)}>
-                        Change Role <ChevronDown size={14} />
+                        역할 변경 <ChevronDown size={14} />
                       </button>
                       <button
                         className="action-btn deactivate-btn"
@@ -231,7 +235,7 @@ export function Members() {
         </div>
 
         <aside className="stats-sidebar glass">
-          <h3>Members per Team</h3>
+          <h3>팀별 멤버 수</h3>
           <div className="bar-chart">
             {Object.entries(teamLabels).map(([key, label]) => {
               const count = state.users.filter((u) => u.team === key).length
@@ -243,11 +247,11 @@ export function Members() {
               )
             })}
           </div>
-          <h3>Role Distribution</h3>
+          <h3>역할 분포</h3>
           <div className="pie-legend">
-            <span><i style={{ background: 'var(--accent-purple)' }} /> Admin {state.users.filter((u) => u.role === 'ADMIN').length}</span>
-            <span><i style={{ background: 'var(--accent-blue, #72b8e8)' }} /> Team Lead {state.users.filter((u) => u.role === 'TEAM_LEAD').length}</span>
-            <span><i style={{ background: 'var(--text-secondary)' }} /> Member {state.users.filter((u) => u.role === 'MEMBER').length}</span>
+            <span><i style={{ background: 'var(--accent-purple)' }} /> 관리자 {state.users.filter((u) => u.role === 'ADMIN').length}</span>
+            <span><i style={{ background: 'var(--accent-blue, #72b8e8)' }} /> 팀장 {state.users.filter((u) => u.role === 'TEAM_LEAD').length}</span>
+            <span><i style={{ background: 'var(--text-secondary)' }} /> 멤버 {state.users.filter((u) => u.role === 'MEMBER').length}</span>
           </div>
         </aside>
       </div>
@@ -255,7 +259,7 @@ export function Members() {
       {changeRoleFor && (
         <div className="modal-overlay" onClick={() => setChangeRoleFor(null)}>
           <div className="change-role-modal glass" onClick={(e) => e.stopPropagation()}>
-            <h3>Change Role — {changeRoleFor.name}</h3>
+            <h3>역할 변경 - {changeRoleFor.name}</h3>
             <div className="role-options">
               {ALL_ROLES.map((r) => (
                 <div key={r} className={"role-option " + (selectedRole === r ? 'selected' : '')} onClick={() => setSelectedRole(r)}>
@@ -267,9 +271,9 @@ export function Members() {
               ))}
             </div>
             <div className="modal-actions">
-              <button className="cancel-btn" onClick={() => setChangeRoleFor(null)}>Cancel</button>
+              <button className="cancel-btn" onClick={() => setChangeRoleFor(null)}>취소</button>
               <button className="confirm-btn" disabled={saving} onClick={handleConfirmRoleChange}>
-                {saving ? '저장 중...' : 'Confirm Change'}
+                {saving ? '저장 중...' : '변경 저장'}
               </button>
             </div>
           </div>

--- a/src/pages/members/members.css
+++ b/src/pages/members/members.css
@@ -4,22 +4,34 @@
 }
 
 .members-header {
-  margin-bottom: 24px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 20px;
 }
 
-.members-header h1 {
-  font-size: 1.75rem;
-  margin: 0;
+.members-header-copy {
   display: flex;
-  align-items: center;
-  gap: 12px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+  min-width: 0;
+}
+
+.members-header-copy p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  max-width: 540px;
 }
 
 .admin-badge {
   font-size: 0.75rem;
-  padding: 4px 10px;
-  background: var(--error);
-  border-radius: 4px;
+  padding: 6px 10px;
+  background: rgba(219, 92, 99, 0.12);
+  color: var(--error);
+  border-radius: 999px;
   font-weight: 600;
 }
 
@@ -120,13 +132,21 @@
 .members-table td {
   padding: 12px 16px;
   text-align: left;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .members-table th {
   color: var(--text-secondary);
   font-size: 0.8rem;
   font-weight: 600;
+}
+
+.members-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.members-table tbody tr:hover td {
+  background: rgba(255, 255, 255, 0.02);
 }
 
 .members-table .avatar {
@@ -148,24 +168,24 @@
   font-size: 0.8rem;
 }
 
-.team-tag.design {
-  background: rgba(59, 130, 246, 0.2);
-  color: var(--accent-blue);
+.team-tag.BACKEND {
+  background: rgba(99, 102, 241, 0.18);
+  color: #a5b4fc;
 }
 
-.team-tag.dev {
-  background: rgba(34, 197, 94, 0.2);
-  color: var(--success);
+.team-tag.FRONTEND {
+  background: rgba(236, 72, 153, 0.18);
+  color: #f9a8d4;
 }
 
-.team-tag.marketing {
-  background: rgba(249, 115, 22, 0.2);
-  color: #f97316;
+.team-tag.AI {
+  background: rgba(16, 185, 129, 0.18);
+  color: #6ee7b7;
 }
 
-.team-tag.product {
-  background: rgba(236, 72, 153, 0.2);
-  color: var(--accent-pink);
+.team-tag.SECURITY {
+  background: rgba(245, 158, 11, 0.18);
+  color: #fcd34d;
 }
 
 .role-tag {
@@ -177,17 +197,17 @@
   font-size: 0.8rem;
 }
 
-.role-tag.leader {
-  background: rgba(234, 179, 8, 0.2);
-  color: var(--warning);
-}
-
-.role-tag.team_lead {
+.role-tag.ADMIN {
   background: rgba(124, 58, 237, 0.2);
   color: var(--accent-purple-light);
 }
 
-.role-tag.member {
+.role-tag.TEAM_LEAD {
+  background: rgba(59, 130, 246, 0.2);
+  color: var(--accent-blue);
+}
+
+.role-tag.MEMBER {
   background: rgba(148, 163, 184, 0.2);
   color: var(--text-secondary);
 }
@@ -357,19 +377,19 @@
   border: 2px solid transparent;
 }
 
-.role-pill.member {
+.role-pill.MEMBER {
   background: rgba(148, 163, 184, 0.2);
   color: var(--text-secondary);
 }
 
-.role-pill.team-lead {
-  background: rgba(124, 58, 237, 0.2);
-  color: var(--accent-purple-light);
+.role-pill.TEAM_LEAD {
+  background: rgba(59, 130, 246, 0.2);
+  color: var(--accent-blue);
 }
 
-.role-pill.leader {
-  background: rgba(234, 179, 8, 0.2);
-  color: var(--warning);
+.role-pill.ADMIN {
+  background: rgba(124, 58, 237, 0.2);
+  color: var(--accent-purple-light);
 }
 
 .modal-actions {
@@ -400,14 +420,6 @@
 }
 
 /* Invite button */
-.members-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 20px;
-}
-
 .invite-btn {
   display: flex;
   align-items: center;
@@ -484,6 +496,15 @@
   background: rgba(150, 128, 204, 0.15);
 }
 
+:root[data-theme='light'] .members-table th,
+:root[data-theme='light'] .members-table td {
+  border-bottom-color: rgba(84, 102, 146, 0.14);
+}
+
+:root[data-theme='light'] .members-table tbody tr:hover td {
+  background: rgba(84, 102, 146, 0.05);
+}
+
 @media (max-width: 900px) {
   .members-header {
     align-items: flex-start;
@@ -522,9 +543,8 @@
 }
 
 @media (max-width: 640px) {
-  .members-header h1 {
-    font-size: 1.45rem;
-    flex-wrap: wrap;
+  .members-header-copy p {
+    font-size: 0.92rem;
   }
 
   .members-table th,

--- a/src/widgets/Layout/Layout.css
+++ b/src/widgets/Layout/Layout.css
@@ -32,6 +32,8 @@
   display: flex;
   align-items: center;
   gap: 12px;
+  flex: 1;
+  min-width: 0;
 }
 
 .logo-img {
@@ -45,16 +47,24 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
+  min-width: 0;
 }
 
 .logo-copy strong {
   font-size: 0.92rem;
   color: var(--text-primary);
+  line-height: 1.1;
+  word-break: keep-all;
 }
 
 .logo-copy span {
   color: var(--text-secondary);
   font-size: 0.76rem;
+  line-height: 1.35;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 .theme-toggle {
@@ -272,6 +282,14 @@
 
   .content-topbar {
     margin-bottom: 20px;
+  }
+
+  .logo-copy strong {
+    font-size: 0.88rem;
+  }
+
+  .logo-copy span {
+    font-size: 0.72rem;
   }
 }
 


### PR DESCRIPTION
## 작업 내용
- 라이트 모드 공통 색상 토큰과 카드 대비를 강화했습니다.
- 일정 상세 모달, 사이드바 로고, 출퇴근/멤버/관리자/AI 화면의 레이아웃 깨짐과 중복 제목을 정리했습니다.
- 채팅 메인 영역과 입력창, 캘린더 우측 패널과 날짜 헤더, 멤버 목록 표를 라이트 모드 기준으로 다시 보정했습니다.

## 변경 이유
- 라이트 모드에서 카드 경계와 텍스트 대비가 약해 정보 구분이 흐렸습니다.
- 일정 상세, 로고 소개 영역, 채팅 입력창, 캘린더 패널처럼 다크 하드코딩이 남아 있던 구간이 화면을 깨 보이게 했습니다.
- 멤버 목록 표는 스크롤 기준과 셀 폭이 불안정해 정돈감이 떨어졌습니다.

## 상세 변경 사항
### 주요 변경
- [x] 라이트 모드 공통 토큰과 카드 대비 강화
- [x] 일정 상세 모달, 사이드바 로고, 공통 헤더 중복 제목 정리
- [x] 채팅/캘린더/멤버 표 라이트 모드 시각 보정

### 추가 메모
- `develop` 반영 PR은 #173, #176 입니다.
- 이번 배포 PR은 `develop -> main` 릴리스 정리용입니다.

## 테스트
- [x] `npm run test:run -- src/pages/attendance/__tests__/Attendance.test.tsx src/pages/members/__tests__/Members.test.tsx src/pages/admin/__tests__/Admin.test.tsx src/features/attendance/ui/__tests__/SetWorkDaysPersonal.test.tsx`
- [x] `npm run test:run -- src/pages/members/__tests__/Members.test.tsx`
- [x] `npm run build`
- [ ] 브라우저에서 주요 동작 확인

## 리뷰 포인트
- 라이트 모드에서 채팅 메인 배경과 입력창, 캘린더 우측 패널과 날짜 헤더가 더 이상 다크 패널처럼 보이지 않는지 확인해주세요.
- 일정 상세 모달 액션 버튼과 좌측 상단 로고 소개 영역이 좁은 폭에서도 깨지지 않는지 봐주세요.
- 멤버 목록 표가 카드와 분리되어 안정적으로 스크롤되고 선이 과하지 않은지 확인해주세요.

## 관련 이슈
- closes #172
- closes #175
