### PR TITLE
release: v0.1.13

### DIFF
--- a/src/pages/admin/admin.css
+++ b/src/pages/admin/admin.css
@@ -113,6 +113,7 @@
   width: 100%;
   border-collapse: collapse;
   min-width: 760px;
+  table-layout: fixed;
 }
 
 .admin-table-wrap {
@@ -136,6 +137,7 @@
   color: var(--text-primary);
   border-bottom: 1px solid rgba(255, 255, 255, 0.04);
   vertical-align: middle;
+  white-space: nowrap;
 }
 
 .admin-members-table tr:last-child td {
@@ -302,10 +304,11 @@
 .admin-role-tag.MEMBER    { background: rgba(100, 116, 139, 0.2); color: var(--text-secondary); }
 
 .admin-actions-cell {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(2, max-content);
   gap: 8px;
-  align-items: center;
-  flex-wrap: wrap;
+  align-items: start;
+  justify-content: start;
 }
 
 .admin-status-cell {
@@ -382,6 +385,36 @@
 
 .admin-action-btn.mute-btn:hover {
   background: rgba(234, 179, 8, 0.1);
+}
+
+.admin-members-table th:first-child,
+.admin-members-table td:first-child {
+  width: 180px;
+}
+
+.admin-members-table th:nth-child(2),
+.admin-members-table td:nth-child(2) {
+  width: 120px;
+}
+
+.admin-members-table th:nth-child(3),
+.admin-members-table td:nth-child(3) {
+  width: 120px;
+}
+
+.admin-members-table th:nth-child(4),
+.admin-members-table td:nth-child(4) {
+  width: 170px;
+}
+
+.admin-members-table th:last-child,
+.admin-members-table td:last-child {
+  width: 220px;
+}
+
+.admin-actions-cell .deactivate-btn {
+  grid-column: 1 / -1;
+  justify-self: start;
 }
 
 /* ── 역할 변경 모달 ── */
@@ -548,13 +581,17 @@
   }
 
   .admin-actions-cell {
-    flex-direction: column;
-    gap: 4px;
+    grid-template-columns: 1fr;
+    gap: 6px;
   }
 
   .admin-status-cell {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .admin-actions-cell .deactivate-btn {
+    grid-column: auto;
   }
 }
 

--- a/src/pages/attendance/attendance.css
+++ b/src/pages/attendance/attendance.css
@@ -183,6 +183,11 @@
   font-weight: 600;
 }
 
+.records-table td {
+  color: var(--text-primary);
+  font-size: 0.9rem;
+}
+
 .records-table tr.late {
   background: rgba(234, 179, 8, 0.12);
 }
@@ -232,6 +237,13 @@
 .status-badge.absent {
   background: rgba(239, 68, 68, 0.2);
   color: var(--error);
+}
+
+.records-empty {
+  text-align: center;
+  color: var(--text-secondary);
+  padding: 24px;
+  font-weight: 600;
 }
 
 .pagination {
@@ -284,6 +296,27 @@
 
 .stat-card .value.red {
   color: var(--error);
+}
+
+:root[data-theme='light'] .records-table th,
+:root[data-theme='light'] .records-table td {
+  border-bottom-color: rgba(84, 102, 146, 0.14);
+}
+
+:root[data-theme='light'] .records-table th {
+  color: #566684;
+}
+
+:root[data-theme='light'] .records-table td {
+  color: #1c2740;
+}
+
+:root[data-theme='light'] .records-empty {
+  color: #5f6f8d;
+}
+
+:root[data-theme='light'] .records-table tr.late {
+  background: rgba(234, 179, 8, 0.08);
 }
 
 @media (max-width: 1100px) {

--- a/src/pages/attendance/index.tsx
+++ b/src/pages/attendance/index.tsx
@@ -289,7 +289,7 @@ export function Attendance() {
               </thead>
               <tbody>
                 {myRecords.length === 0 ? (
-                  <tr><td colSpan={4} style={{ textAlign: 'center', color: 'var(--text-secondary)', padding: '24px' }}>기록이 없습니다</td></tr>
+                  <tr><td colSpan={4} className="records-empty">기록이 없습니다</td></tr>
                 ) : (
                   myRecords.map((r) => (
                     <tr key={r.id}>

--- a/src/pages/calendar/calendar.css
+++ b/src/pages/calendar/calendar.css
@@ -207,8 +207,18 @@
 }
 
 .fullcalendar-wrapper .fc-button {
+  background: var(--fc-button-bg-color);
+  border-color: var(--fc-button-border-color);
   color: var(--text-primary);
   text-transform: none;
+  box-shadow: none;
+}
+
+.fullcalendar-wrapper .fc-button:disabled {
+  opacity: 1;
+  background: color-mix(in srgb, var(--bg-card-solid) 88%, transparent);
+  border-color: var(--border-color);
+  color: var(--text-muted);
 }
 
 .fullcalendar-wrapper .fc-toolbar-title {
@@ -882,6 +892,12 @@
 
 :root[data-theme='light'] .fullcalendar-wrapper .fc {
   --fc-border-color: rgba(84, 102, 146, 0.14);
+  --fc-button-bg-color: rgba(255, 255, 255, 0.94);
+  --fc-button-border-color: rgba(107, 79, 196, 0.28);
+  --fc-button-hover-bg-color: rgba(107, 79, 196, 0.1);
+  --fc-button-hover-border-color: rgba(107, 79, 196, 0.38);
+  --fc-button-active-bg-color: rgba(107, 79, 196, 0.14);
+  --fc-button-active-border-color: rgba(107, 79, 196, 0.44);
   --fc-today-bg-color: rgba(107, 79, 196, 0.08);
 }
 
@@ -891,6 +907,28 @@
 
 :root[data-theme='light'] .fullcalendar-wrapper .fc-daygrid-day:hover {
   background: rgba(107, 79, 196, 0.04);
+}
+
+:root[data-theme='light'] .fullcalendar-wrapper .fc .fc-button-primary {
+  color: var(--text-primary);
+}
+
+:root[data-theme='light'] .fullcalendar-wrapper .fc .fc-button-primary:not(:disabled).fc-button-active,
+:root[data-theme='light'] .fullcalendar-wrapper .fc .fc-button-primary:not(:disabled):active {
+  color: var(--accent-purple-dark);
+}
+
+:root[data-theme='light'] .fullcalendar-wrapper .fc-button:disabled {
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--text-muted);
+}
+
+:root[data-theme='light'] .tasks-tabs span {
+  color: var(--text-secondary);
+}
+
+:root[data-theme='light'] .tasks-tabs span.active {
+  color: var(--accent-purple-dark);
 }
 
 :root[data-theme='light'] .add-task-time::-webkit-calendar-picker-indicator,

--- a/src/shared/ui/TimeInput/TimeInput.css
+++ b/src/shared/ui/TimeInput/TimeInput.css
@@ -2,13 +2,14 @@
   display: flex;
   align-items: center;
   gap: 4px;
+  min-width: 0;
 }
 
 .time-input-group {
   display: flex;
   align-items: center;
-  background: rgba(15, 13, 26, 0.5);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: var(--bg-input);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -32,6 +33,8 @@
   display: flex;
   flex-direction: column;
   padding-right: 4px;
+  border-left: 1px solid var(--border-color);
+  background: color-mix(in srgb, var(--bg-soft) 72%, transparent);
 }
 
 .time-input-arrows button {
@@ -48,4 +51,17 @@
   font-size: 1.2rem;
   font-weight: 600;
   color: var(--text-secondary);
+}
+
+:root[data-theme='light'] .time-input-group {
+  background: rgba(244, 247, 253, 0.98);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.72);
+}
+
+:root[data-theme='light'] .time-input-field {
+  color: var(--text-primary);
+}
+
+:root[data-theme='light'] .time-input-arrows {
+  background: rgba(107, 79, 196, 0.08);
 }


### PR DESCRIPTION
## 작업 내용
- `develop`에 반영된 라이트 모드 캘린더/표 시각 오류 수정 사항을 `main` 배포 브랜치로 승격합니다.
- 캘린더 버튼과 공용 시간 입력기의 라이트 모드 대비 개선이 포함됩니다.
- 관리자 멤버 표와 출퇴근 이력 표의 정렬 및 가독성 개선이 포함됩니다.

## 변경 이유
- 라이트 모드에서 일부 컴포넌트가 다크 스타일을 유지해 버튼과 숫자가 잘 보이지 않았습니다.
- 표 레이아웃이 어긋나고 빈 상태 문구가 흐리게 보여 사용자 경험이 떨어졌습니다.

## 상세 변경 사항
### 주요 변경
- [x] FullCalendar 버튼과 TimeInput 라이트 모드 색 대비 개선
- [x] 관리자 멤버 관리 표 액션 영역 정렬 안정화
- [x] 출퇴근 이력 표 헤더, 본문, 빈 상태 문구 가독성 개선

### 추가 메모
- `develop` PR: #194
- 관련 이슈: #193

## 테스트
- [x] `npm run test:run -- src/pages/admin/__tests__/Admin.test.tsx src/pages/attendance/__tests__/Attendance.test.tsx src/pages/members/__tests__/Members.test.tsx`
- [x] `npm run build`
- [ ] 브라우저에서 주요 동작 확인

## 리뷰 포인트
- 라이트 모드에서 캘린더 상단 버튼과 시간 입력 UI가 충분히 또렷한지 확인 부탁드립니다.
- 관리자 멤버 표 액션 버튼이 화면 폭이 줄어들어도 겹치지 않는지 확인 부탁드립니다.
- 출퇴근 이력의 빈 상태 문구와 표 텍스트 대비가 자연스러운지 확인 부탁드립니다.

## 관련 이슈
- #193
