### PR TITLE
[feat] #188 - 리프레시 토큰 만료 자동 로그아웃 처리

### DIFF
--- a/src/features/auth/api/__tests__/authClient.test.ts
+++ b/src/features/auth/api/__tests__/authClient.test.ts
@@ -47,7 +47,10 @@ const server = setupServer(
 )
 
 beforeAll(() => server.listen())
-afterEach(() => server.resetHandlers())
+afterEach(() => {
+  server.resetHandlers()
+  localStorage.clear()
+})
 afterAll(() => server.close())
 
 describe('authClient', () => {
@@ -55,6 +58,8 @@ describe('authClient', () => {
     it('성공 시 accessToken을 반환한다', async () => {
       const token = await login('admin@yanus.kr', 'password')
       expect(token).toBe('mock-token')
+      expect(localStorage.getItem('accessToken')).toBe('mock-token')
+      expect(localStorage.getItem('refreshToken')).toBe('refresh-token')
     })
 
     it('잘못된 자격증명이면 에러를 던진다', async () => {
@@ -97,7 +102,11 @@ describe('authClient', () => {
 
   describe('logout()', () => {
     it('로그아웃 요청이 성공한다', async () => {
+      localStorage.setItem('accessToken', 'mock-token')
+      localStorage.setItem('refreshToken', 'refresh-token')
       await expect(logout()).resolves.not.toThrow()
+      expect(localStorage.getItem('accessToken')).toBeNull()
+      expect(localStorage.getItem('refreshToken')).toBeNull()
     })
   })
 })

--- a/src/features/auth/api/authClient.ts
+++ b/src/features/auth/api/authClient.ts
@@ -1,12 +1,19 @@
 import { baseClient } from '../../../shared/api/baseClient'
 import { ApiError } from '../../../shared/api/baseClient'
 import type { User } from '../../../entities/user/model/types'
+import { clearAuthTokens, storeAuthTokens } from '../../../shared/lib/authStorage'
 
 export interface RegisterPayload {
   name: string
   email: string
   password: string
   teamId: number
+}
+
+export interface LoginTokens {
+  accessToken: string
+  refreshToken: string
+  tokenType: string
 }
 
 // OpenAPI MeResponse: id는 integer(int64) — User.id(string)로 변환 필요
@@ -20,10 +27,11 @@ interface MeResponse {
 
 export async function login(email: string, password: string): Promise<string> {
   try {
-    const data = await baseClient.post<{ accessToken: string; refreshToken: string; tokenType: string }>(
+    const data = await baseClient.post<LoginTokens>(
       '/api/v1/auth/login',
       { email, password },
     )
+    storeAuthTokens(data)
     return data.accessToken
   } catch (err) {
     if (err instanceof ApiError && err.code === 'MEMBER_INACTIVE') {
@@ -49,5 +57,9 @@ export async function getMe(): Promise<User> {
 }
 
 export async function logout(): Promise<void> {
-  await baseClient.post<null>('/api/v1/auth/logout', {})
+  try {
+    await baseClient.post<null>('/api/v1/auth/logout', {})
+  } finally {
+    clearAuthTokens()
+  }
 }

--- a/src/features/auth/model/AppProvider.tsx
+++ b/src/features/auth/model/AppProvider.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useState, useEffect, useCallback } from 'rea
 import type { ReactNode } from 'react'
 import type { User } from '../../../entities/user/model/types'
 import { getMe } from '../api/authClient'
+import { clearAuthTokens, getAccessToken } from '../../../shared/lib/authStorage'
 
 export type { UserRole, Team, User, UserStatus } from '../../../entities/user/model/types'
 
@@ -29,7 +30,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
 
   // 앱 시작 시 저장된 토큰으로 currentUser 복원
   useEffect(() => {
-    const token = localStorage.getItem('accessToken')
+    const token = getAccessToken()
     if (!token) {
       setIsInitializing(false)
       return
@@ -38,7 +39,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
       .then((user) => setState((prev) => ({ ...prev, currentUser: user })))
       .catch(() => {
         // 토큰 만료 또는 유효하지 않음 — 자동 로그아웃
-        localStorage.removeItem('accessToken')
+        clearAuthTokens()
       })
       .finally(() => setIsInitializing(false))
   }, [])
@@ -55,7 +56,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const logout = useCallback(() => {
-    localStorage.removeItem('accessToken')
+    clearAuthTokens()
     setState({ currentUser: null, users: [] })
   }, [])
 

--- a/src/pages/login/__tests__/Login.test.tsx
+++ b/src/pages/login/__tests__/Login.test.tsx
@@ -66,13 +66,18 @@ describe('Login 페이지', () => {
   })
 
   it('로그인 성공 시 accessToken을 localStorage에 저장하고 /로 이동한다', async () => {
-    mockLogin.mockResolvedValue('real-token')
+    mockLogin.mockImplementation(async () => {
+      localStorage.setItem('accessToken', 'real-token')
+      localStorage.setItem('refreshToken', 'real-refresh-token')
+      return 'real-token'
+    })
     renderLogin()
     await userEvent.type(screen.getByLabelText('이메일'), 'user@test.com')
     await userEvent.type(screen.getByLabelText('비밀번호'), 'password123')
     await userEvent.click(screen.getByRole('button', { name: '로그인' }))
     await waitFor(() => {
       expect(localStorage.getItem('accessToken')).toBe('real-token')
+      expect(localStorage.getItem('refreshToken')).toBe('real-refresh-token')
       expect(mockNavigate).toHaveBeenCalledWith('/')
     })
   })

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -47,8 +47,7 @@ export function Login() {
 
     setLoading(true)
     try {
-      const token = await login(email, password)
-      localStorage.setItem('accessToken', token)
+      await login(email, password)
       const user = await getMe()
       loadUser(user)
       navigate('/')

--- a/src/pages/register/__tests__/Register.test.tsx
+++ b/src/pages/register/__tests__/Register.test.tsx
@@ -37,7 +37,11 @@ describe('Register 페이지', () => {
     vi.clearAllMocks()
     localStorage.clear()
     mockGetMe.mockResolvedValue({ id: '4', name: '새사용자', email: 'new@yanus.kr', team: 'BACKEND', role: 'MEMBER', online: true })
-    mockLogin.mockResolvedValue('mock-login-token')
+    mockLogin.mockImplementation(async () => {
+      localStorage.setItem('accessToken', 'mock-login-token')
+      localStorage.setItem('refreshToken', 'mock-refresh-token')
+      return 'mock-login-token'
+    })
   })
 
   it('이름, 이메일, 팀, 비밀번호 필드와 회원가입 버튼이 렌더링된다', () => {
@@ -82,6 +86,7 @@ describe('Register 페이지', () => {
     await userEvent.click(screen.getByRole('button', { name: '회원가입' }))
     await waitFor(() => {
       expect(localStorage.getItem('accessToken')).toBe('mock-login-token')
+      expect(localStorage.getItem('refreshToken')).toBe('mock-refresh-token')
       expect(mockNavigate).toHaveBeenCalledWith('/')
     })
   })

--- a/src/pages/register/index.tsx
+++ b/src/pages/register/index.tsx
@@ -93,8 +93,7 @@ export function Register() {
     try {
       const teamId = teamOptions.find((t) => t.name === team)?.id ?? 1
       await register({ name, email, password, teamId })
-      const token = await login(email, password)
-      localStorage.setItem('accessToken', token)
+      await login(email, password)
       const user = await getMe()
       loadUser(user)
       navigate('/')

--- a/src/shared/api/__tests__/baseClient.test.ts
+++ b/src/shared/api/__tests__/baseClient.test.ts
@@ -6,7 +6,10 @@ import { baseClient } from '../baseClient'
 const server = setupServer()
 
 beforeAll(() => server.listen())
-afterEach(() => server.resetHandlers())
+afterEach(() => {
+  server.resetHandlers()
+  localStorage.clear()
+})
 afterAll(() => server.close())
 
 describe('baseClient', () => {
@@ -40,6 +43,60 @@ describe('baseClient', () => {
       code: 'UNAUTHORIZED',
       message: '인증 실패',
     })
+  })
+
+  it('access token 만료 시 refresh로 재발급한 뒤 요청을 다시 수행한다', async () => {
+    localStorage.setItem('accessToken', 'expired-access-token')
+    localStorage.setItem('refreshToken', 'refresh-token')
+
+    server.use(
+      http.get('/test-refresh', ({ request }) => {
+        const authorization = request.headers.get('Authorization')
+        if (authorization === 'Bearer renewed-access-token') {
+          return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: { ok: true } })
+        }
+        return HttpResponse.json({ code: 'UNAUTHORIZED', message: 'access 만료', data: null }, { status: 401 })
+      }),
+      http.post('/api/v1/auth/refresh', async ({ request }) => {
+        const body = await request.json() as { refreshToken: string }
+        expect(body.refreshToken).toBe('refresh-token')
+        return HttpResponse.json({
+          code: 'SUCCESS',
+          message: 'ok',
+          data: {
+            accessToken: 'renewed-access-token',
+            refreshToken: 'renewed-refresh-token',
+            tokenType: 'Bearer',
+          },
+        })
+      }),
+    )
+
+    const result = await baseClient.get<{ ok: boolean }>('/test-refresh')
+    expect(result).toEqual({ ok: true })
+    expect(localStorage.getItem('accessToken')).toBe('renewed-access-token')
+    expect(localStorage.getItem('refreshToken')).toBe('renewed-refresh-token')
+  })
+
+  it('refresh token도 만료되면 토큰을 정리하고 ApiError를 던진다', async () => {
+    localStorage.setItem('accessToken', 'expired-access-token')
+    localStorage.setItem('refreshToken', 'expired-refresh-token')
+
+    server.use(
+      http.get('/test-refresh-expired', () =>
+        HttpResponse.json({ code: 'UNAUTHORIZED', message: 'access 만료', data: null }, { status: 401 }),
+      ),
+      http.post('/api/v1/auth/refresh', () =>
+        HttpResponse.json({ code: 'UNAUTHORIZED', message: 'refresh 만료', data: null }, { status: 401 }),
+      ),
+    )
+
+    await expect(baseClient.get('/test-refresh-expired')).rejects.toMatchObject({
+      status: 401,
+      code: 'UNAUTHORIZED',
+    })
+    expect(localStorage.getItem('accessToken')).toBeNull()
+    expect(localStorage.getItem('refreshToken')).toBeNull()
   })
 
   it('4xx 응답 시 ApiError를 던진다', async () => {

--- a/src/shared/api/baseClient.ts
+++ b/src/shared/api/baseClient.ts
@@ -1,4 +1,5 @@
 const BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? ''
+import { clearAuthTokens, getAccessToken, getRefreshToken, storeAuthTokens } from '../lib/authStorage'
 
 export class ApiError extends Error {
   status: number
@@ -12,17 +13,67 @@ export class ApiError extends Error {
 }
 
 function getAuthHeaders(): Record<string, string> {
-  const token = localStorage.getItem('accessToken')
+  const token = getAccessToken()
   return token ? { Authorization: `Bearer ${token}` } : {}
 }
 
 function handleUnauthorized() {
-  localStorage.removeItem('accessToken')
+  clearAuthTokens()
   window.location.href = '/login'
 }
 
-async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
-  const hasAuthToken = Boolean(localStorage.getItem('accessToken'))
+let refreshPromise: Promise<boolean> | null = null
+
+async function tryRefreshToken(): Promise<boolean> {
+  const refreshToken = getRefreshToken()
+  if (!refreshToken) return false
+
+  if (!refreshPromise) {
+    refreshPromise = (async () => {
+      try {
+        const res = await fetch(`${BASE_URL}/api/v1/auth/refresh`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ refreshToken }),
+        })
+
+        if (!res.ok) {
+          clearAuthTokens()
+          return false
+        }
+
+        const body = await res.json() as unknown
+        const data =
+          body !== null &&
+          typeof body === 'object' &&
+          'data' in body &&
+          'code' in body
+            ? (body as { data: { accessToken: string; refreshToken: string; tokenType: string } }).data
+            : body as { accessToken: string; refreshToken: string; tokenType: string }
+
+        if (!data?.accessToken || !data?.refreshToken) {
+          clearAuthTokens()
+          return false
+        }
+
+        storeAuthTokens(data)
+        return true
+      } catch {
+        clearAuthTokens()
+        return false
+      } finally {
+        refreshPromise = null
+      }
+    })()
+  }
+
+  return refreshPromise
+}
+
+async function request<T>(path: string, options: RequestInit = {}, canRetry = true): Promise<T> {
+  const hasAuthToken = Boolean(getAccessToken())
   const res = await fetch(`${BASE_URL}${path}`, {
     ...options,
     headers: {
@@ -42,7 +93,11 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
     } catch {
       // Ignore non-JSON error bodies and keep the fallback message.
     }
-    if (res.status === 401 && hasAuthToken) {
+    if (res.status === 401 && hasAuthToken && canRetry) {
+      const refreshed = await tryRefreshToken()
+      if (refreshed) {
+        return request<T>(path, options, false)
+      }
       handleUnauthorized()
     }
     throw new ApiError(res.status, message, code)
@@ -61,13 +116,17 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   return body as T
 }
 
-async function requestBlob(path: string): Promise<Blob> {
-  const hasAuthToken = Boolean(localStorage.getItem('accessToken'))
+async function requestBlob(path: string, canRetry = true): Promise<Blob> {
+  const hasAuthToken = Boolean(getAccessToken())
   const res = await fetch(`${BASE_URL}${path}`, {
     headers: getAuthHeaders(),
   })
   if (res.status === 401) {
-    if (hasAuthToken) {
+    if (hasAuthToken && canRetry) {
+      const refreshed = await tryRefreshToken()
+      if (refreshed) {
+        return requestBlob(path, false)
+      }
       handleUnauthorized()
     }
     throw new ApiError(401, '인증이 필요합니다', 'UNAUTHORIZED')
@@ -76,15 +135,19 @@ async function requestBlob(path: string): Promise<Blob> {
   return res.blob()
 }
 
-async function requestUpload<T>(path: string, formData: FormData): Promise<T> {
-  const hasAuthToken = Boolean(localStorage.getItem('accessToken'))
+async function requestUpload<T>(path: string, formData: FormData, canRetry = true): Promise<T> {
+  const hasAuthToken = Boolean(getAccessToken())
   const res = await fetch(`${BASE_URL}${path}`, {
     method: 'POST',
     headers: getAuthHeaders(), // Content-Type 미설정 → 브라우저가 multipart boundary 자동 지정
     body: formData,
   })
   if (res.status === 401) {
-    if (hasAuthToken) {
+    if (hasAuthToken && canRetry) {
+      const refreshed = await tryRefreshToken()
+      if (refreshed) {
+        return requestUpload<T>(path, formData, false)
+      }
       handleUnauthorized()
     }
     throw new ApiError(401, '인증이 필요합니다', 'UNAUTHORIZED')

--- a/src/shared/api/mock/handlers/auth.ts
+++ b/src/shared/api/mock/handlers/auth.ts
@@ -90,6 +90,30 @@ export const authHandlers = [
     return HttpResponse.json({ code: 'SUCCESS', message: 'created', data: null }, { status: 201 })
   }),
 
+  http.post('/api/v1/auth/refresh', async ({ request }) => {
+    const body = await request.json() as { refreshToken?: string }
+    const refreshToken = body.refreshToken ?? ''
+    const userId = refreshToken.replace('refresh-', '')
+    const member = mockUsers.find((user) => user.id === userId)
+
+    if (!member || member.status === 'INACTIVE') {
+      return HttpResponse.json(
+        { code: 'UNAUTHORIZED', message: '리프레시 토큰이 만료되었습니다', data: null },
+        { status: 401 },
+      )
+    }
+
+    return HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: {
+        accessToken: `mock-token-${member.id}`,
+        refreshToken: `refresh-${member.id}`,
+        tokenType: 'Bearer',
+      },
+    })
+  }),
+
   http.get('/api/v1/auth/me', ({ request }) => {
     const authorization = request.headers.get('Authorization')
     if (!authorization?.startsWith('Bearer ')) {

--- a/src/shared/lib/authStorage.ts
+++ b/src/shared/lib/authStorage.ts
@@ -1,0 +1,23 @@
+export interface AuthTokens {
+  accessToken: string
+  refreshToken: string
+  tokenType: string
+}
+
+export function getAccessToken() {
+  return localStorage.getItem('accessToken')
+}
+
+export function getRefreshToken() {
+  return localStorage.getItem('refreshToken')
+}
+
+export function storeAuthTokens(tokens: AuthTokens) {
+  localStorage.setItem('accessToken', tokens.accessToken)
+  localStorage.setItem('refreshToken', tokens.refreshToken)
+}
+
+export function clearAuthTokens() {
+  localStorage.removeItem('accessToken')
+  localStorage.removeItem('refreshToken')
+}


### PR DESCRIPTION
## 작업 내용
- access token 만료 시 refresh token으로 자동 재발급되도록 정리했습니다.
- refresh token까지 만료되면 저장된 토큰을 정리하고 로그인 화면으로 보내도록 처리했습니다.
- 로그인/회원가입 흐름에서 refresh token 저장을 함께 반영했습니다.
- 인증 관련 테스트를 보강해 재발급과 강제 로그아웃 시나리오를 검증했습니다.

## 테스트
- [x] `npm run test:run`
- [x] `npm run build`

## 관련 이슈
- close #188
