### PR TITLE
[fix] #207 - 멤버 목록 정렬 기준 통일

### DIFF
--- a/src/pages/admin/__tests__/Admin.test.tsx
+++ b/src/pages/admin/__tests__/Admin.test.tsx
@@ -8,15 +8,17 @@ import { AppProvider } from '../../../features/auth/model'
 import { Admin } from '../index'
 
 const mockMembers = [
-  { id: '1', name: '김민준', email: 'min@yanus.kr', team: '1팀', role: 'MEMBER', status: 'ACTIVE' },
-  { id: '2', name: '이서연', email: 'seo@yanus.kr', team: '2팀', role: 'TEAM_LEAD', status: 'ACTIVE' },
+  { id: '1', name: '이서연', email: 'seo@yanus.kr', team: '2팀', role: 'TEAM_LEAD', status: 'ACTIVE' },
+  { id: '2', name: '강민준', email: 'kang@yanus.kr', team: '1팀', role: 'MEMBER', status: 'ACTIVE' },
+  { id: '3', name: '김민준', email: 'min@yanus.kr', team: '1팀', role: 'MEMBER', status: 'ACTIVE' },
+  { id: '4', name: '한비활성', email: 'inactive@yanus.kr', team: '1팀', role: 'MEMBER', status: 'INACTIVE' },
 ]
 
 const mockRecords = [
   {
     id: 1,
     memberId: 1,
-    memberName: '김민준',
+    memberName: '이서연',
     workDate: '2026-03-23',
     checkInTime: '2026-03-23T09:00:00',
     checkOutTime: null,
@@ -93,6 +95,28 @@ describe('Admin 페이지', () => {
     expect(screen.getAllByRole('button', { name: '비활성화' }).length).toBeGreaterThan(0)
   })
 
+  it('멤버 목록은 팀 순, 이름 순이며 비활성 멤버는 마지막에 표시된다', async () => {
+    const user = userEvent.setup()
+    renderAdmin()
+    await user.click(screen.getByRole('button', { name: '멤버 관리' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('강민준')).toBeInTheDocument()
+      expect(screen.getByText('김민준')).toBeInTheDocument()
+      expect(screen.getByText('이서연')).toBeInTheDocument()
+      expect(screen.getByText('한비활성')).toBeInTheDocument()
+    })
+
+    const activeFirst = screen.getByText('강민준')
+    const activeSecond = screen.getByText('김민준')
+    const otherTeam = screen.getByText('이서연')
+    const inactiveLast = screen.getByText('한비활성')
+
+    expect(activeFirst.compareDocumentPosition(activeSecond) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(activeSecond.compareDocumentPosition(otherTeam) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(otherTeam.compareDocumentPosition(inactiveLast) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
   it('출근 현황 탭에 요약 카운트가 표시된다', async () => {
     renderAdmin()
     await waitFor(() => {
@@ -105,8 +129,8 @@ describe('Admin 페이지', () => {
   it('출근 현황 탭 기본 필터(근무 중)에 근무 중인 팀원만 표시된다', async () => {
     renderAdmin()
     await waitFor(() => {
-      expect(screen.getByText('김민준')).toBeInTheDocument()
+      expect(screen.getByText('이서연')).toBeInTheDocument()
     })
-    expect(screen.queryByText('이서연')).not.toBeInTheDocument()
+    expect(screen.queryByText('김민준')).not.toBeInTheDocument()
   })
 })

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -11,7 +11,7 @@ import { Toast } from '../../shared/ui/Toast'
 import { getTodayStr } from '../../shared/lib/date'
 import { createTeam, deleteTeam, getTeams } from '../../shared/api/teamsApi'
 import type { TeamResponse } from '../../shared/api/teamsApi'
-import { FALLBACK_TEAMS, formatTeamName, getTeamOptions, sortTeams } from '../../shared/lib/team'
+import { FALLBACK_TEAMS, formatTeamName, getTeamOptions, sortTeams, sortUsersByTeamAndName } from '../../shared/lib/team'
 import './admin.css'
 
 type Tab = 'attendance' | 'members' | 'teams'
@@ -53,8 +53,9 @@ export function Admin() {
       getTeams().catch(() => FALLBACK_TEAMS),
     ])
       .then(([memberList, attendanceList, teamList]) => {
-        setMembers(memberList)
-        loadMembers(memberList)
+        const sortedMembers = sortUsersByTeamAndName(memberList)
+        setMembers(sortedMembers)
+        loadMembers(sortedMembers)
         setRecords(attendanceList)
         setTeams(sortTeams(teamList))
       })
@@ -66,8 +67,9 @@ export function Admin() {
       getMembers(),
       getTeams().catch(() => FALLBACK_TEAMS),
     ])
-    setMembers(memberList)
-    loadMembers(memberList)
+    const sortedMembers = sortUsersByTeamAndName(memberList)
+    setMembers(sortedMembers)
+    loadMembers(sortedMembers)
     setTeams(sortTeams(teamList))
   }
 
@@ -82,9 +84,9 @@ export function Admin() {
     setSaving(true)
     try {
       await updateMemberRole(changeRoleFor.id, selectedRole)
-      const updated = members.map((member) =>
+      const updated = sortUsersByTeamAndName(members.map((member) =>
         member.id === changeRoleFor.id ? { ...member, role: selectedRole } : member,
-      )
+      ))
       setMembers(updated)
       loadMembers(updated)
       setSuccessMessage(`${changeRoleFor.name}의 역할을 ${roleLabels[selectedRole]}로 변경했습니다`)

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -5,7 +5,7 @@ import { getMembers, updateMemberRole, deactivateMember, activateMember } from '
 import { getTeams } from '../../shared/api/teamsApi'
 import type { TeamResponse } from '../../shared/api/teamsApi'
 import type { UserRole } from '../../entities/user/model/types'
-import { FALLBACK_TEAMS, formatTeamName, getTeamOptions, sortTeams } from '../../shared/lib/team'
+import { FALLBACK_TEAMS, formatTeamName, getTeamOptions, sortTeams, sortUsersByTeamAndName } from '../../shared/lib/team'
 import { Toast } from '../../shared/ui/Toast'
 import './members.css'
 
@@ -50,7 +50,9 @@ export function Members() {
       .catch((err) => setErrorMessage(err instanceof Error ? err.message : '멤버 목록을 불러오지 못했습니다'))
   }, [loadMembers])
 
-  const visibleUsers = state.users.filter((user) => (user.status ?? 'ACTIVE') === 'ACTIVE')
+  const visibleUsers = sortUsersByTeamAndName(
+    state.users.filter((user) => (user.status ?? 'ACTIVE') === 'ACTIVE'),
+  )
   const baseTeamOptions = getTeamOptions(visibleUsers, teams)
   const activeTeamNames = new Set(visibleUsers.map((user) => user.team).filter((team): team is string => Boolean(team)))
   const teamOptions = sortTeams(baseTeamOptions.filter((team) => activeTeamNames.has(team.name)))

--- a/src/pages/team-management/index.tsx
+++ b/src/pages/team-management/index.tsx
@@ -5,7 +5,7 @@ import type { User } from '../../entities/user/model/types'
 import { getMembers, updateMemberTeam } from '../../shared/api/membersApi'
 import { getTeams } from '../../shared/api/teamsApi'
 import type { TeamResponse } from '../../shared/api/teamsApi'
-import { FALLBACK_TEAMS, formatTeamName, sortTeams } from '../../shared/lib/team'
+import { FALLBACK_TEAMS, formatTeamName, sortTeams, sortUsersByTeamAndName } from '../../shared/lib/team'
 import { Toast } from '../../shared/ui/Toast'
 import './team-management.css'
 
@@ -41,7 +41,7 @@ export function TeamManagement() {
         getMembers({ teamName: currentTeam }),
         getTeams().catch(() => FALLBACK_TEAMS),
       ])
-      setMembers(memberList)
+      setMembers(sortUsersByTeamAndName(memberList))
       setTeams(sortTeams(teamList))
       loadMembers(memberList)
     } catch (err) {
@@ -54,7 +54,7 @@ export function TeamManagement() {
   }, [currentTeam])
 
   const filteredMembers = useMemo(() => (
-    members.filter((member) => {
+    sortUsersByTeamAndName(members).filter((member) => {
       if (!search.trim()) return true
       const keyword = search.trim().toLowerCase()
       return member.name.toLowerCase().includes(keyword) || member.email.toLowerCase().includes(keyword)

--- a/src/shared/lib/__tests__/team.test.ts
+++ b/src/shared/lib/__tests__/team.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { sortUsersByTeamAndName } from '../team'
+
+describe('sortUsersByTeamAndName', () => {
+  it('활성 멤버를 팀 순, 이름 순으로 정렬하고 비활성 멤버는 마지막으로 보낸다', () => {
+    const sorted = sortUsersByTeamAndName([
+      { id: '1', name: '이서연', email: 'seo@test.com', team: '2팀', role: 'TEAM_LEAD', status: 'ACTIVE' },
+      { id: '2', name: '한비활성', email: 'inactive@test.com', team: '1팀', role: 'MEMBER', status: 'INACTIVE' },
+      { id: '3', name: '김민준', email: 'kim@test.com', team: '1팀', role: 'MEMBER', status: 'ACTIVE' },
+      { id: '4', name: '강민준', email: 'kang@test.com', team: '1팀', role: 'MEMBER', status: 'ACTIVE' },
+    ])
+
+    expect(sorted.map((user) => user.name)).toEqual(['강민준', '김민준', '이서연', '한비활성'])
+  })
+})

--- a/src/shared/lib/team.ts
+++ b/src/shared/lib/team.ts
@@ -17,6 +17,28 @@ export function sortTeams<T extends { name: string }>(teams: T[]) {
   return [...teams].sort((left, right) => left.name.localeCompare(right.name, 'ko-KR', { numeric: true }))
 }
 
+function compareTeamName(left?: string | null, right?: string | null) {
+  return formatTeamName(left).localeCompare(formatTeamName(right), 'ko-KR', { numeric: true })
+}
+
+export function sortUsersByTeamAndName<T extends User>(users: T[]) {
+  return [...users].sort((left, right) => {
+    const leftInactive = (left.status ?? 'ACTIVE') === 'INACTIVE'
+    const rightInactive = (right.status ?? 'ACTIVE') === 'INACTIVE'
+
+    if (leftInactive !== rightInactive) {
+      return leftInactive ? 1 : -1
+    }
+
+    const teamCompare = compareTeamName(left.team, right.team)
+    if (teamCompare !== 0) {
+      return teamCompare
+    }
+
+    return left.name.localeCompare(right.name, 'ko-KR', { numeric: true })
+  })
+}
+
 export function getTeamOptions(users: User[], teams: TeamResponse[]) {
   if (teams.length > 0) {
     return sortTeams(teams)


### PR DESCRIPTION
## 작업 내용
- 멤버 관련 목록 정렬을 활성 우선, 팀 순, 이름 순 기준으로 통일했습니다.
- 비활성 멤버는 항상 마지막에 보이도록 공통 정렬 함수를 추가했습니다.
- 관리자, 멤버, 팀 관리 화면과 회귀 테스트를 함께 정리했습니다.

## 테스트
- [x] npm run test:run -- src/shared/lib/__tests__/team.test.ts src/pages/admin/__tests__/Admin.test.tsx src/pages/members/__tests__/Members.test.tsx src/pages/team-management/__tests__/TeamManagement.test.tsx
- [x] npm run build

## 관련 이슈
- Closes #207