### PR TITLE
[fix] #186 - 채팅 목록에서 비활성 멤버 숨김

### DIFF
--- a/src/pages/chat/__tests__/Chat.test.tsx
+++ b/src/pages/chat/__tests__/Chat.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Chat } from '../index'
+
+const mockSetActiveChannelId = vi.fn()
+const mockAddMessage = vi.fn()
+
+window.HTMLElement.prototype.scrollIntoView = vi.fn()
+
+vi.mock('../../../features/auth/model', () => ({
+  useApp: () => ({
+    state: {
+      currentUser: { id: '1', name: '김리더', role: 'ADMIN', team: 'BACKEND' },
+      users: [
+        { id: '1', name: '김리더', role: 'ADMIN', team: 'BACKEND', email: 'admin@yanus.kr', status: 'ACTIVE', online: true },
+        { id: '2', name: '박팀장', role: 'TEAM_LEAD', team: 'FRONTEND', email: 'lead@yanus.kr', status: 'ACTIVE', online: true },
+        { id: '5', name: '비활성멤버', role: 'MEMBER', team: 'SECURITY', email: 'inactive@yanus.kr', status: 'INACTIVE', online: false },
+      ],
+    },
+    loadMembers: vi.fn(),
+  }),
+}))
+
+vi.mock('../../../features/chat/model', () => ({
+  useChat: () => ({
+    channels: [
+      { id: '1', name: 'General', lastMessage: '안녕하세요!' },
+      { id: '2', name: 'Design Team', lastMessage: '디자인 피드백 부탁드려요' },
+    ],
+    activeChannelId: '1',
+    setActiveChannelId: mockSetActiveChannelId,
+    addMessage: mockAddMessage,
+    getMessagesByChannel: () => [],
+  }),
+}))
+
+vi.mock('../../../shared/api/membersApi', () => ({
+  getMembers: vi.fn(),
+}))
+
+describe('Chat 페이지', () => {
+  it('개인 대화 목록에서 비활성 멤버를 숨긴다', () => {
+    render(<Chat />)
+
+    expect(screen.getByText('박팀장')).toBeInTheDocument()
+    expect(screen.queryByText('비활성멤버')).not.toBeInTheDocument()
+  })
+})

--- a/src/pages/chat/index.tsx
+++ b/src/pages/chat/index.tsx
@@ -107,7 +107,7 @@ export function Chat() {
 
   const activeChannel = channels.find((c) => c.id === activeChannelId)
   const currentUserId = state.currentUser?.id ?? ''
-  const directRooms = state.users.filter((user) => user.id !== currentUserId)
+  const directRooms = state.users.filter((user) => user.id !== currentUserId && user.status !== 'INACTIVE')
   const activeDirectUser = directRooms.find((user) => `dm-${user.id}` === activeChannelId)
   const isDirectRoom = activeChannelId.startsWith('dm-')
   const messages = getMessagesByChannel(activeChannelId)
@@ -139,6 +139,11 @@ export function Chat() {
       setIsMobileRoomOpen(true)
     }
   }, [isMobile])
+
+  useEffect(() => {
+    if (!isDirectRoom || activeDirectUser || channels.length === 0) return
+    setActiveChannelId(channels[0].id)
+  }, [activeDirectUser, channels, isDirectRoom, setActiveChannelId])
 
   useEffect(() => {
     if (!showEmojiPicker) return


### PR DESCRIPTION
## 작업 내용
- 채팅 개인 대화 목록에서 비활성 멤버를 숨겼습니다.
- 비활성 멤버 DM이 현재 활성 상태면 기본 채널로 자연스럽게 되돌리도록 정리했습니다.
- 채팅 페이지 테스트를 추가해 노출 기준을 고정했습니다.

## 테스트
- [x] `npm run test:run -- src/pages/chat/__tests__/Chat.test.tsx src/features/chat/model/__tests__/ChatProvider.test.tsx src/shared/api/__tests__/chatApi.test.ts`
- [x] `npm run build`

## 관련 이슈
- close #186
