### PR TITLE
release: v0.1.10

### DIFF
--- a/src/pages/calendar/calendar.css
+++ b/src/pages/calendar/calendar.css
@@ -4,7 +4,8 @@
   height: calc(100vh - 48px);
   max-height: calc(100vh - 48px);
   margin: -24px;
-  background: var(--bg-dark);
+  background:
+    linear-gradient(180deg, var(--bg-card) 0%, rgba(var(--bg-app-rgb), 0.72) 100%);
   overflow: hidden;
 }
 
@@ -79,7 +80,7 @@
   --fc-button-active-bg-color: var(--accent-purple);
   --fc-today-bg-color: rgba(124, 58, 237, 0.08);
   --fc-page-bg-color: transparent;
-  --fc-neutral-bg-color: var(--bg-dark);
+  --fc-neutral-bg-color: var(--bg-card-solid);
   --fc-list-event-hover-bg-color: rgba(124, 58, 237, 0.15);
 }
 
@@ -93,7 +94,7 @@
 }
 
 .fullcalendar-wrapper .fc-col-header-cell {
-  background: rgba(18, 16, 28, 0.6);
+  background: var(--bg-soft);
   color: var(--text-secondary);
   font-size: 0.8rem;
 }
@@ -224,10 +225,10 @@
   margin-top: 6px;
   padding: 10px 14px;
   min-width: 180px;
-  background: rgba(55, 48, 80, 0.95);
-  border: 1px solid rgba(124, 58, 237, 0.35);
+  background: var(--bg-card-solid);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-soft);
   z-index: 10;
 }
 
@@ -268,16 +269,16 @@
 .fc-popover,
 .fc .fc-popover,
 .fc-more-popover {
-  background: rgba(25, 23, 40, 0.98) !important;
-  border: 1px solid rgba(148, 163, 184, 0.2) !important;
+  background: var(--bg-card-solid) !important;
+  border: 1px solid var(--border-color) !important;
   border-radius: 10px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-soft);
 }
 
 .fc-popover .fc-popover-header,
 .fc .fc-popover-header {
-  background: rgba(30, 28, 40, 0.98) !important;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+  background: var(--bg-elevated) !important;
+  border-bottom: 1px solid var(--border-color);
   padding: 10px 14px;
 }
 
@@ -293,7 +294,7 @@
 
 .fc-popover .fc-popover-body,
 .fc .fc-popover-body {
-  background: rgba(25, 23, 40, 0.98) !important;
+  background: var(--bg-card-solid) !important;
   color: var(--text-primary) !important;
   padding: 12px;
 }
@@ -434,8 +435,8 @@
   width: 100%;
   padding: 10px 14px;
   border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(15, 13, 26, 0.5);
+  border: 1px solid var(--border-color);
+  background: var(--bg-input);
   color: var(--text-primary);
   font-size: 0.9rem;
   margin-bottom: 16px;
@@ -481,8 +482,8 @@
   padding: 24px;
   overflow-y: auto;
   flex-shrink: 0;
-  background: rgba(18, 16, 28, 0.95);
-  border-left: 1px solid rgba(148, 163, 184, 0.2);
+  background: var(--bg-elevated);
+  border-left: 1px solid var(--border-color);
 }
 
 .tasks-tabs {
@@ -540,8 +541,8 @@
   width: 100%;
   padding: 10px 14px;
   border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(15, 13, 26, 0.5);
+  border: 1px solid var(--border-color);
+  background: var(--bg-input);
   color: var(--text-primary);
   font-size: 0.9rem;
 }
@@ -557,8 +558,8 @@
   min-width: 0;
   padding: 8px 12px;
   border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(15, 13, 26, 0.5);
+  border: 1px solid var(--border-color);
+  background: var(--bg-input);
   color: var(--text-primary);
   font-size: 0.8rem;
 }
@@ -874,6 +875,35 @@
   font-weight: 500;
 }
 
+:root[data-theme='light'] .calendar-page {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.82) 0%, rgba(238, 243, 251, 0.96) 100%);
+}
+
+:root[data-theme='light'] .fullcalendar-wrapper .fc {
+  --fc-border-color: rgba(84, 102, 146, 0.14);
+  --fc-today-bg-color: rgba(107, 79, 196, 0.08);
+}
+
+:root[data-theme='light'] .fullcalendar-wrapper .fc-col-header-cell {
+  background: rgba(84, 102, 146, 0.08);
+}
+
+:root[data-theme='light'] .fullcalendar-wrapper .fc-daygrid-day:hover {
+  background: rgba(107, 79, 196, 0.04);
+}
+
+:root[data-theme='light'] .add-task-time::-webkit-calendar-picker-indicator,
+:root[data-theme='light'] .add-task-date::-webkit-calendar-picker-indicator {
+  filter: none;
+  opacity: 0.8;
+}
+
+:root[data-theme='light'] .task-item:hover,
+:root[data-theme='light'] .event-item:hover {
+  background: rgba(107, 79, 196, 0.05);
+}
+
 @media (max-width: 900px) {
   .calendar-page {
     flex-direction: column;
@@ -908,7 +938,7 @@
   .tasks-sidebar {
     width: 100%;
     border-left: none;
-    border-top: 1px solid rgba(255, 255, 255, 0.05);
+    border-top: 1px solid var(--border-color);
     padding: 18px 16px 24px;
   }
 }

--- a/src/pages/chat/chat.css
+++ b/src/pages/chat/chat.css
@@ -184,7 +184,9 @@
   min-width: 0;
   min-height: 0;
   height: 100%;
-  background: rgba(16, 20, 36, 0.45);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.02) 0%, transparent 100%),
+    var(--bg-card);
 }
 
 .chat-header {
@@ -194,7 +196,7 @@
   justify-content: space-between;
   gap: 12px;
   min-width: 0;
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--bg-elevated);
   border-bottom: 1px solid var(--border-color);
   box-shadow: none;
 }
@@ -226,7 +228,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--bg-soft);
   color: var(--text-primary);
   border: 1px solid var(--border-color);
 }
@@ -275,7 +277,7 @@
   margin: 16px auto 0;
   padding: 18px;
   border-radius: 20px;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--bg-soft);
   border: 1px solid var(--border-color);
   text-align: center;
 }
@@ -293,7 +295,7 @@
 .chat-empty-search {
   padding: 12px;
   border-radius: 14px;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--bg-soft);
   color: var(--text-secondary);
   font-size: 0.85rem;
 }
@@ -333,8 +335,8 @@
 .msg-content {
   max-width: 75%;
   padding: 12px 16px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(164, 177, 214, 0.08);
+  background: var(--bg-soft);
+  border: 1px solid var(--border-color);
   border-radius: 16px;
 }
 
@@ -384,7 +386,7 @@
 }
 
 .msg-markdown code {
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--bg-soft-strong);
   padding: 2px 6px;
   border-radius: 4px;
   font-size: 0.9em;
@@ -393,7 +395,8 @@
 .msg-markdown pre {
   margin: 0.5em 0;
   padding: 12px;
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--bg-soft-strong);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   overflow-x: auto;
 }
@@ -435,7 +438,8 @@
 }
 
 .code-block {
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--bg-soft-strong);
+  border: 1px solid var(--border-color);
   padding: 12px;
   border-radius: 8px;
   font-family: monospace;
@@ -449,7 +453,7 @@
   flex-direction: column;
   gap: 10px;
   flex-shrink: 0;
-  background: rgba(15, 18, 32, 0.72);
+  background: var(--bg-card-solid);
   border-top: 1px solid var(--border-color);
   box-shadow: none;
 }
@@ -616,7 +620,7 @@
   width: 100%;
   padding: 12px 16px;
   margin-bottom: 16px;
-  background: rgba(15, 15, 26, 0.6);
+  background: var(--bg-input);
   border: 1px solid var(--border-color);
   border-radius: 10px;
   color: var(--text-primary);
@@ -651,6 +655,17 @@
   color: var(--text-on-accent);
   border-radius: 14px;
   font-weight: 700;
+}
+
+:root[data-theme='light'] .chat-main {
+  background:
+    radial-gradient(circle at top right, rgba(107, 79, 196, 0.08), transparent 28%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.82) 0%, rgba(244, 247, 253, 0.96) 100%);
+}
+
+:root[data-theme='light'] .msg.own .msg-content {
+  background: rgba(107, 79, 196, 0.16);
+  border-color: rgba(107, 79, 196, 0.2);
 }
 
 @media (max-width: 768px) {

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -175,63 +175,65 @@ export function Members() {
       <div className="members-content">
         <div className="table-section glass">
           <h3>멤버 목록</h3>
-          <table className="members-table">
-            <thead>
-              <tr>
-                <th>프로필</th>
-                <th>팀</th>
-                <th>역할</th>
-                {isAdmin && <th>상태</th>}
-                {isAdmin && <th>관리</th>}
-              </tr>
-            </thead>
-            <tbody>
-              {filtered.map((u) => (
-                <tr key={u.id}>
-                  <td><span className="avatar">{u.name[0]}</span>{u.name}</td>
-                  <td><span className={"team-tag " + u.team}>{teamLabels[u.team] ?? u.team}</span></td>
-                  <td>
-                    <span className={"role-tag " + u.role}>
-                      {u.role === 'ADMIN' && <Crown size={14} />}
-                      {roleLabels[u.role] ?? u.role}
-                    </span>
-                  </td>
-                  {isAdmin && (
-                    <td>
-                      <div className="member-status-cell">
-                        <span className={`member-status-tag ${u.status ?? 'ACTIVE'}`}>
-                          {statusLabels[u.status ?? 'ACTIVE'] ?? (u.status ?? 'ACTIVE')}
-                        </span>
-                        {u.status === 'INACTIVE' ? (
-                          <button className="action-btn activate-btn" disabled={saving} onClick={() => handleActivate(u.id)}>
-                            활성화
-                          </button>
-                        ) : (
-                          <button className="action-btn mute-btn" disabled={saving} onClick={() => handleDeactivate(u.id)}>
-                            비활성화
-                          </button>
-                        )}
-                      </div>
-                    </td>
-                  )}
-                  {isAdmin && (
-                    <td className="actions-cell">
-                      <button className="action-btn" onClick={() => handleOpenChangeRole(u.id, u.name, u.role)}>
-                        역할 변경 <ChevronDown size={14} />
-                      </button>
-                      <button
-                        className="action-btn deactivate-btn"
-                        disabled={saving || u.status === 'INACTIVE'}
-                        onClick={() => handleExpel(u.id)}
-                      >
-                        {u.status === 'INACTIVE' ? '퇴출됨' : '퇴출'}
-                      </button>
-                    </td>
-                  )}
+          <div className="members-table-wrap">
+            <table className="members-table">
+              <thead>
+                <tr>
+                  <th>프로필</th>
+                  <th>팀</th>
+                  <th>역할</th>
+                  {isAdmin && <th>상태</th>}
+                  {isAdmin && <th>관리</th>}
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {filtered.map((u) => (
+                  <tr key={u.id}>
+                    <td><span className="avatar">{u.name[0]}</span>{u.name}</td>
+                    <td><span className={"team-tag " + u.team}>{teamLabels[u.team] ?? u.team}</span></td>
+                    <td>
+                      <span className={"role-tag " + u.role}>
+                        {u.role === 'ADMIN' && <Crown size={14} />}
+                        {roleLabels[u.role] ?? u.role}
+                      </span>
+                    </td>
+                    {isAdmin && (
+                      <td>
+                        <div className="member-status-cell">
+                          <span className={`member-status-tag ${u.status ?? 'ACTIVE'}`}>
+                            {statusLabels[u.status ?? 'ACTIVE'] ?? (u.status ?? 'ACTIVE')}
+                          </span>
+                          {u.status === 'INACTIVE' ? (
+                            <button className="action-btn activate-btn" disabled={saving} onClick={() => handleActivate(u.id)}>
+                              활성화
+                            </button>
+                          ) : (
+                            <button className="action-btn mute-btn" disabled={saving} onClick={() => handleDeactivate(u.id)}>
+                              비활성화
+                            </button>
+                          )}
+                        </div>
+                      </td>
+                    )}
+                    {isAdmin && (
+                      <td className="actions-cell">
+                        <button className="action-btn" onClick={() => handleOpenChangeRole(u.id, u.name, u.role)}>
+                          역할 변경 <ChevronDown size={14} />
+                        </button>
+                        <button
+                          className="action-btn deactivate-btn"
+                          disabled={saving || u.status === 'INACTIVE'}
+                          onClick={() => handleExpel(u.id)}
+                        >
+                          {u.status === 'INACTIVE' ? '퇴출됨' : '퇴출'}
+                        </button>
+                      </td>
+                    )}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
 
         <aside className="stats-sidebar glass">

--- a/src/pages/members/members.css
+++ b/src/pages/members/members.css
@@ -112,7 +112,7 @@
 
 .table-section {
   padding: 24px;
-  overflow-x: auto;
+  overflow: hidden;
   overflow-y: hidden;
   min-width: 0;
 }
@@ -120,6 +120,13 @@
 .table-section h3 {
   margin-bottom: 16px;
   font-size: 1rem;
+}
+
+.members-table-wrap {
+  overflow-x: auto;
+  padding-bottom: 6px;
+  min-width: 0;
+  scrollbar-width: thin;
 }
 
 .members-table {
@@ -133,6 +140,8 @@
   padding: 12px 16px;
   text-align: left;
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  vertical-align: middle;
+  white-space: nowrap;
 }
 
 .members-table th {
@@ -147,6 +156,15 @@
 
 .members-table tbody tr:hover td {
   background: rgba(255, 255, 255, 0.02);
+}
+
+.members-table td:first-child {
+  min-width: 180px;
+}
+
+.members-table td:last-child,
+.members-table th:last-child {
+  min-width: 190px;
 }
 
 .members-table .avatar {
@@ -222,6 +240,7 @@
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
+  justify-content: flex-start;
 }
 
 .action-btn {
@@ -503,6 +522,10 @@
 
 :root[data-theme='light'] .members-table tbody tr:hover td {
   background: rgba(84, 102, 146, 0.05);
+}
+
+:root[data-theme='light'] .members-table-wrap {
+  scrollbar-color: rgba(84, 102, 146, 0.32) transparent;
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## 작업 내용
- 라이트 모드 공통 색상 토큰과 카드 대비를 강화했습니다.
- 일정 상세 모달, 사이드바 로고, 출퇴근/멤버/관리자/AI 화면의 레이아웃 깨짐과 중복 제목을 정리했습니다.
- 채팅 메인 영역과 입력창, 캘린더 우측 패널과 날짜 헤더, 멤버 목록 표를 라이트 모드 기준으로 다시 보정했습니다.
- `main` 머지 시 release PR 제목을 기준으로 태그와 GitHub Release를 자동 생성하는 워크플로를 추가했습니다.

## 변경 이유
- 라이트 모드에서 카드 경계와 텍스트 대비가 약해 정보 구분이 흐렸습니다.
- 일정 상세, 로고 소개 영역, 채팅 입력창, 캘린더 패널처럼 다크 하드코딩이 남아 있던 구간이 화면을 깨 보이게 했습니다.
- GitHub Releases 영역이 비어 있어 배포 이력이 남지 않았고, 이후에도 릴리스가 빠지지 않도록 자동화가 필요했습니다.

## 상세 변경 사항
### 주요 변경
- [x] 라이트 모드 공통 토큰과 카드 대비 강화
- [x] 일정 상세 모달, 사이드바 로고, 공통 헤더 중복 제목 정리
- [x] 채팅/캘린더/멤버 표 라이트 모드 시각 보정
- [x] `main` push 시 GitHub Release 자동 생성 워크플로 추가

### 추가 메모
- `develop` 반영 PR은 #173, #176, #180 입니다.
- 현재 게시된 GitHub Release는 `v0.1.9` 입니다.
- 이번 PR `release: v0.1.10` 이 머지되면 워크플로가 같은 버전 태그와 GitHub Release를 자동 생성합니다.

## 테스트
- [x] `npm run test:run -- src/pages/attendance/__tests__/Attendance.test.tsx src/pages/members/__tests__/Members.test.tsx src/pages/admin/__tests__/Admin.test.tsx src/features/attendance/ui/__tests__/SetWorkDaysPersonal.test.tsx`
- [x] `npm run test:run -- src/pages/members/__tests__/Members.test.tsx`
- [x] `npm run build`
- [x] `gh release view v0.1.9`
- [ ] 브라우저에서 주요 동작 확인
- [ ] `main` 머지 후 자동 릴리스 생성 동작 확인

## 리뷰 포인트
- 라이트 모드에서 채팅 메인 배경과 입력창, 캘린더 우측 패널과 날짜 헤더가 더 이상 다크 패널처럼 보이지 않는지 확인해주세요.
- 일정 상세 모달 액션 버튼과 좌측 상단 로고 소개 영역이 좁은 폭에서도 깨지지 않는지 봐주세요.
- 멤버 목록 표가 카드와 분리되어 안정적으로 스크롤되고 선이 과하지 않은지 확인해주세요.
- `release.yml` 이 `main` 머지 커밋에 연결된 release PR 제목을 안정적으로 읽는지 확인해주세요.

## 관련 이슈
- closes #172
- closes #175
- closes #179
