### PR TITLE
[cicd] #179 - GitHub Release 자동 생성 흐름 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  publish-release:
+    name: GitHub Release 발행
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 릴리스 PR 기준으로 태그와 Release 생성
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const releaseTitlePattern = /^release:\s*(v\d+\.\d+\.\d+)$/i
+            const { owner, repo } = context.repo
+            const commit_sha = context.sha
+
+            const associatedPrs = await github.paginate(
+              github.rest.repos.listPullRequestsAssociatedWithCommit,
+              {
+                owner,
+                repo,
+                commit_sha,
+              },
+            )
+
+            const releasePr = associatedPrs.find((pr) => {
+              if (!pr.merged_at) return false
+              return releaseTitlePattern.test(pr.title.trim())
+            })
+
+            if (!releasePr) {
+              core.notice('release: vX.Y.Z 형식의 머지된 PR을 찾지 못해 GitHub Release 생성을 건너뜁니다.')
+              return
+            }
+
+            const [, tagName] = releasePr.title.trim().match(releaseTitlePattern)
+            const releaseBody = (releasePr.body || `Release ${tagName}`).trim()
+
+            try {
+              await github.rest.git.getRef({
+                owner,
+                repo,
+                ref: `tags/${tagName}`,
+              })
+              core.notice(`태그 ${tagName} 이 이미 존재합니다.`)
+            } catch (error) {
+              if (error.status !== 404) throw error
+
+              await github.rest.git.createRef({
+                owner,
+                repo,
+                ref: `refs/tags/${tagName}`,
+                sha: commit_sha,
+              })
+
+              core.notice(`태그 ${tagName} 을 ${commit_sha} 에 생성했습니다.`)
+            }
+
+            try {
+              const existingRelease = await github.rest.repos.getReleaseByTag({
+                owner,
+                repo,
+                tag: tagName,
+              })
+
+              await github.rest.repos.updateRelease({
+                owner,
+                repo,
+                release_id: existingRelease.data.id,
+                tag_name: tagName,
+                name: tagName,
+                body: releaseBody,
+                draft: false,
+                prerelease: false,
+              })
+
+              core.notice(`기존 GitHub Release ${tagName} 을 업데이트했습니다.`)
+            } catch (error) {
+              if (error.status !== 404) throw error
+
+              await github.rest.repos.createRelease({
+                owner,
+                repo,
+                tag_name: tagName,
+                name: tagName,
+                body: releaseBody,
+                draft: false,
+                prerelease: false,
+                target_commitish: commit_sha,
+              })
+
+              core.notice(`GitHub Release ${tagName} 을 생성했습니다.`)
+            }

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -21,6 +21,7 @@ main          ← 프로덕션 (Vercel 자동 배포)
 - `develop` 머지는 작업 정리 후 진행할 수 있습니다.
 - `main` 머지는 배포 성격이므로 저장소 관리자만 진행합니다.
 - 즉, `main` 대상 PR은 `develop` 브랜치에서만 올립니다.
+- `main` 머지 후에는 GitHub Release가 자동 생성되므로, 배포 PR 제목은 반드시 `release: v0.1.10` 같은 버전 형식을 사용합니다.
 
 ### 브랜치 생성 규칙
 
@@ -106,6 +107,8 @@ feat(auth): add login, logout, signup pages
 2. 기능 구현과 테스트를 작업 브랜치에서 마칩니다.
 3. 작업 브랜치에서 `develop` 대상으로 PR을 생성합니다.
 4. `develop` 머지 후 필요할 때 `develop`에서 `main` 대상으로 배포 PR을 생성합니다.
+5. `main` 대상 배포 PR 제목은 `release: v0.1.10` 형식으로 작성합니다.
+6. `main` 머지 후 GitHub Actions가 같은 버전 태그와 GitHub Release를 자동 생성합니다.
 
 ### 금지 사항
 
@@ -120,6 +123,12 @@ feat(auth): 로그인 페이지 구현
 ```
 
 커밋 컨벤션과 동일한 형식 사용.
+
+단, `develop -> main` 배포 PR은 아래 형식을 사용합니다.
+
+```
+release: v0.1.10
+```
 
 ### PR 머지 전 체크리스트
 


### PR DESCRIPTION
## 작업 내용
- `main` 머지 시 release PR 제목을 읽어 태그와 GitHub Release를 자동 생성하는 워크플로를 추가했습니다.
- 현재 비어 있던 Releases 영역을 `v0.1.9` 기준으로 초기화했습니다.
- 배포 PR 제목과 릴리스 생성 규칙을 기여 가이드에 반영했습니다.

## 변경 이유
- 지금까지는 release PR만 있고 실제 GitHub Release와 태그가 비어 있어 배포 이력이 남지 않았습니다.
- 이후에도 릴리스가 빠지지 않도록 `main` 머지 시 자동화가 필요했습니다.
- 이미 팀에서 쓰고 있는 `release: v0.1.x` 제목 규칙을 그대로 자동화에 연결하는 것이 가장 자연스럽습니다.

## 상세 변경 사항
### 주요 변경
- [x] `main` push 시 GitHub Release 자동 생성 워크플로 추가
- [x] `v0.1.9` GitHub Release 생성
- [x] 기여 가이드에 배포 PR 제목 및 Release 규칙 반영

### 추가 메모
- 현재 게시된 릴리스는 `v0.1.9` 입니다.
- 열려 있는 `main` PR #177 이 머지되면 워크플로가 `release: v0.1.10` 제목을 읽어 다음 릴리스를 자동 생성하게 됩니다.

## 테스트
- [x] `gh release view v0.1.9`
- [x] 워크플로 파일과 가이드 문서 반영 확인
- [ ] `main` 머지 후 자동 릴리스 생성 동작 확인

## 리뷰 포인트
- `release.yml` 이 `main` 머지 커밋에 연결된 release PR 제목을 안정적으로 읽는지 봐주세요.
- 배포 PR 제목 형식이 `release: v0.1.x` 로 계속 유지되어야 자동화가 정상 동작합니다.

## 관련 이슈
- closes #179
