### PR TITLE
[fix] #175 - 라이트 모드 채팅 캘린더와 멤버 표를 정리

### DIFF
--- a/src/pages/calendar/calendar.css
+++ b/src/pages/calendar/calendar.css
@@ -4,7 +4,8 @@
   height: calc(100vh - 48px);
   max-height: calc(100vh - 48px);
   margin: -24px;
-  background: var(--bg-dark);
+  background:
+    linear-gradient(180deg, var(--bg-card) 0%, rgba(var(--bg-app-rgb), 0.72) 100%);
   overflow: hidden;
 }
 
@@ -79,7 +80,7 @@
   --fc-button-active-bg-color: var(--accent-purple);
   --fc-today-bg-color: rgba(124, 58, 237, 0.08);
   --fc-page-bg-color: transparent;
-  --fc-neutral-bg-color: var(--bg-dark);
+  --fc-neutral-bg-color: var(--bg-card-solid);
   --fc-list-event-hover-bg-color: rgba(124, 58, 237, 0.15);
 }
 
@@ -93,7 +94,7 @@
 }
 
 .fullcalendar-wrapper .fc-col-header-cell {
-  background: rgba(18, 16, 28, 0.6);
+  background: var(--bg-soft);
   color: var(--text-secondary);
   font-size: 0.8rem;
 }
@@ -224,10 +225,10 @@
   margin-top: 6px;
   padding: 10px 14px;
   min-width: 180px;
-  background: rgba(55, 48, 80, 0.95);
-  border: 1px solid rgba(124, 58, 237, 0.35);
+  background: var(--bg-card-solid);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-soft);
   z-index: 10;
 }
 
@@ -268,16 +269,16 @@
 .fc-popover,
 .fc .fc-popover,
 .fc-more-popover {
-  background: rgba(25, 23, 40, 0.98) !important;
-  border: 1px solid rgba(148, 163, 184, 0.2) !important;
+  background: var(--bg-card-solid) !important;
+  border: 1px solid var(--border-color) !important;
   border-radius: 10px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-soft);
 }
 
 .fc-popover .fc-popover-header,
 .fc .fc-popover-header {
-  background: rgba(30, 28, 40, 0.98) !important;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+  background: var(--bg-elevated) !important;
+  border-bottom: 1px solid var(--border-color);
   padding: 10px 14px;
 }
 
@@ -293,7 +294,7 @@
 
 .fc-popover .fc-popover-body,
 .fc .fc-popover-body {
-  background: rgba(25, 23, 40, 0.98) !important;
+  background: var(--bg-card-solid) !important;
   color: var(--text-primary) !important;
   padding: 12px;
 }
@@ -434,8 +435,8 @@
   width: 100%;
   padding: 10px 14px;
   border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(15, 13, 26, 0.5);
+  border: 1px solid var(--border-color);
+  background: var(--bg-input);
   color: var(--text-primary);
   font-size: 0.9rem;
   margin-bottom: 16px;
@@ -481,8 +482,8 @@
   padding: 24px;
   overflow-y: auto;
   flex-shrink: 0;
-  background: rgba(18, 16, 28, 0.95);
-  border-left: 1px solid rgba(148, 163, 184, 0.2);
+  background: var(--bg-elevated);
+  border-left: 1px solid var(--border-color);
 }
 
 .tasks-tabs {
@@ -540,8 +541,8 @@
   width: 100%;
   padding: 10px 14px;
   border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(15, 13, 26, 0.5);
+  border: 1px solid var(--border-color);
+  background: var(--bg-input);
   color: var(--text-primary);
   font-size: 0.9rem;
 }
@@ -557,8 +558,8 @@
   min-width: 0;
   padding: 8px 12px;
   border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(15, 13, 26, 0.5);
+  border: 1px solid var(--border-color);
+  background: var(--bg-input);
   color: var(--text-primary);
   font-size: 0.8rem;
 }
@@ -874,6 +875,35 @@
   font-weight: 500;
 }
 
+:root[data-theme='light'] .calendar-page {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.82) 0%, rgba(238, 243, 251, 0.96) 100%);
+}
+
+:root[data-theme='light'] .fullcalendar-wrapper .fc {
+  --fc-border-color: rgba(84, 102, 146, 0.14);
+  --fc-today-bg-color: rgba(107, 79, 196, 0.08);
+}
+
+:root[data-theme='light'] .fullcalendar-wrapper .fc-col-header-cell {
+  background: rgba(84, 102, 146, 0.08);
+}
+
+:root[data-theme='light'] .fullcalendar-wrapper .fc-daygrid-day:hover {
+  background: rgba(107, 79, 196, 0.04);
+}
+
+:root[data-theme='light'] .add-task-time::-webkit-calendar-picker-indicator,
+:root[data-theme='light'] .add-task-date::-webkit-calendar-picker-indicator {
+  filter: none;
+  opacity: 0.8;
+}
+
+:root[data-theme='light'] .task-item:hover,
+:root[data-theme='light'] .event-item:hover {
+  background: rgba(107, 79, 196, 0.05);
+}
+
 @media (max-width: 900px) {
   .calendar-page {
     flex-direction: column;
@@ -908,7 +938,7 @@
   .tasks-sidebar {
     width: 100%;
     border-left: none;
-    border-top: 1px solid rgba(255, 255, 255, 0.05);
+    border-top: 1px solid var(--border-color);
     padding: 18px 16px 24px;
   }
 }

--- a/src/pages/chat/chat.css
+++ b/src/pages/chat/chat.css
@@ -184,7 +184,9 @@
   min-width: 0;
   min-height: 0;
   height: 100%;
-  background: rgba(16, 20, 36, 0.45);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.02) 0%, transparent 100%),
+    var(--bg-card);
 }
 
 .chat-header {
@@ -194,7 +196,7 @@
   justify-content: space-between;
   gap: 12px;
   min-width: 0;
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--bg-elevated);
   border-bottom: 1px solid var(--border-color);
   box-shadow: none;
 }
@@ -226,7 +228,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--bg-soft);
   color: var(--text-primary);
   border: 1px solid var(--border-color);
 }
@@ -275,7 +277,7 @@
   margin: 16px auto 0;
   padding: 18px;
   border-radius: 20px;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--bg-soft);
   border: 1px solid var(--border-color);
   text-align: center;
 }
@@ -293,7 +295,7 @@
 .chat-empty-search {
   padding: 12px;
   border-radius: 14px;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--bg-soft);
   color: var(--text-secondary);
   font-size: 0.85rem;
 }
@@ -333,8 +335,8 @@
 .msg-content {
   max-width: 75%;
   padding: 12px 16px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(164, 177, 214, 0.08);
+  background: var(--bg-soft);
+  border: 1px solid var(--border-color);
   border-radius: 16px;
 }
 
@@ -384,7 +386,7 @@
 }
 
 .msg-markdown code {
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--bg-soft-strong);
   padding: 2px 6px;
   border-radius: 4px;
   font-size: 0.9em;
@@ -393,7 +395,8 @@
 .msg-markdown pre {
   margin: 0.5em 0;
   padding: 12px;
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--bg-soft-strong);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   overflow-x: auto;
 }
@@ -435,7 +438,8 @@
 }
 
 .code-block {
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--bg-soft-strong);
+  border: 1px solid var(--border-color);
   padding: 12px;
   border-radius: 8px;
   font-family: monospace;
@@ -449,7 +453,7 @@
   flex-direction: column;
   gap: 10px;
   flex-shrink: 0;
-  background: rgba(15, 18, 32, 0.72);
+  background: var(--bg-card-solid);
   border-top: 1px solid var(--border-color);
   box-shadow: none;
 }
@@ -616,7 +620,7 @@
   width: 100%;
   padding: 12px 16px;
   margin-bottom: 16px;
-  background: rgba(15, 15, 26, 0.6);
+  background: var(--bg-input);
   border: 1px solid var(--border-color);
   border-radius: 10px;
   color: var(--text-primary);
@@ -651,6 +655,17 @@
   color: var(--text-on-accent);
   border-radius: 14px;
   font-weight: 700;
+}
+
+:root[data-theme='light'] .chat-main {
+  background:
+    radial-gradient(circle at top right, rgba(107, 79, 196, 0.08), transparent 28%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.82) 0%, rgba(244, 247, 253, 0.96) 100%);
+}
+
+:root[data-theme='light'] .msg.own .msg-content {
+  background: rgba(107, 79, 196, 0.16);
+  border-color: rgba(107, 79, 196, 0.2);
 }
 
 @media (max-width: 768px) {

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -175,63 +175,65 @@ export function Members() {
       <div className="members-content">
         <div className="table-section glass">
           <h3>멤버 목록</h3>
-          <table className="members-table">
-            <thead>
-              <tr>
-                <th>프로필</th>
-                <th>팀</th>
-                <th>역할</th>
-                {isAdmin && <th>상태</th>}
-                {isAdmin && <th>관리</th>}
-              </tr>
-            </thead>
-            <tbody>
-              {filtered.map((u) => (
-                <tr key={u.id}>
-                  <td><span className="avatar">{u.name[0]}</span>{u.name}</td>
-                  <td><span className={"team-tag " + u.team}>{teamLabels[u.team] ?? u.team}</span></td>
-                  <td>
-                    <span className={"role-tag " + u.role}>
-                      {u.role === 'ADMIN' && <Crown size={14} />}
-                      {roleLabels[u.role] ?? u.role}
-                    </span>
-                  </td>
-                  {isAdmin && (
-                    <td>
-                      <div className="member-status-cell">
-                        <span className={`member-status-tag ${u.status ?? 'ACTIVE'}`}>
-                          {statusLabels[u.status ?? 'ACTIVE'] ?? (u.status ?? 'ACTIVE')}
-                        </span>
-                        {u.status === 'INACTIVE' ? (
-                          <button className="action-btn activate-btn" disabled={saving} onClick={() => handleActivate(u.id)}>
-                            활성화
-                          </button>
-                        ) : (
-                          <button className="action-btn mute-btn" disabled={saving} onClick={() => handleDeactivate(u.id)}>
-                            비활성화
-                          </button>
-                        )}
-                      </div>
-                    </td>
-                  )}
-                  {isAdmin && (
-                    <td className="actions-cell">
-                      <button className="action-btn" onClick={() => handleOpenChangeRole(u.id, u.name, u.role)}>
-                        역할 변경 <ChevronDown size={14} />
-                      </button>
-                      <button
-                        className="action-btn deactivate-btn"
-                        disabled={saving || u.status === 'INACTIVE'}
-                        onClick={() => handleExpel(u.id)}
-                      >
-                        {u.status === 'INACTIVE' ? '퇴출됨' : '퇴출'}
-                      </button>
-                    </td>
-                  )}
+          <div className="members-table-wrap">
+            <table className="members-table">
+              <thead>
+                <tr>
+                  <th>프로필</th>
+                  <th>팀</th>
+                  <th>역할</th>
+                  {isAdmin && <th>상태</th>}
+                  {isAdmin && <th>관리</th>}
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {filtered.map((u) => (
+                  <tr key={u.id}>
+                    <td><span className="avatar">{u.name[0]}</span>{u.name}</td>
+                    <td><span className={"team-tag " + u.team}>{teamLabels[u.team] ?? u.team}</span></td>
+                    <td>
+                      <span className={"role-tag " + u.role}>
+                        {u.role === 'ADMIN' && <Crown size={14} />}
+                        {roleLabels[u.role] ?? u.role}
+                      </span>
+                    </td>
+                    {isAdmin && (
+                      <td>
+                        <div className="member-status-cell">
+                          <span className={`member-status-tag ${u.status ?? 'ACTIVE'}`}>
+                            {statusLabels[u.status ?? 'ACTIVE'] ?? (u.status ?? 'ACTIVE')}
+                          </span>
+                          {u.status === 'INACTIVE' ? (
+                            <button className="action-btn activate-btn" disabled={saving} onClick={() => handleActivate(u.id)}>
+                              활성화
+                            </button>
+                          ) : (
+                            <button className="action-btn mute-btn" disabled={saving} onClick={() => handleDeactivate(u.id)}>
+                              비활성화
+                            </button>
+                          )}
+                        </div>
+                      </td>
+                    )}
+                    {isAdmin && (
+                      <td className="actions-cell">
+                        <button className="action-btn" onClick={() => handleOpenChangeRole(u.id, u.name, u.role)}>
+                          역할 변경 <ChevronDown size={14} />
+                        </button>
+                        <button
+                          className="action-btn deactivate-btn"
+                          disabled={saving || u.status === 'INACTIVE'}
+                          onClick={() => handleExpel(u.id)}
+                        >
+                          {u.status === 'INACTIVE' ? '퇴출됨' : '퇴출'}
+                        </button>
+                      </td>
+                    )}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
 
         <aside className="stats-sidebar glass">

--- a/src/pages/members/members.css
+++ b/src/pages/members/members.css
@@ -112,7 +112,7 @@
 
 .table-section {
   padding: 24px;
-  overflow-x: auto;
+  overflow: hidden;
   overflow-y: hidden;
   min-width: 0;
 }
@@ -120,6 +120,13 @@
 .table-section h3 {
   margin-bottom: 16px;
   font-size: 1rem;
+}
+
+.members-table-wrap {
+  overflow-x: auto;
+  padding-bottom: 6px;
+  min-width: 0;
+  scrollbar-width: thin;
 }
 
 .members-table {
@@ -133,6 +140,8 @@
   padding: 12px 16px;
   text-align: left;
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  vertical-align: middle;
+  white-space: nowrap;
 }
 
 .members-table th {
@@ -147,6 +156,15 @@
 
 .members-table tbody tr:hover td {
   background: rgba(255, 255, 255, 0.02);
+}
+
+.members-table td:first-child {
+  min-width: 180px;
+}
+
+.members-table td:last-child,
+.members-table th:last-child {
+  min-width: 190px;
 }
 
 .members-table .avatar {
@@ -222,6 +240,7 @@
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
+  justify-content: flex-start;
 }
 
 .action-btn {
@@ -503,6 +522,10 @@
 
 :root[data-theme='light'] .members-table tbody tr:hover td {
   background: rgba(84, 102, 146, 0.05);
+}
+
+:root[data-theme='light'] .members-table-wrap {
+  scrollbar-color: rgba(84, 102, 146, 0.32) transparent;
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## 작업 내용
- 채팅 메인 영역과 입력창을 공통 테마 토큰 기준으로 다시 맞췄습니다.
- 캘린더 우측 패널, 날짜 헤더, 입력 필드의 다크 하드코딩 배경을 정리했습니다.
- 멤버 목록 표에 전용 스크롤 래퍼와 셀 폭 보정을 넣어 라이트 모드에서도 정돈되게 보이도록 맞췄습니다.

## 변경 이유
- 라이트 모드에서 채팅 입력창과 캘린더 패널이 과하게 어두워 화면이 깨져 보였습니다.
- 캘린더 헤더/입력 요소와 멤버 표 선 정리가 약해서 밝은 테마에서 더 어수선하게 보였습니다.
- 표 스크롤 기준이 섹션 전체에 걸려 제목과 표가 함께 흔들리는 문제가 있었습니다.

## 상세 변경 사항
### 주요 변경
- [x] 채팅 라이트 모드 배경과 입력창 대비 보정
- [x] 캘린더 라이트 모드 패널과 입력 필드 하드코딩 배경 제거
- [x] 멤버 목록 표 래퍼 분리와 셀 폭/선 정리

### 추가 메모
- 기존 release PR #174 는 develop -> main 흐름이라 이번 develop 머지 후 자동 반영됩니다.

## 테스트
- [x] `npm run test:run -- src/pages/members/__tests__/Members.test.tsx`
- [x] `npm run build`
- [ ] 브라우저에서 주요 동작 확인

## 리뷰 포인트
- 라이트 모드에서 채팅 메인 배경과 입력창이 더 이상 다크 패널처럼 보이지 않는지 확인해주세요.
- 캘린더 우측 패널과 입력 필드, 요일 헤더가 라이트 모드에서 자연스럽게 보이는지 봐주세요.
- 멤버 목록 표가 카드와 분리되어 안정적으로 스크롤되고 선이 과하지 않은지 확인해주세요.

## 관련 이슈
- closes #175
