### PR TITLE
[style] #184 - 사이드바 브랜드 문구 정리

### DIFF
--- a/src/widgets/Layout/Layout.css
+++ b/src/widgets/Layout/Layout.css
@@ -45,26 +45,18 @@
 
 .logo-copy {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  align-items: center;
   min-width: 0;
 }
 
 .logo-copy strong {
-  font-size: 0.92rem;
+  font-size: 0.98rem;
   color: var(--text-primary);
   line-height: 1.1;
   word-break: keep-all;
-}
-
-.logo-copy span {
-  color: var(--text-secondary);
-  font-size: 0.76rem;
-  line-height: 1.35;
   overflow: hidden;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .theme-toggle {

--- a/src/widgets/Layout/Layout.tsx
+++ b/src/widgets/Layout/Layout.tsx
@@ -43,7 +43,6 @@ export function Layout() {
             <img src={logoImg} alt="yANUs" className="logo-img" />
             <div className="logo-copy">
               <strong>yANUs Groupware</strong>
-              <span>클럽 운영을 더 매끄럽게</span>
             </div>
           </div>
           <button


### PR DESCRIPTION
## 작업 내용
- 사이드바 좌측 상단 브랜드 영역에서 보조 문구를 제거했습니다.
- `yANUs Groupware`만 남기고 한 줄 기준으로 더 안정적으로 보이게 정리했습니다.

## 테스트
- [x] `npm run test:run -- src/widgets/Layout/__tests__/Layout.test.tsx`
- [x] `npm run build`

## 관련 이슈
- close #184
