### PR TITLE
[fix] #202 - 멤버 탭 비활성 멤버 숨김 처리

### DIFF
--- a/src/pages/members/__tests__/Members.test.tsx
+++ b/src/pages/members/__tests__/Members.test.tsx
@@ -43,8 +43,9 @@ describe('Members 페이지', () => {
     await waitFor(() => {
       expect(screen.getByText('김리더')).toBeInTheDocument()
       expect(screen.getByText('박팀장')).toBeInTheDocument()
-      expect(screen.getByText('비활성멤버')).toBeInTheDocument()
     })
+
+    expect(screen.queryByText('비활성멤버')).not.toBeInTheDocument()
   })
 
   it('관리자에게 관리 컬럼이 표시된다', () => {
@@ -65,6 +66,7 @@ describe('Members 페이지', () => {
     render(<Members />)
 
     expect(screen.getByText('비활성 멤버는 집계에서 제외됩니다.')).toBeInTheDocument()
+    expect(screen.getByText('전체 멤버 2명')).toBeInTheDocument()
     expect(screen.getByLabelText('1팀 활성 멤버 1명')).toBeInTheDocument()
     expect(screen.getByLabelText('2팀 활성 멤버 1명')).toBeInTheDocument()
   })

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -5,7 +5,7 @@ import { getMembers, updateMemberRole, deactivateMember, activateMember } from '
 import { getTeams } from '../../shared/api/teamsApi'
 import type { TeamResponse } from '../../shared/api/teamsApi'
 import type { UserRole } from '../../entities/user/model/types'
-import { FALLBACK_TEAMS, formatTeamName, getTeamOptions } from '../../shared/lib/team'
+import { FALLBACK_TEAMS, formatTeamName, getTeamOptions, sortTeams } from '../../shared/lib/team'
 import { Toast } from '../../shared/ui/Toast'
 import './members.css'
 
@@ -50,20 +50,22 @@ export function Members() {
       .catch((err) => setErrorMessage(err instanceof Error ? err.message : '멤버 목록을 불러오지 못했습니다'))
   }, [loadMembers])
 
-  const teamOptions = getTeamOptions(state.users, teams)
+  const visibleUsers = state.users.filter((user) => (user.status ?? 'ACTIVE') === 'ACTIVE')
+  const baseTeamOptions = getTeamOptions(visibleUsers, teams)
+  const activeTeamNames = new Set(visibleUsers.map((user) => user.team).filter((team): team is string => Boolean(team)))
+  const teamOptions = sortTeams(baseTeamOptions.filter((team) => activeTeamNames.has(team.name)))
 
-  const filtered = state.users.filter((user) => {
+  const filtered = visibleUsers.filter((user) => {
     const matchSearch = !search || user.name.toLowerCase().includes(search.toLowerCase())
     const matchTeam = teamFilter === '전체 팀' || user.team === teamFilter
     const matchRole = roleFilter === '전체 역할' || user.role === roleFilter
     return matchSearch && matchTeam && matchRole
   })
 
-  const activeUsers = state.users.filter((user) => (user.status ?? 'ACTIVE') === 'ACTIVE')
   const activeCountsByTeam = teamOptions.map((team) => ({
     id: team.id,
     name: team.name,
-    count: activeUsers.filter((user) => user.team === team.name).length,
+    count: visibleUsers.filter((user) => user.team === team.name).length,
   }))
   const maxActiveTeamCount = Math.max(...activeCountsByTeam.map((team) => team.count), 1)
 
@@ -189,7 +191,7 @@ export function Members() {
             ))}
           </div>
         </div>
-        <div className="total-members glass">전체 멤버 {state.users.length}명</div>
+        <div className="total-members glass">전체 멤버 {visibleUsers.length}명</div>
       </div>
 
       <div className="members-content">
@@ -291,9 +293,9 @@ export function Members() {
           <p className="stats-caption">비활성 멤버는 집계에서 제외됩니다.</p>
           <h3>역할 분포</h3>
           <div className="pie-legend">
-            <span><i style={{ background: 'var(--accent-purple)' }} /> 관리자 {state.users.filter((user) => user.role === 'ADMIN').length}</span>
-            <span><i style={{ background: 'var(--accent-blue, #72b8e8)' }} /> 팀장 {state.users.filter((user) => user.role === 'TEAM_LEAD').length}</span>
-            <span><i style={{ background: 'var(--text-secondary)' }} /> 멤버 {state.users.filter((user) => user.role === 'MEMBER').length}</span>
+            <span><i style={{ background: 'var(--accent-purple)' }} /> 관리자 {visibleUsers.filter((user) => user.role === 'ADMIN').length}</span>
+            <span><i style={{ background: 'var(--accent-blue, #72b8e8)' }} /> 팀장 {visibleUsers.filter((user) => user.role === 'TEAM_LEAD').length}</span>
+            <span><i style={{ background: 'var(--text-secondary)' }} /> 멤버 {visibleUsers.filter((user) => user.role === 'MEMBER').length}</span>
           </div>
         </aside>
       </div>


### PR DESCRIPTION
## 작업 내용
- 멤버 탭에서는 활성 멤버만 보이도록 목록 필터 기준을 정리했습니다.
- 총 멤버 수와 역할 분포, 팀별 집계도 보이는 멤버 기준으로 맞췄습니다.
- 비활성 멤버가 보이지 않는지 테스트를 보강했습니다.

## 테스트
- [x] npm run test:run -- src/pages/members/__tests__/Members.test.tsx src/pages/admin/__tests__/Admin.test.tsx
- [x] npm run build

## 관련 이슈
- Closes #202