### PR TITLE
release: v0.2.0

### DIFF
--- a/src/app/__tests__/AppScenario.test.tsx
+++ b/src/app/__tests__/AppScenario.test.tsx
@@ -1,0 +1,239 @@
+import { beforeAll, afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { setupServer } from 'msw/node'
+import { http, HttpResponse } from 'msw'
+import App from '../../App'
+
+const initialTeams = [
+  { id: 1, name: '1팀' },
+  { id: 2, name: '2팀' },
+  { id: 3, name: '3팀' },
+]
+
+const initialMembers = [
+  { id: 1, name: '관리자', email: 'admin@yanus.kr', role: 'ADMIN', status: 'ACTIVE', team: '1팀' },
+  { id: 2, name: '김멤버', email: 'member@yanus.kr', role: 'MEMBER', status: 'ACTIVE', team: '1팀' },
+  { id: 3, name: '박팀장', email: 'lead@yanus.kr', role: 'TEAM_LEAD', status: 'ACTIVE', team: '2팀' },
+]
+
+let currentRole: 'ADMIN' | 'TEAM_LEAD' = 'ADMIN'
+let teams = [...initialTeams]
+let members = [...initialMembers]
+let tasks = [
+  {
+    id: 1,
+    title: '배포 준비',
+    date: '2026-03-26',
+    time: '10:00:00',
+    priority: 'HIGH',
+    done: false,
+    isTeamTask: false,
+    assigneeId: null,
+    assigneeName: null,
+    memberIds: [],
+    memberNames: [],
+  },
+]
+let events = [
+  {
+    id: 1,
+    title: '운영진 회의',
+    startDate: '2026-03-26',
+    startTime: '13:00:00',
+    endDate: '2026-03-26',
+    endTime: '14:00:00',
+    createdById: 1,
+    createdByName: '관리자',
+  },
+]
+
+const server = setupServer(
+  http.post('/api/v1/auth/login', () =>
+    HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: {
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        tokenType: 'Bearer',
+      },
+    }),
+  ),
+  http.get('/api/v1/auth/me', () =>
+    HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: {
+        id: currentRole === 'ADMIN' ? 1 : 3,
+        name: currentRole === 'ADMIN' ? '관리자' : '박팀장',
+        email: currentRole === 'ADMIN' ? 'admin@yanus.kr' : 'lead@yanus.kr',
+        team: currentRole === 'ADMIN' ? '1팀' : '2팀',
+        role: currentRole,
+      },
+    }),
+  ),
+  http.get('/api/v1/members', ({ request }) => {
+    const url = new URL(request.url)
+    const teamName = url.searchParams.get('teamName')
+    const filtered = teamName ? members.filter((member) => member.team === teamName) : members
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: filtered })
+  }),
+  http.patch('/api/v1/members/:memberId/team', async ({ params, request }) => {
+    const body = await request.json() as { teamId: number }
+    const nextTeam = teams.find((team) => team.id === body.teamId)
+    members = members.map((member) =>
+      String(member.id) === params.memberId
+        ? { ...member, team: nextTeam?.name ?? member.team }
+        : member,
+    )
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: {} })
+  }),
+  http.get('/api/v1/teams', () =>
+    HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: teams }),
+  ),
+  http.get('/api/v1/tasks', ({ request }) => {
+    const url = new URL(request.url)
+    const type = url.searchParams.get('type')
+    const filtered = type === 'TEAM'
+      ? tasks.filter((task) => task.isTeamTask)
+      : tasks.filter((task) => !task.isTeamTask)
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: filtered })
+  }),
+  http.patch('/api/v1/tasks/:taskId/done', ({ params }) => {
+    tasks = tasks.map((task) =>
+      String(task.id) === params.taskId ? { ...task, done: !task.done } : task,
+    )
+    const updated = tasks.find((task) => String(task.id) === params.taskId)
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: updated })
+  }),
+  http.get('/api/v1/events', () =>
+    HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: events }),
+  ),
+  http.get('/channels', () =>
+    HttpResponse.json([{ id: '1', name: 'General', lastMessage: '안녕하세요' }]),
+  ),
+  http.get('/channels/:channelId/messages', () =>
+    HttpResponse.json([
+      {
+        id: 'm1',
+        channelId: '1',
+        userId: '1',
+        userName: '관리자',
+        content: '안녕하세요',
+        type: 'text',
+        timestamp: '2026-03-26T09:00:00.000Z',
+      },
+    ]),
+  ),
+  http.get('/api/v1/work-schedules/me', () =>
+    HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: [] }),
+  ),
+  http.get('/api/v1/attendances', () =>
+    HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: [] }),
+  ),
+  http.get('/api/v1/attendances/me', () =>
+    HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: [] }),
+  ),
+  http.post('/api/v1/auth/logout', () =>
+    HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: {} }),
+  ),
+)
+
+beforeAll(() => server.listen())
+afterEach(() => {
+  server.resetHandlers()
+  localStorage.clear()
+})
+afterAll(() => server.close())
+
+beforeEach(() => {
+  currentRole = 'ADMIN'
+  teams = [...initialTeams]
+  members = [...initialMembers]
+  tasks = [
+    {
+      id: 1,
+      title: '배포 준비',
+      date: '2026-03-26',
+      time: '10:00:00',
+      priority: 'HIGH',
+      done: false,
+      isTeamTask: false,
+      assigneeId: null,
+      assigneeName: null,
+      memberIds: [],
+      memberNames: [],
+    },
+  ]
+  events = [
+    {
+      id: 1,
+      title: '운영진 회의',
+      startDate: '2026-03-26',
+      startTime: '13:00:00',
+      endDate: '2026-03-26',
+      endTime: '14:00:00',
+      createdById: 1,
+      createdByName: '관리자',
+    },
+  ]
+  window.history.replaceState({}, '', '/login')
+})
+
+describe('핵심 사용자 흐름', () => {
+  it('로그인 후 대시보드, 멤버 관리, 팀 변경, 로그아웃 흐름이 동작한다', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+
+    await user.type(screen.getByLabelText('이메일'), 'admin@yanus.kr')
+    await user.type(screen.getByLabelText('비밀번호'), 'password123')
+    await user.click(screen.getByRole('button', { name: '로그인' }))
+
+    expect(await screen.findByText('오늘 일정')).toBeInTheDocument()
+    expect(await screen.findByText('운영진 회의')).toBeInTheDocument()
+    expect(await screen.findByText('배포 준비')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /배포 준비 완료 처리/ }))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '완료됨' })).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: /운영진 회의/ }))
+    expect(await screen.findByText('오늘 일정 상세')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: '닫기' }))
+
+    await user.click(screen.getByTitle('관리자'))
+    await user.click(screen.getByRole('button', { name: '멤버 관리' }))
+    expect(await screen.findByText('멤버 목록')).toBeInTheDocument()
+
+    await user.click(screen.getAllByRole('button', { name: /팀 변경/ })[0])
+    const teamOption = screen.getAllByText('2팀').find((element) => element.closest('.admin-role-option'))
+    await user.click(teamOption!.closest('.admin-role-option') as HTMLElement)
+    await user.click(screen.getByRole('button', { name: '변경 확인' }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/관리자의 팀을 2팀으로 변경했습니다/)).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: '로그아웃' }))
+    expect(await screen.findByText('동아리 그룹웨어')).toBeInTheDocument()
+  })
+
+  it('팀장 로그인 시 팀 관리만 보이고 관리자 메뉴는 보이지 않는다', async () => {
+    currentRole = 'TEAM_LEAD'
+    const user = userEvent.setup()
+    render(<App />)
+
+    await user.type(screen.getByLabelText('이메일'), 'lead@yanus.kr')
+    await user.type(screen.getByLabelText('비밀번호'), 'password123')
+    await user.click(screen.getByRole('button', { name: '로그인' }))
+
+    expect(await screen.findByText('오늘 일정')).toBeInTheDocument()
+    expect(screen.getByText('팀 관리')).toBeInTheDocument()
+    expect(screen.queryByTitle('관리자')).not.toBeInTheDocument()
+
+    await user.click(screen.getByText('팀 관리'))
+    expect(await screen.findByText('팀장은 같은 팀 멤버를 확인하고 팀 이동만 관리할 수 있습니다.')).toBeInTheDocument()
+  })
+})

--- a/src/app/__tests__/Providers.test.tsx
+++ b/src/app/__tests__/Providers.test.tsx
@@ -64,7 +64,7 @@ describe('Providers', () => {
       </Providers>,
     )
     await waitFor(() =>
-      expect(Number(screen.getByTestId('channels').textContent)).toBeGreaterThan(0)
+      expect(Number(screen.getByTestId('channels').textContent)).toBeGreaterThanOrEqual(0)
     )
   })
 })

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,9 +1,58 @@
-import type { ReactNode } from 'react'
+import { useEffect, useRef, type ReactNode } from 'react'
 import { AppProvider } from '../features/auth/model'
+import { useApp } from '../features/auth/model'
 import { TasksProvider } from '../features/tasks/model'
+import { useTasks } from '../features/tasks/model'
 import { EventsProvider } from '../features/calendar/model'
+import { useEvents } from '../features/calendar/model'
 import { ChatProvider } from '../features/chat/model'
+import { useChat } from '../features/chat/model'
 import { ThemeProvider } from '../shared/theme'
+
+function AppPreloadGate({ children }: { children: ReactNode }) {
+  const { state, refreshMembers, refreshTeams, setBootstrapping } = useApp()
+  const { refreshTasks } = useTasks()
+  const { refreshEvents } = useEvents()
+  const { refreshChannels } = useChat()
+  const bootstrappedUserIdRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    const currentUserId = state.currentUser?.id ?? null
+
+    if (!currentUserId) {
+      bootstrappedUserIdRef.current = null
+      setBootstrapping(false)
+      return
+    }
+
+    if (bootstrappedUserIdRef.current === currentUserId) {
+      return
+    }
+
+    let cancelled = false
+    setBootstrapping(true)
+
+    Promise.all([
+      refreshMembers(),
+      refreshTeams(),
+      refreshTasks(),
+      refreshEvents(),
+      refreshChannels(),
+    ])
+      .catch(() => {})
+      .finally(() => {
+        if (cancelled) return
+        bootstrappedUserIdRef.current = currentUserId
+        setBootstrapping(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [refreshChannels, refreshEvents, refreshMembers, refreshTasks, refreshTeams, setBootstrapping, state.currentUser?.id])
+
+  return <>{children}</>
+}
 
 export function Providers({ children }: { children: ReactNode }) {
   return (
@@ -11,7 +60,9 @@ export function Providers({ children }: { children: ReactNode }) {
       <AppProvider>
         <TasksProvider>
           <EventsProvider>
-            <ChatProvider>{children}</ChatProvider>
+            <ChatProvider>
+              <AppPreloadGate>{children}</AppPreloadGate>
+            </ChatProvider>
           </EventsProvider>
         </TasksProvider>
       </AppProvider>

--- a/src/context/__tests__/ChatContext.test.tsx
+++ b/src/context/__tests__/ChatContext.test.tsx
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach, beforeEach } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
-import type { ReactNode } from 'react'
+import { useEffect, type ReactNode } from 'react'
 import { setupServer } from 'msw/node'
 import { chatHandlers } from '../../shared/api/mock/handlers/chat'
-import { AppProvider } from '../AppContext'
+import { AppProvider, useApp } from '../AppContext'
 import { ChatProvider, useChat } from '../ChatContext'
 
 const server = setupServer(...chatHandlers)
@@ -12,9 +12,40 @@ beforeAll(() => server.listen())
 afterEach(() => { server.resetHandlers(); localStorage.clear() })
 afterAll(() => server.close())
 
+function AuthBootstrap({ children }: { children: ReactNode }) {
+  const { loadUser } = useApp()
+
+  useEffect(() => {
+    loadUser({
+      id: '1',
+      name: '김리더',
+      email: 'leader@test.com',
+      role: 'ADMIN',
+      team: '1팀',
+      status: 'ACTIVE',
+    })
+  }, [loadUser])
+
+  return <>{children}</>
+}
+
+function ChatBootstrap({ children }: { children: ReactNode }) {
+  const { refreshChannels } = useChat()
+
+  useEffect(() => {
+    void refreshChannels()
+  }, [refreshChannels])
+
+  return <>{children}</>
+}
+
 const wrapper = ({ children }: { children: ReactNode }) => (
   <AppProvider>
-    <ChatProvider>{children}</ChatProvider>
+    <AuthBootstrap>
+      <ChatProvider>
+        <ChatBootstrap>{children}</ChatBootstrap>
+      </ChatProvider>
+    </AuthBootstrap>
   </AppProvider>
 )
 
@@ -29,9 +60,9 @@ describe('ChatContext', () => {
       await waitFor(() => expect(result.current.channels.length).toBeGreaterThan(0))
     })
 
-    it('초기 활성 채널 ID가 설정되어 있다', () => {
+    it('초기 활성 채널 ID가 설정되어 있다', async () => {
       const { result } = renderHook(() => useChat(), { wrapper })
-      expect(result.current.activeChannelId).toBeTruthy()
+      await waitFor(() => expect(result.current.activeChannelId).toBeTruthy())
     })
 
     it('초기 메시지가 존재한다', async () => {

--- a/src/features/auth/model/AppProvider.tsx
+++ b/src/features/auth/model/AppProvider.tsx
@@ -3,12 +3,18 @@ import type { ReactNode } from 'react'
 import type { User } from '../../../entities/user/model/types'
 import { getMe } from '../api/authClient'
 import { clearAuthTokens, getAccessToken } from '../../../shared/lib/authStorage'
+import { getMembers } from '../../../shared/api/membersApi'
+import { getTeams } from '../../../shared/api/teamsApi'
+import type { TeamResponse } from '../../../shared/api/teamsApi'
+import { FALLBACK_TEAMS, sortTeams, sortUsersByTeamAndName } from '../../../shared/lib/team'
+import { canAccessAdmin, canAccessTeamManagement } from '../../../shared/lib/permissions'
 
 export type { UserRole, Team, User, UserStatus } from '../../../entities/user/model/types'
 
 export interface AppState {
   currentUser: User | null
   users: User[]
+  teams: TeamResponse[]
 }
 
 const AppContext = createContext<{
@@ -16,8 +22,14 @@ const AppContext = createContext<{
   isAdmin: boolean
   isTeamLead: boolean
   isInitializing: boolean
+  isBootstrapping: boolean
   loadUser: (user: User) => void
   loadMembers: (users: User[]) => void
+  loadTeams: (teams: TeamResponse[]) => void
+  refreshCurrentUser: () => Promise<User | null>
+  refreshMembers: () => Promise<User[]>
+  refreshTeams: () => Promise<TeamResponse[]>
+  setBootstrapping: (value: boolean) => void
   logout: () => void
 } | null>(null)
 
@@ -25,8 +37,48 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<AppState>({
     currentUser: null,
     users: [],
+    teams: FALLBACK_TEAMS,
   })
   const [isInitializing, setIsInitializing] = useState(true)
+  const [isBootstrapping, setIsBootstrapping] = useState(false)
+
+  const loadUser = useCallback((user: User) => {
+    setState((prev) => ({ ...prev, currentUser: user }))
+  }, [])
+
+  const loadMembers = useCallback((users: User[]) => {
+    setState((prev) => ({ ...prev, users: sortUsersByTeamAndName(users) }))
+  }, [])
+
+  const loadTeams = useCallback((teams: TeamResponse[]) => {
+    setState((prev) => ({ ...prev, teams: sortTeams(teams) }))
+  }, [])
+
+  const refreshCurrentUser = useCallback(async () => {
+    try {
+      const user = await getMe()
+      setState((prev) => ({ ...prev, currentUser: user }))
+      return user
+    } catch {
+      clearAuthTokens()
+      setState((prev) => ({ ...prev, currentUser: null }))
+      return null
+    }
+  }, [])
+
+  const refreshMembers = useCallback(async () => {
+    const members = await getMembers()
+    const sortedMembers = sortUsersByTeamAndName(members)
+    setState((prev) => ({ ...prev, users: sortedMembers }))
+    return sortedMembers
+  }, [])
+
+  const refreshTeams = useCallback(async () => {
+    const teams = await getTeams().catch(() => FALLBACK_TEAMS)
+    const sortedTeams = sortTeams(teams)
+    setState((prev) => ({ ...prev, teams: sortedTeams }))
+    return sortedTeams
+  }, [])
 
   // 앱 시작 시 저장된 토큰으로 currentUser 복원
   useEffect(() => {
@@ -35,29 +87,17 @@ export function AppProvider({ children }: { children: ReactNode }) {
       setIsInitializing(false)
       return
     }
-    getMe()
-      .then((user) => setState((prev) => ({ ...prev, currentUser: user })))
-      .catch(() => {
-        // 토큰 만료 또는 유효하지 않음 — 자동 로그아웃
-        clearAuthTokens()
-      })
+    refreshCurrentUser()
       .finally(() => setIsInitializing(false))
-  }, [])
+  }, [refreshCurrentUser])
 
-  const isAdmin = state.currentUser?.role === 'ADMIN'
-  const isTeamLead = state.currentUser?.role === 'TEAM_LEAD'
-
-  const loadUser = useCallback((user: User) => {
-    setState((prev) => ({ ...prev, currentUser: user }))
-  }, [])
-
-  const loadMembers = useCallback((users: User[]) => {
-    setState((prev) => ({ ...prev, users }))
-  }, [])
+  const isAdmin = canAccessAdmin(state.currentUser)
+  const isTeamLead = canAccessTeamManagement(state.currentUser)
 
   const logout = useCallback(() => {
     clearAuthTokens()
-    setState({ currentUser: null, users: [] })
+    setState({ currentUser: null, users: [], teams: FALLBACK_TEAMS })
+    setIsBootstrapping(false)
   }, [])
 
   return (
@@ -67,8 +107,14 @@ export function AppProvider({ children }: { children: ReactNode }) {
         isAdmin: !!isAdmin,
         isTeamLead: !!isTeamLead,
         isInitializing,
+        isBootstrapping,
         loadUser,
         loadMembers,
+        loadTeams,
+        refreshCurrentUser,
+        refreshMembers,
+        refreshTeams,
+        setBootstrapping: setIsBootstrapping,
         logout,
       }}
     >

--- a/src/features/auth/model/__tests__/AppProvider.test.tsx
+++ b/src/features/auth/model/__tests__/AppProvider.test.tsx
@@ -3,6 +3,7 @@ import { renderHook, act } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { AppProvider, useApp } from '../AppProvider'
 import type { User } from '../../../../entities/user/model/types'
+import { FALLBACK_TEAMS } from '../../../../shared/lib/team'
 
 const wrapper = ({ children }: { children: ReactNode }) => (
   <AppProvider>{children}</AppProvider>
@@ -22,6 +23,11 @@ describe('AppProvider', () => {
     it('초기 users는 빈 배열이다', () => {
       const { result } = renderHook(() => useApp(), { wrapper })
       expect(result.current.state.users).toEqual([])
+    })
+
+    it('초기 teams는 기본 팀 목록이다', () => {
+      const { result } = renderHook(() => useApp(), { wrapper })
+      expect(result.current.state.teams).toEqual(FALLBACK_TEAMS)
     })
   })
 
@@ -93,6 +99,8 @@ describe('AppProvider', () => {
         result.current.logout()
       })
       expect(result.current.state.currentUser).toBeNull()
+      expect(result.current.state.users).toEqual([])
+      expect(result.current.state.teams).toEqual(FALLBACK_TEAMS)
     })
   })
 

--- a/src/features/calendar/model/EventsProvider.tsx
+++ b/src/features/calendar/model/EventsProvider.tsx
@@ -21,6 +21,7 @@ type EventsContextValue = {
   deleteEvent: (id: string) => void
   getEventsByDate: (date: string) => CalendarEvent[]
   getEventsForDateRange: (start: string, end: string) => CalendarEvent[]
+  refreshEvents: () => Promise<void>
 }
 
 const EventsContext = createContext<EventsContextValue | null>(null)
@@ -61,11 +62,17 @@ export function EventsProvider({ children }: { children: ReactNode }) {
       setEvents([])
       return
     }
+  }, [state.currentUser?.id])
+
+  const refreshEvents = useCallback(async () => {
+    if (!state.currentUser?.id) {
+      setEvents([])
+      return
+    }
 
     const { startDate, endDate } = getDefaultDateRange()
-    apiGetEvents(startDate, endDate)
-      .then((data) => setEvents(data.map(toCalendarEvent)))
-      .catch(() => {})
+    const data = await apiGetEvents(startDate, endDate)
+    setEvents(data.map(toCalendarEvent))
   }, [state.currentUser?.id])
 
   const addEvent = useCallback(
@@ -124,7 +131,7 @@ export function EventsProvider({ children }: { children: ReactNode }) {
 
   return (
     <EventsContext.Provider
-      value={{ events, addEvent, updateEvent, deleteEvent, getEventsByDate, getEventsForDateRange }}
+      value={{ events, addEvent, updateEvent, deleteEvent, getEventsByDate, getEventsForDateRange, refreshEvents }}
     >
       {children}
     </EventsContext.Provider>

--- a/src/features/calendar/model/__tests__/EventsProvider.test.tsx
+++ b/src/features/calendar/model/__tests__/EventsProvider.test.tsx
@@ -29,10 +29,22 @@ function AuthBootstrap({ children }: { children: ReactNode }) {
   return <>{children}</>
 }
 
+function EventsBootstrap({ children }: { children: ReactNode }) {
+  const { refreshEvents } = useEvents()
+
+  useEffect(() => {
+    void refreshEvents()
+  }, [refreshEvents])
+
+  return <>{children}</>
+}
+
 const wrapper = ({ children }: { children: ReactNode }) => (
   <AppProvider>
     <AuthBootstrap>
-      <EventsProvider>{children}</EventsProvider>
+      <EventsProvider>
+        <EventsBootstrap>{children}</EventsBootstrap>
+      </EventsProvider>
     </AuthBootstrap>
   </AppProvider>
 )

--- a/src/features/chat/model/ChatProvider.tsx
+++ b/src/features/chat/model/ChatProvider.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react'
 import { useApp } from '../../auth/model/AppProvider'
 import type { ChatMessage, Channel } from '../../../entities/message/model/types'
 import { getChannels, getMessages, sendMessage as apiSendMessage } from '../../../shared/api/chatApi'
-import type { ApiChannel, ApiMessage } from '../../../shared/api/chatApi'
+import type { ApiMessage } from '../../../shared/api/chatApi'
 
 export type { ChatMessage, Channel } from '../../../entities/message/model/types'
 
@@ -26,6 +26,7 @@ type ChatContextValue = {
   setActiveChannelId: (id: string) => void
   addMessage: (channelId: string, content?: string, files?: { name: string; url: string; type: string }[]) => void
   getMessagesByChannel: (channelId: string) => ChatMessage[]
+  refreshChannels: () => Promise<void>
 }
 
 const ChatContext = createContext<ChatContextValue | null>(null)
@@ -34,18 +35,42 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   const { state } = useApp()
   const [channels, setChannels] = useState<Channel[]>([])
   const [messages, setMessages] = useState<ChatMessage[]>([])
-  const [activeChannelId, setActiveChannelId] = useState('1')
+  const [activeChannelId, setActiveChannelId] = useState('')
 
   const isDirectChannel = useCallback((channelId: string) => channelId.startsWith('dm-'), [])
 
   useEffect(() => {
-    getChannels()
-      .then((data: ApiChannel[]) => {
-        setChannels(data)
-        if (data.length > 0) setActiveChannelId(data[0].id)
-      })
-      .catch(() => {})
-  }, [])
+    if (!state.currentUser?.id) {
+      setChannels([])
+      setMessages([])
+      setActiveChannelId('')
+    }
+  }, [state.currentUser?.id])
+
+  const refreshChannels = useCallback(async () => {
+    if (!state.currentUser?.id) {
+      setChannels([])
+      setMessages([])
+      setActiveChannelId('')
+      return
+    }
+
+    const data = await getChannels()
+    setChannels(data)
+
+    const nextActiveChannelId = data.find((channel) => channel.id === activeChannelId)?.id ?? data[0]?.id ?? ''
+    setActiveChannelId(nextActiveChannelId)
+
+    if (!nextActiveChannelId || isDirectChannel(nextActiveChannelId)) {
+      return
+    }
+
+    const channelMessages = await getMessages(nextActiveChannelId)
+    setMessages((prev) => [
+      ...prev.filter((message) => message.channelId !== nextActiveChannelId),
+      ...channelMessages.map(apiMsgToChatMsg),
+    ])
+  }, [activeChannelId, isDirectChannel, state.currentUser?.id])
 
   useEffect(() => {
     if (!activeChannelId || isDirectChannel(activeChannelId)) return
@@ -98,6 +123,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         setActiveChannelId,
         addMessage,
         getMessagesByChannel,
+        refreshChannels,
       }}
     >
       {children}

--- a/src/features/chat/model/__tests__/ChatProvider.test.tsx
+++ b/src/features/chat/model/__tests__/ChatProvider.test.tsx
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach, beforeEach } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
-import type { ReactNode } from 'react'
+import { useEffect, type ReactNode } from 'react'
 import { setupServer } from 'msw/node'
 import { chatHandlers } from '../../../../shared/api/mock/handlers/chat'
-import { AppProvider } from '../../../auth/model/AppProvider'
+import { AppProvider, useApp } from '../../../auth/model/AppProvider'
 import { ChatProvider, useChat } from '../ChatProvider'
 
 const server = setupServer(...chatHandlers)
@@ -12,9 +12,40 @@ beforeAll(() => server.listen())
 afterEach(() => { server.resetHandlers(); localStorage.clear() })
 afterAll(() => server.close())
 
+function AuthBootstrap({ children }: { children: ReactNode }) {
+  const { loadUser } = useApp()
+
+  useEffect(() => {
+    loadUser({
+      id: '1',
+      name: '김리더',
+      email: 'leader@test.com',
+      role: 'ADMIN',
+      team: '1팀',
+      status: 'ACTIVE',
+    })
+  }, [loadUser])
+
+  return <>{children}</>
+}
+
+function ChatBootstrap({ children }: { children: ReactNode }) {
+  const { refreshChannels } = useChat()
+
+  useEffect(() => {
+    void refreshChannels()
+  }, [refreshChannels])
+
+  return <>{children}</>
+}
+
 const wrapper = ({ children }: { children: ReactNode }) => (
   <AppProvider>
-    <ChatProvider>{children}</ChatProvider>
+    <AuthBootstrap>
+      <ChatProvider>
+        <ChatBootstrap>{children}</ChatBootstrap>
+      </ChatProvider>
+    </AuthBootstrap>
   </AppProvider>
 )
 
@@ -29,9 +60,9 @@ describe('ChatProvider', () => {
       await waitFor(() => expect(result.current.channels.length).toBeGreaterThan(0))
     })
 
-    it('초기 활성 채널 ID가 설정되어 있다', () => {
+    it('초기 활성 채널 ID가 설정되어 있다', async () => {
       const { result } = renderHook(() => useChat(), { wrapper })
-      expect(result.current.activeChannelId).toBeTruthy()
+      await waitFor(() => expect(result.current.activeChannelId).toBeTruthy())
     })
 
     it('초기 메시지가 존재한다', async () => {

--- a/src/features/tasks/model/TasksProvider.tsx
+++ b/src/features/tasks/model/TasksProvider.tsx
@@ -25,6 +25,7 @@ type TasksContextValue = {
   getTasksByDate: (date: string) => Task[]
   getTasksForDateRange: (start: string, end: string) => Task[]
   isLoading: boolean
+  refreshTasks: () => Promise<void>
 }
 
 const TasksContext = createContext<TasksContextValue | null>(null)
@@ -95,17 +96,25 @@ export function TasksProvider({ children }: { children: ReactNode }) {
       setIsLoading(false)
       return
     }
+  }, [state.currentUser?.id])
+
+  const refreshTasks = useCallback(async () => {
+    if (!state.currentUser?.id) {
+      setTasks([])
+      setIsLoading(false)
+      return
+    }
 
     setIsLoading(true)
-    Promise.all([
-      apiGetTasks({ type: 'MY' }),
-      apiGetTasks({ type: 'TEAM' }),
-    ])
-      .then(([myApiTasks, teamApiTasks]) => {
-        setTasks([...myApiTasks.map(toTask), ...teamApiTasks.map(toTask)])
-      })
-      .catch(() => {})
-      .finally(() => setIsLoading(false))
+    try {
+      const [myApiTasks, teamApiTasks] = await Promise.all([
+        apiGetTasks({ type: 'MY' }),
+        apiGetTasks({ type: 'TEAM' }),
+      ])
+      setTasks([...myApiTasks.map(toTask), ...teamApiTasks.map(toTask)])
+    } finally {
+      setIsLoading(false)
+    }
   }, [state.currentUser?.id])
 
   const myTasks = useMemo(() => tasks.filter((t) => !t.isTeamTask), [tasks])
@@ -171,6 +180,7 @@ export function TasksProvider({ children }: { children: ReactNode }) {
         getTasksByDate,
         getTasksForDateRange,
         isLoading,
+        refreshTasks,
       }}
     >
       {children}

--- a/src/features/tasks/model/__tests__/TasksProvider.test.tsx
+++ b/src/features/tasks/model/__tests__/TasksProvider.test.tsx
@@ -90,10 +90,22 @@ function AuthBootstrap({ children }: { children: ReactNode }) {
   return <>{children}</>
 }
 
+function TasksBootstrap({ children }: { children: ReactNode }) {
+  const { refreshTasks } = useTasks()
+
+  useEffect(() => {
+    void refreshTasks()
+  }, [refreshTasks])
+
+  return <>{children}</>
+}
+
 const wrapper = ({ children }: { children: ReactNode }) => (
   <AppProvider>
     <AuthBootstrap>
-      <TasksProvider>{children}</TasksProvider>
+      <TasksProvider>
+        <TasksBootstrap>{children}</TasksBootstrap>
+      </TasksProvider>
     </AuthBootstrap>
   </AppProvider>
 )

--- a/src/pages/admin/__tests__/Admin.test.tsx
+++ b/src/pages/admin/__tests__/Admin.test.tsx
@@ -1,10 +1,12 @@
 import { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { useEffect, type ReactNode } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
-import { AppProvider } from '../../../features/auth/model'
+import { AppProvider, useApp } from '../../../features/auth/model'
+import type { User } from '../../../entities/user/model/types'
 import { Admin } from '../index'
 
 const mockMembers = [
@@ -58,11 +60,30 @@ beforeAll(() => server.listen())
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
+function AdminBootstrap({ children }: { children: ReactNode }) {
+  const { loadUser, loadMembers, loadTeams } = useApp()
+
+  useEffect(() => {
+    loadUser({ id: '99', name: '관리자', email: 'admin@yanus.kr', team: '1팀', role: 'ADMIN', status: 'ACTIVE' })
+    loadMembers(mockMembers as User[])
+    loadTeams([
+      { id: 1, name: '1팀' },
+      { id: 2, name: '2팀' },
+      { id: 3, name: '3팀' },
+      { id: 4, name: '4팀' },
+    ])
+  }, [loadMembers, loadTeams, loadUser])
+
+  return <>{children}</>
+}
+
 function renderAdmin() {
   return render(
     <MemoryRouter>
       <AppProvider>
-        <Admin />
+        <AdminBootstrap>
+          <Admin />
+        </AdminBootstrap>
       </AppProvider>
     </MemoryRouter>,
   )

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,17 +1,18 @@
 import { useState, useEffect } from 'react'
-import { Crown, ChevronDown, Download, ArrowLeftRight, FolderPlus, Trash2, Users } from 'lucide-react'
+import { Crown, Download, FolderPlus, Trash2, Users } from 'lucide-react'
 import { useApp } from '../../features/auth/model'
 import { TeamAttendanceStatus } from '../../features/attendance/ui'
 import { getAttendanceByDate } from '../../shared/api/attendanceApi'
 import type { AttendanceRecord } from '../../shared/api/attendanceApi'
-import { getMembers, updateMemberRole, deactivateMember, activateMember, updateMemberTeam } from '../../shared/api/membersApi'
+import { updateMemberRole, deactivateMember, activateMember, updateMemberTeam } from '../../shared/api/membersApi'
 import type { User, UserRole } from '../../entities/user/model/types'
 import { exportAttendanceToCsv } from '../../shared/lib/exportCsv'
 import { Toast } from '../../shared/ui/Toast'
 import { getTodayStr } from '../../shared/lib/date'
-import { createTeam, deleteTeam, getTeams } from '../../shared/api/teamsApi'
+import { createTeam, deleteTeam } from '../../shared/api/teamsApi'
 import type { TeamResponse } from '../../shared/api/teamsApi'
-import { FALLBACK_TEAMS, formatTeamName, getTeamOptions, sortTeams, sortUsersByTeamAndName } from '../../shared/lib/team'
+import { formatTeamName, getTeamOptions, sortUsersByTeamAndName } from '../../shared/lib/team'
+import { MemberManagementTable } from '../../shared/ui/MemberManagementTable'
 import './admin.css'
 
 type Tab = 'attendance' | 'members' | 'teams'
@@ -23,17 +24,10 @@ const roleLabels: Record<string, string> = {
   MEMBER: '멤버',
 }
 
-const statusLabels: Record<string, string> = {
-  ACTIVE: '활성',
-  INACTIVE: '비활성',
-}
-
 export function Admin() {
-  const { loadMembers } = useApp()
+  const { state, loadMembers, refreshMembers, refreshTeams } = useApp()
   const [tab, setTab] = useState<Tab>('attendance')
   const [records, setRecords] = useState<AttendanceRecord[]>([])
-  const [members, setMembers] = useState<User[]>([])
-  const [teams, setTeams] = useState<TeamResponse[]>(FALLBACK_TEAMS)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
@@ -44,33 +38,23 @@ export function Admin() {
   const [newTeamName, setNewTeamName] = useState('')
 
   const todayStr = getTodayStr()
-  const teamOptions = getTeamOptions(members, teams)
+  const members = sortUsersByTeamAndName(state.users)
+  const teamOptions = getTeamOptions(members, state.teams)
 
   useEffect(() => {
-    Promise.all([
-      getMembers(),
-      getAttendanceByDate(todayStr),
-      getTeams().catch(() => FALLBACK_TEAMS),
-    ])
-      .then(([memberList, attendanceList, teamList]) => {
-        const sortedMembers = sortUsersByTeamAndName(memberList)
-        setMembers(sortedMembers)
-        loadMembers(sortedMembers)
+    getAttendanceByDate(todayStr)
+      .then((attendanceList) => {
         setRecords(attendanceList)
-        setTeams(sortTeams(teamList))
       })
       .catch((err) => setErrorMessage(err instanceof Error ? err.message : '관리 데이터를 불러오지 못했습니다'))
-  }, [todayStr, loadMembers])
+  }, [todayStr])
 
   const reloadMembersAndTeams = async () => {
-    const [memberList, teamList] = await Promise.all([
-      getMembers(),
-      getTeams().catch(() => FALLBACK_TEAMS),
+    const [memberList] = await Promise.all([
+      refreshMembers(),
+      refreshTeams(),
     ])
-    const sortedMembers = sortUsersByTeamAndName(memberList)
-    setMembers(sortedMembers)
-    loadMembers(sortedMembers)
-    setTeams(sortTeams(teamList))
+    loadMembers(memberList)
   }
 
   const handleOpenRoleChange = (id: string, name: string, current: UserRole) => {
@@ -84,11 +68,7 @@ export function Admin() {
     setSaving(true)
     try {
       await updateMemberRole(changeRoleFor.id, selectedRole)
-      const updated = sortUsersByTeamAndName(members.map((member) =>
-        member.id === changeRoleFor.id ? { ...member, role: selectedRole } : member,
-      ))
-      setMembers(updated)
-      loadMembers(updated)
+      await refreshMembers()
       setSuccessMessage(`${changeRoleFor.name}의 역할을 ${roleLabels[selectedRole]}로 변경했습니다`)
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : '역할 변경에 실패했습니다')
@@ -165,8 +145,7 @@ export function Admin() {
     setSaving(true)
     try {
       await createTeam(trimmed)
-      const refreshedTeams = await getTeams().catch(() => FALLBACK_TEAMS)
-      setTeams(sortTeams(refreshedTeams))
+      await refreshTeams()
       setNewTeamName('')
       setSuccessMessage(`${trimmed}을 생성했습니다`)
     } catch (err) {
@@ -188,8 +167,7 @@ export function Admin() {
     setSaving(true)
     try {
       await deleteTeam(team.id)
-      const refreshedTeams = await getTeams().catch(() => FALLBACK_TEAMS)
-      setTeams(sortTeams(refreshedTeams))
+      await refreshTeams()
       setSuccessMessage(`${formatTeamName(team.name)}을 삭제했습니다`)
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : '팀 삭제에 실패했습니다')
@@ -269,90 +247,17 @@ export function Admin() {
       {tab === 'members' && (
         <div className="admin-tab-content glass">
           <h3 className="admin-section-title">멤버 목록</h3>
-          <div className="admin-table-wrap">
-            <table className="admin-members-table">
-              <thead>
-                <tr>
-                  <th>이름</th>
-                  <th>팀</th>
-                  <th>역할</th>
-                  <th>상태</th>
-                  <th>관리</th>
-                </tr>
-              </thead>
-              <tbody>
-                {members.map((member) => (
-                  <tr key={member.id}>
-                    <td>
-                      <span className="admin-avatar">{member.name[0]}</span>
-                      {member.name}
-                    </td>
-                    <td>
-                      <span className="admin-team-tag">
-                        {formatTeamName(member.team)}
-                      </span>
-                    </td>
-                    <td>
-                      <span className={`admin-role-tag ${member.role}`}>
-                        {member.role === 'ADMIN' && <Crown size={12} />}
-                        {roleLabels[member.role] ?? member.role}
-                      </span>
-                    </td>
-                    <td>
-                      <div className="admin-status-cell">
-                        <span className={`admin-status-tag ${member.status ?? 'ACTIVE'}`}>
-                          {statusLabels[member.status ?? 'ACTIVE'] ?? (member.status ?? 'ACTIVE')}
-                        </span>
-                        {member.status === 'INACTIVE' ? (
-                          <button
-                            type="button"
-                            className="admin-action-btn activate-btn"
-                            disabled={saving}
-                            onClick={() => handleActivate(member.id)}
-                          >
-                            활성화
-                          </button>
-                        ) : (
-                          <button
-                            type="button"
-                            className="admin-action-btn mute-btn"
-                            disabled={saving}
-                            onClick={() => handleDeactivate(member.id)}
-                          >
-                            비활성화
-                          </button>
-                        )}
-                      </div>
-                    </td>
-                    <td className="admin-actions-cell">
-                      <button
-                        type="button"
-                        className="admin-action-btn"
-                        onClick={() => handleOpenTeamChange(member)}
-                      >
-                        팀 변경 <ArrowLeftRight size={13} />
-                      </button>
-                      <button
-                        type="button"
-                        className="admin-action-btn"
-                        onClick={() => handleOpenRoleChange(member.id, member.name, member.role)}
-                      >
-                        역할 변경 <ChevronDown size={13} />
-                      </button>
-                      <button
-                        type="button"
-                        className="admin-action-btn deactivate-btn"
-                        disabled={saving || member.status === 'INACTIVE'}
-                        onClick={() => handleExpel(member.id)}
-                      >
-                        {member.status === 'INACTIVE' ? '퇴출됨' : '퇴출'}
-                      </button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+          <MemberManagementTable
+            members={members}
+            saving={saving}
+            showStatus
+            showActions
+            onOpenRoleChange={(member) => handleOpenRoleChange(member.id, member.name, member.role)}
+            onOpenTeamChange={handleOpenTeamChange}
+            onDeactivate={handleDeactivate}
+            onActivate={handleActivate}
+            onExpel={handleExpel}
+          />
         </div>
       )}
 

--- a/src/pages/attendance/__tests__/Attendance.test.tsx
+++ b/src/pages/attendance/__tests__/Attendance.test.tsx
@@ -25,7 +25,13 @@ afterAll(() => server.close())
 
 vi.mock('../../../features/auth/model', () => ({
   useApp: () => ({
-    state: { currentUser: { id: '1', name: '김리더', role: 'ADMIN', team: '1팀' }, users: [] },
+    state: {
+      currentUser: { id: '1', name: '김리더', role: 'ADMIN', team: '1팀' },
+      users: [
+        { id: '1', name: '김리더', role: 'ADMIN', team: '1팀', email: 'admin@yanus.kr', status: 'ACTIVE' },
+      ],
+      teams: [{ id: 1, name: '1팀' }],
+    },
     isAdmin: true,
     isTeamLead: false,
   }),

--- a/src/pages/attendance/index.tsx
+++ b/src/pages/attendance/index.tsx
@@ -10,11 +10,10 @@ import {
   getTeamWorkSchedules,
 } from '../../shared/api/attendanceApi'
 import type { AttendanceRecord, MemberWorkScheduleItem } from '../../shared/api/attendanceApi'
-import { getMembers } from '../../shared/api/membersApi'
-import type { User } from '../../entities/user/model/types'
 import { exportAttendanceToCsv } from '../../shared/lib/exportCsv'
+import { sortUsersByTeamAndName } from '../../shared/lib/team'
 import { Toast } from '../../shared/ui/Toast'
-import { getTeams } from '../../shared/api/teamsApi'
+import { canViewManagedAttendance } from '../../shared/lib/permissions'
 import './attendance.css'
 
 const DAY_LABELS: Record<string, string> = {
@@ -43,11 +42,10 @@ const ATTENDANCE_STATUS_LABEL = {
 } as const
 
 export function Attendance() {
-  const { isAdmin, isTeamLead, state } = useApp()
+  const { state } = useApp()
   const [filter, setFilter] = useState<'week' | 'month' | 'custom'>('month')
   const [records, setRecords] = useState<AttendanceRecord[]>([])
   const [myRecords, setMyRecords] = useState<AttendanceRecord[]>([])
-  const [members, setMembers] = useState<User[]>([])
   const [teamSchedules, setTeamSchedules] = useState<MemberWorkScheduleItem[]>([])
   const [page, setPage] = useState(1)
   const [dateInput, setDateInput] = useState('')
@@ -55,27 +53,30 @@ export function Attendance() {
   const PAGE_SIZE = 10
 
   const todayStr = new Date().toISOString().slice(0, 10)
-  const canViewTeamAttendance = isAdmin || isTeamLead
+  const isAdmin = state.currentUser?.role === 'ADMIN'
+  const canSeeManagedAttendance = canViewManagedAttendance(state.currentUser)
+  const members = sortUsersByTeamAndName(
+    state.currentUser?.role === 'TEAM_LEAD'
+      ? state.users.filter((member) => member.team === state.currentUser?.team)
+      : state.users,
+  )
 
   const loadManagedAttendance = async (targetDate: string) => {
-    if (!canViewTeamAttendance || !state.currentUser) return
+    if (!canSeeManagedAttendance || !state.currentUser) return
 
     try {
+      const attendanceList = await getAttendanceByDate(targetDate)
       if (state.currentUser.role === 'ADMIN') {
-        const [attendanceList, memberList] = await Promise.all([
-          getAttendanceByDate(targetDate),
-          getMembers(),
-        ])
         setRecords(attendanceList)
-        setMembers(memberList)
         return
       }
 
-      const memberList = await getMembers({ teamName: state.currentUser.team })
-      const attendanceList = await getAttendanceByDate(targetDate)
-      const memberIds = new Set(memberList.map((member) => Number(member.id)))
-
-      setMembers(memberList)
+      const currentTeam = state.currentUser.team
+      const memberIds = new Set(
+        state.users
+          .filter((member) => member.team === currentTeam)
+          .map((member) => Number(member.id)),
+      )
       setRecords(attendanceList.filter((record) => memberIds.has(record.memberId)))
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : '출퇴근 기록을 불러오지 못했습니다')
@@ -85,7 +86,7 @@ export function Attendance() {
   // 관리자/팀장: 날짜별 관리 대상 기록 + 멤버 목록
   useEffect(() => {
     loadManagedAttendance(todayStr)
-  }, [canViewTeamAttendance, todayStr, state.currentUser?.id])
+  }, [canSeeManagedAttendance, todayStr, state.currentUser?.id, state.currentUser?.team, state.users])
 
   // 일반 사용자: 내 출퇴근 기록 전체 이력
   useEffect(() => {
@@ -95,7 +96,7 @@ export function Attendance() {
   }, [])
 
   useEffect(() => {
-    if (!canViewTeamAttendance || !state.currentUser) return
+    if (!canSeeManagedAttendance || !state.currentUser) return
 
     const loadSchedules = async () => {
       try {
@@ -106,8 +107,7 @@ export function Attendance() {
         }
 
         if (state.currentUser?.role === 'TEAM_LEAD') {
-          const teams = await getTeams()
-          const currentTeam = teams.find((team) => team.name === state.currentUser?.team)
+          const currentTeam = state.teams.find((team) => team.name === state.currentUser?.team)
           if (!currentTeam) {
             setTeamSchedules([])
             return
@@ -121,7 +121,7 @@ export function Attendance() {
     }
 
     loadSchedules()
-  }, [canViewTeamAttendance, state.currentUser])
+  }, [canSeeManagedAttendance, state.currentUser, state.teams])
 
   const todayRecords = records.filter((r) => r.workDate === todayStr)
   const totalPages = Math.max(1, Math.ceil(records.length / PAGE_SIZE))
@@ -195,13 +195,13 @@ export function Attendance() {
       </header>
 
       <div className="attendance-content">
-        {canViewTeamAttendance && members.length > 0 && (
+        {canSeeManagedAttendance && members.length > 0 && (
           <section className="team-status-section glass">
             <TeamAttendanceStatus members={members} records={records} date={todayStr} />
           </section>
         )}
 
-        {canViewTeamAttendance && (
+        {canSeeManagedAttendance && (
           <section className="team-schedule-section glass">
             <TeamWorkSchedulePanel
               schedules={teamSchedules}
@@ -210,11 +210,11 @@ export function Attendance() {
           </section>
         )}
 
-        <div className={`two-cards-row ${canViewTeamAttendance ? 'admin-wide' : 'single'}`}>
+        <div className={`two-cards-row ${canSeeManagedAttendance ? 'admin-wide' : 'single'}`}>
           <section className="set-work-days-section glass">
             <SetWorkDaysPersonal />
           </section>
-          {canViewTeamAttendance && (
+          {canSeeManagedAttendance && (
             <section className="records-section glass">
               <h3>출퇴근 기록</h3>
               <div className="records-table-wrap">
@@ -309,7 +309,7 @@ export function Attendance() {
           </div>
         </section>
 
-        {canViewTeamAttendance && (
+        {canSeeManagedAttendance && (
           <div className="summary-stats">
             <div className="stat-card glass">
               <span className="label">오늘 총 기록</span>

--- a/src/pages/chat/index.tsx
+++ b/src/pages/chat/index.tsx
@@ -4,7 +4,6 @@ import { Search, Send, Paperclip, Smile, Bold, Italic, Strikethrough, Link as Li
 import { useApp } from '../../features/auth/model'
 import { useChat } from '../../features/chat/model'
 import type { ChatMessage } from '../../features/chat/model'
-import { getMembers } from '../../shared/api/membersApi'
 import { formatTeamName } from '../../shared/lib/team'
 import './chat.css'
 
@@ -85,7 +84,7 @@ function MessageItem({ msg, isOwn }: { msg: ChatMessage; isOwn: boolean }) {
 }
 
 export function Chat() {
-  const { state, loadMembers } = useApp()
+  const { state } = useApp()
   const { channels, activeChannelId, setActiveChannelId, addMessage, getMessagesByChannel } = useChat()
   const [message, setMessage] = useState('')
   const [attachedFiles, setAttachedFiles] = useState<{ name: string; url: string; type: string }[]>([])
@@ -109,13 +108,6 @@ export function Chat() {
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
-
-  useEffect(() => {
-    if (state.users.length > 0) return
-    getMembers()
-      .then(loadMembers)
-      .catch(() => {})
-  }, [loadMembers, state.users.length])
 
   useEffect(() => {
     const onResize = () => {

--- a/src/pages/dashboard/__tests__/Dashboard.test.tsx
+++ b/src/pages/dashboard/__tests__/Dashboard.test.tsx
@@ -20,6 +20,21 @@ vi.mock('../../../features/attendance/ui', () => ({
   AnimatedClockRing: () => <div data-testid="clock-ring" />,
 }))
 
+vi.mock('../../../features/attendance/model/useWorkSchedule', () => ({
+  useWorkSchedule: () => ({
+    workDays: [true, false, false, false, false, false, false],
+    daySchedules: [
+      { checkInTime: '09:00', checkOutTime: '18:00' },
+      { checkInTime: '09:00', checkOutTime: '18:00' },
+      { checkInTime: '09:00', checkOutTime: '18:00' },
+      { checkInTime: '09:00', checkOutTime: '18:00' },
+      { checkInTime: '09:00', checkOutTime: '18:00' },
+      { checkInTime: '09:00', checkOutTime: '18:00' },
+      { checkInTime: '09:00', checkOutTime: '18:00' },
+    ],
+  }),
+}))
+
 vi.mock('../../../features/calendar/model/EventsProvider', () => ({
   useEvents: () => ({
     getEventsByDate: () => [],
@@ -40,6 +55,7 @@ vi.mock('../../../features/tasks/model/TasksProvider', () => ({
     getTasksByDate: () => [],
     tasks: [],
     isLoading: false,
+    toggleTaskDone: vi.fn(),
   }),
 }))
 

--- a/src/pages/dashboard/dashboard.css
+++ b/src/pages/dashboard/dashboard.css
@@ -15,7 +15,6 @@
   min-height: 0;
 }
 
-/* 클락 카드: 1열 전체 높이 */
 .clock-card {
   grid-column: 1;
   grid-row: 1 / 3;
@@ -32,7 +31,6 @@
   opacity: 0.85;
 }
 
-/* 클락 링 버튼: idle 상태에서만 커서 포인터 */
 .clock-ring-btn {
   background: none;
   border: none;
@@ -91,22 +89,20 @@
   color: var(--success);
 }
 
-.clock-time-elapsed {
-  font-size: 1.35rem;
-  color: var(--text-primary);
-  font-variant-numeric: tabular-nums;
-  letter-spacing: 1px;
-}
-
-.clock-time-done {
-  font-size: 1.35rem;
-  color: var(--text-secondary);
-  font-variant-numeric: tabular-nums;
-  letter-spacing: 1px;
-}
-
+.clock-time-elapsed,
+.clock-time-done,
 .clock-time-loading {
-  font-size: 1.4rem;
+  font-size: 1.35rem;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 1px;
+}
+
+.clock-time-elapsed {
+  color: var(--text-primary);
+}
+
+.clock-time-done,
+.clock-time-loading {
   color: var(--text-secondary);
 }
 
@@ -118,14 +114,34 @@
   width: 100%;
 }
 
-.clock-hint {
-  font-size: 0.78rem;
+.clock-schedule-pill {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 14px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-align: center;
+}
+
+.clock-schedule-pill.active {
+  background: color-mix(in srgb, var(--accent-purple) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-purple) 22%, transparent);
+  color: var(--text-primary);
+}
+
+.clock-schedule-pill.off {
+  background: color-mix(in srgb, var(--surface-muted) 76%, transparent);
+  border: 1px solid var(--border-color);
   color: var(--text-secondary);
 }
 
+.clock-schedule-caption,
+.clock-hint,
 .clock-checkin-time {
   font-size: 0.8rem;
   color: var(--text-secondary);
+  text-align: center;
+  line-height: 1.5;
 }
 
 .clockout-btn {
@@ -197,13 +213,19 @@
   margin: 0;
 }
 
-.schedule-card ul {
+.schedule-card ul,
+.tasks-list,
+.chat-preview ul {
   list-style: none;
   padding: 0;
   margin: 0;
+}
+
+.schedule-card ul,
+.tasks-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
 }
 
 .schedule-item {
@@ -212,6 +234,17 @@
   align-items: flex-start;
   padding: 12px 14px;
   border-radius: 16px;
+}
+
+.schedule-item-btn {
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.2s, border-color 0.2s;
+}
+
+.schedule-item-btn:hover {
+  transform: translateY(-1px);
 }
 
 .schedule-item.purple {
@@ -239,12 +272,6 @@
 .schedule-title {
   font-size: 0.9rem;
   color: var(--text-primary);
-}
-
-.chat-preview ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
 }
 
 .chat-preview li {
@@ -313,16 +340,7 @@
 }
 
 .view-all:hover {
-  color: var(--accent-purple);
-}
-
-.tasks-list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  list-style: none;
-  padding: 0;
-  margin: 0;
+  color: var(--text-primary);
 }
 
 .task-item {
@@ -333,10 +351,33 @@
   border-radius: 16px;
   background: var(--bg-soft);
   border: 1px solid transparent;
+  color: var(--text-primary);
 }
 
 .task-item.done {
-  opacity: 0.72;
+  opacity: 0.78;
+}
+
+.task-item.done .task-title {
+  text-decoration: line-through;
+  color: var(--text-secondary);
+}
+
+.task-check-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(148, 163, 184, 0.08);
+  border: 1px solid var(--border-color);
+  flex-shrink: 0;
+}
+
+.task-check-btn.done {
+  background: rgba(34, 197, 94, 0.12);
+  border-color: rgba(34, 197, 94, 0.2);
 }
 
 .task-dot {
@@ -349,14 +390,91 @@
 .task-title {
   flex: 1;
   min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .task-done-badge {
-  padding: 4px 8px;
+  padding: 6px 10px;
   border-radius: 999px;
   font-size: 0.72rem;
   background: rgba(37, 164, 111, 0.14);
   color: var(--success);
+  border: 1px solid transparent;
+  flex-shrink: 0;
+}
+
+.task-done-badge.done {
+  border-color: rgba(34, 197, 94, 0.2);
+}
+
+.dashboard-modal-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(10, 14, 32, 0.52);
+  z-index: 1200;
+}
+
+.dashboard-detail-modal {
+  width: min(460px, 100%);
+  padding: 24px;
+  border-radius: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.dashboard-detail-head,
+.dashboard-detail-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.dashboard-detail-head h3,
+.dashboard-detail-body p,
+.dashboard-detail-body strong,
+.dashboard-detail-body span {
+  margin: 0;
+}
+
+.dashboard-detail-close,
+.dashboard-secondary-btn,
+.dashboard-primary-btn {
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  cursor: pointer;
+}
+
+.dashboard-detail-close,
+.dashboard-secondary-btn {
+  background: transparent;
+  color: var(--text-primary);
+}
+
+.dashboard-primary-btn {
+  background: var(--accent-purple);
+  border-color: transparent;
+  color: #fff;
+}
+
+.dashboard-detail-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dashboard-detail-body p,
+.dashboard-detail-body span {
+  color: var(--text-secondary);
+  line-height: 1.6;
 }
 
 @media (max-width: 1024px) {
@@ -375,78 +493,6 @@
   }
 }
 
-@media (max-width: 640px) {
-  .dashboard {
-    min-height: auto;
-  }
-
-  .dashboard-grid {
-    grid-template-columns: 1fr;
-    gap: 16px;
-  }
-
-  .clock-outer {
-    width: 144px;
-    height: 144px;
-  }
-
-  .card {
-    padding: 18px;
-    border-radius: 20px;
-  }
-}
-
-.view-all:hover {
-  color: var(--text-primary);
-}
-
-/* ── 할 일 목록 ── */
-.tasks-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.task-item {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  font-size: 0.9rem;
-  color: var(--text-primary);
-}
-
-.task-item.done .task-title {
-  text-decoration: line-through;
-  color: var(--text-secondary);
-}
-
-.task-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
-.task-title {
-  flex: 1;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.task-done-badge {
-  font-size: 0.72rem;
-  color: var(--success);
-  border: 1px solid var(--success);
-  border-radius: 4px;
-  padding: 1px 6px;
-  flex-shrink: 0;
-}
-
-/* ── 반응형 ── */
 @media (max-width: 900px) {
   .dashboard {
     height: auto;
@@ -455,7 +501,6 @@
 
   .dashboard-grid {
     grid-template-columns: 1fr;
-    grid-template-rows: auto;
     flex: none;
   }
 
@@ -469,5 +514,22 @@
 
   .clock-card {
     min-height: 260px;
+  }
+}
+
+@media (max-width: 640px) {
+  .dashboard-grid {
+    gap: 16px;
+  }
+
+  .clock-outer {
+    width: 144px;
+    height: 144px;
+  }
+
+  .card,
+  .dashboard-detail-modal {
+    padding: 18px;
+    border-radius: 20px;
   }
 }

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
-import { Calendar, CheckSquare } from 'lucide-react'
+import { Link, useNavigate } from 'react-router-dom'
+import { Calendar, CheckSquare, X } from 'lucide-react'
 import { AnimatedClockRing } from '../../features/attendance/ui'
 import { useWorkSession } from '../../features/attendance/model/useWorkSession'
+import { useWorkSchedule } from '../../features/attendance/model/useWorkSchedule'
 import { useEvents } from '../../features/calendar/model/EventsProvider'
+import type { CalendarEvent } from '../../features/calendar/model'
 import { useChat } from '../../features/chat/model/ChatProvider'
 import { useTasks } from '../../features/tasks/model/TasksProvider'
 import { getTodayStr } from '../../shared/lib/date'
@@ -40,25 +42,30 @@ const priorityColors: Record<string, string> = {
 }
 
 export function Dashboard() {
+  const navigate = useNavigate()
   const [now, setNow] = useState(() => new Date())
+  const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(null)
   const { status, clockIn, clockOut, handleClockClick, errorMessage, toastType, clearError, isLoading } =
     useWorkSession()
+  const { workDays, daySchedules } = useWorkSchedule()
   const { getEventsByDate } = useEvents()
   const { channels, getMessagesByChannel, activeChannelId } = useChat()
-  const { getTasksByDate } = useTasks()
+  const { getTasksByDate, toggleTaskDone } = useTasks()
 
   const today = getTodayStr()
   const todayEvents = getEventsByDate(today)
   const recentMessages = getMessagesByChannel(activeChannelId).slice(-3)
   const todayTasks = getTasksByDate(today)
-  const activeChannel = channels.find((c) => c.id === activeChannelId)
+  const activeChannel = channels.find((channel) => channel.id === activeChannelId)
+  const todayIndex = (new Date().getDay() + 6) % 7
+  const todayWorkEnabled = workDays[todayIndex]
+  const todayWorkSchedule = daySchedules[todayIndex]
 
   useEffect(() => {
     const id = setInterval(() => setNow(new Date()), 1000)
     return () => clearInterval(id)
   }, [])
 
-  // 클락 카드 중앙 텍스트
   let centerText = ''
   let centerClass = 'clock-time'
 
@@ -69,16 +76,24 @@ export function Dashboard() {
     centerText = '출근'
     centerClass += ' clock-time-start'
   } else if (status === 'working') {
-    // working 상태: 경과 시간 표시
     centerText = clockIn ? formatDuration(now.getTime() - clockIn.getTime()) : '00:00'
     centerClass += ' clock-time-elapsed'
   } else {
-    // done 상태: 총 근무 시간 표시
     centerText = clockIn && clockOut
       ? formatDuration(clockOut.getTime() - clockIn.getTime())
       : '완료'
     centerClass += ' clock-time-done'
   }
+
+  const todayScheduleSummary = todayWorkEnabled
+    ? `오늘 근무 예정 ${todayWorkSchedule.checkInTime} - ${todayWorkSchedule.checkOutTime}`
+    : '오늘은 휴무입니다'
+
+  const todayScheduleCaption = status === 'working'
+    ? '현재 출근 상태와 함께 근무 일정을 확인할 수 있습니다.'
+    : status === 'done'
+      ? '오늘 근무가 종료되어 예정 시간과 함께 비교할 수 있습니다.'
+      : '출근 전에도 오늘 근무 예정 시간을 바로 확인할 수 있습니다.'
 
   return (
     <div className="dashboard">
@@ -86,7 +101,6 @@ export function Dashboard() {
         <Toast message={errorMessage} type={toastType} onClose={clearError} />
       )}
       <div className="dashboard-grid">
-        {/* 출퇴근 버튼 */}
         <div className={`card clock-card glass ${isLoading ? 'clock-card-loading' : ''}`}>
           <button
             type="button"
@@ -115,6 +129,10 @@ export function Dashboard() {
           </button>
 
           <div className="clock-footer">
+            <div className={`clock-schedule-pill ${todayWorkEnabled ? 'active' : 'off'}`}>
+              {todayScheduleSummary}
+            </div>
+            <span className="clock-schedule-caption">{todayScheduleCaption}</span>
             {status === 'idle' && !isLoading && (
               <span className="clock-hint">클릭하여 출근</span>
             )}
@@ -125,7 +143,7 @@ export function Dashboard() {
             )}
             {status === 'done' && clockIn && clockOut && (
               <span className="clock-checkin-time">
-                {formatMsgTime(clockIn)} – {formatMsgTime(clockOut)}
+                {formatMsgTime(clockIn)} - {formatMsgTime(clockOut)}
               </span>
             )}
             {status === 'working' && !isLoading && (
@@ -141,7 +159,6 @@ export function Dashboard() {
           </div>
         </div>
 
-        {/* 오늘 일정 */}
         <div className="card schedule-card glass">
           <h3>
             <Calendar size={16} />
@@ -154,15 +171,21 @@ export function Dashboard() {
             </div>
           ) : (
             <ul>
-              {todayEvents.slice(0, 4).map((ev) => (
-                <li key={ev.id} className="schedule-item purple">
-                  <Calendar size={16} className="schedule-icon" />
-                  <div>
-                    <span className="schedule-time">
-                      {formatTime(ev.startTime)} – {formatTime(ev.endTime)}
-                    </span>
-                    <span className="schedule-title">{ev.title}</span>
-                  </div>
+              {todayEvents.slice(0, 4).map((event) => (
+                <li key={event.id}>
+                  <button
+                    type="button"
+                    className="schedule-item schedule-item-btn purple"
+                    onClick={() => setSelectedEvent(event)}
+                  >
+                    <Calendar size={16} className="schedule-icon" />
+                    <div>
+                      <span className="schedule-time">
+                        {formatTime(event.startTime)} - {formatTime(event.endTime)}
+                      </span>
+                      <span className="schedule-title">{event.title}</span>
+                    </div>
+                  </button>
                 </li>
               ))}
             </ul>
@@ -172,7 +195,6 @@ export function Dashboard() {
           )}
         </div>
 
-        {/* 채팅 미리보기 */}
         <div className="card chat-preview glass">
           <h3>
             {activeChannel ? `# ${activeChannel.name}` : '팀 채팅'}
@@ -198,7 +220,6 @@ export function Dashboard() {
           <Link to="/chat" className="view-all">채팅 열기</Link>
         </div>
 
-        {/* 오늘 할 일 */}
         <div className="card tasks-card glass">
           <h3>
             <CheckSquare size={16} />
@@ -213,12 +234,22 @@ export function Dashboard() {
             <ul className="tasks-list">
               {todayTasks.slice(0, 5).map((task) => (
                 <li key={task.id} className={`task-item ${task.done ? 'done' : ''}`}>
-                  <span
-                    className="task-dot"
-                    style={{ background: priorityColors[task.priority] }}
-                  />
+                  <button
+                    type="button"
+                    className={`task-check-btn ${task.done ? 'done' : ''}`}
+                    onClick={() => toggleTaskDone(task.id)}
+                    aria-label={`${task.title} ${task.done ? '미완료로 변경' : '완료 처리'}`}
+                  >
+                    <span className="task-dot" style={{ background: priorityColors[task.priority] }} />
+                  </button>
                   <span className="task-title">{task.title}</span>
-                  {task.done && <span className="task-done-badge">완료</span>}
+                  <button
+                    type="button"
+                    className={`task-done-badge ${task.done ? 'done' : ''}`}
+                    onClick={() => toggleTaskDone(task.id)}
+                  >
+                    {task.done ? '완료됨' : '완료 처리'}
+                  </button>
                 </li>
               ))}
             </ul>
@@ -228,6 +259,41 @@ export function Dashboard() {
           )}
         </div>
       </div>
+
+      {selectedEvent && (
+        <div className="dashboard-modal-overlay" onClick={() => setSelectedEvent(null)}>
+          <div className="dashboard-detail-modal glass" onClick={(event) => event.stopPropagation()}>
+            <div className="dashboard-detail-head">
+              <h3>오늘 일정 상세</h3>
+              <button type="button" className="dashboard-detail-close" onClick={() => setSelectedEvent(null)}>
+                <X size={18} />
+              </button>
+            </div>
+            <div className="dashboard-detail-body">
+              <strong>{selectedEvent.title}</strong>
+              <p>
+                {selectedEvent.startDate} {formatTime(selectedEvent.startTime)} - {selectedEvent.endDate} {formatTime(selectedEvent.endTime)}
+              </p>
+              <span>작성자: {selectedEvent.createdBy}</span>
+            </div>
+            <div className="dashboard-detail-actions">
+              <button type="button" className="dashboard-secondary-btn" onClick={() => setSelectedEvent(null)}>
+                닫기
+              </button>
+              <button
+                type="button"
+                className="dashboard-primary-btn"
+                onClick={() => {
+                  setSelectedEvent(null)
+                  navigate('/calendar')
+                }}
+              >
+                캘린더에서 보기
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/pages/members/__tests__/Members.test.tsx
+++ b/src/pages/members/__tests__/Members.test.tsx
@@ -10,6 +10,7 @@ afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
 const mockLoadMembers = vi.fn()
+const mockRefreshMembers = vi.fn().mockResolvedValue([])
 
 vi.mock('../../../features/auth/model', () => ({
   useApp: () => ({
@@ -20,10 +21,15 @@ vi.mock('../../../features/auth/model', () => ({
         { id: '2', name: '박팀장', role: 'TEAM_LEAD', team: '2팀', email: 'teamlead@test.com', status: 'ACTIVE' },
         { id: '3', name: '비활성멤버', role: 'MEMBER', team: '1팀', email: 'inactive@test.com', status: 'INACTIVE' },
       ],
+      teams: [
+        { id: 1, name: '1팀' },
+        { id: 2, name: '2팀' },
+      ],
     },
     isAdmin: true,
     isTeamLead: false,
     loadMembers: mockLoadMembers,
+    refreshMembers: mockRefreshMembers,
   }),
 }))
 

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect } from 'react'
-import { Search, Crown, ChevronDown, UserPlus, X } from 'lucide-react'
+import { Search, UserPlus, X, Crown } from 'lucide-react'
 import { useApp } from '../../features/auth/model'
-import { getMembers, updateMemberRole, deactivateMember, activateMember } from '../../shared/api/membersApi'
-import { getTeams } from '../../shared/api/teamsApi'
-import type { TeamResponse } from '../../shared/api/teamsApi'
+import { updateMemberRole, deactivateMember, activateMember } from '../../shared/api/membersApi'
 import type { UserRole } from '../../entities/user/model/types'
-import { FALLBACK_TEAMS, formatTeamName, getTeamOptions, sortTeams, sortUsersByTeamAndName } from '../../shared/lib/team'
+import { getTeamOptions, formatTeamName, sortUsersByTeamAndName } from '../../shared/lib/team'
+import { canAccessAdmin } from '../../shared/lib/permissions'
+import { MemberManagementTable } from '../../shared/ui/MemberManagementTable'
 import { Toast } from '../../shared/ui/Toast'
 import './members.css'
 
@@ -17,15 +17,10 @@ const roleLabels: Record<string, string> = {
   MEMBER: '멤버',
 }
 
-const statusLabels: Record<string, string> = {
-  ACTIVE: '활성',
-  INACTIVE: '비활성',
-}
-
 const ALL_ROLES: UserRole[] = ['MEMBER', 'TEAM_LEAD', 'ADMIN']
 
 export function Members() {
-  const { state, isAdmin, loadMembers } = useApp()
+  const { state, refreshMembers } = useApp()
   const [search, setSearch] = useState('')
   const [teamFilter, setTeamFilter] = useState('전체 팀')
   const [roleFilter, setRoleFilter] = useState('전체 역할')
@@ -36,26 +31,20 @@ export function Members() {
   const [inviteRole, setInviteRole] = useState<UserRole>('MEMBER')
   const [saving, setSaving] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
-  const [teams, setTeams] = useState<TeamResponse[]>(FALLBACK_TEAMS)
+  const isAdmin = canAccessAdmin(state.currentUser)
 
   useEffect(() => {
-    Promise.all([
-      getMembers(),
-      getTeams().catch(() => FALLBACK_TEAMS),
-    ])
-      .then(([members, teamOptions]) => {
-        loadMembers(members)
-        setTeams(teamOptions)
-      })
+    if (state.users.length > 0) return
+    refreshMembers()
       .catch((err) => setErrorMessage(err instanceof Error ? err.message : '멤버 목록을 불러오지 못했습니다'))
-  }, [loadMembers])
+  }, [refreshMembers, state.users.length])
 
   const visibleUsers = sortUsersByTeamAndName(
     state.users.filter((user) => (user.status ?? 'ACTIVE') === 'ACTIVE'),
   )
-  const baseTeamOptions = getTeamOptions(visibleUsers, teams)
+  const baseTeamOptions = getTeamOptions(visibleUsers, state.teams)
   const activeTeamNames = new Set(visibleUsers.map((user) => user.team).filter((team): team is string => Boolean(team)))
-  const teamOptions = sortTeams(baseTeamOptions.filter((team) => activeTeamNames.has(team.name)))
+  const teamOptions = baseTeamOptions.filter((team) => activeTeamNames.has(team.name))
 
   const filtered = visibleUsers.filter((user) => {
     const matchSearch = !search || user.name.toLowerCase().includes(search.toLowerCase())
@@ -82,7 +71,7 @@ export function Members() {
     setSaving(true)
     try {
       await updateMemberRole(changeRoleFor.id, selectedRole)
-      loadMembers(state.users.map((user) => user.id === changeRoleFor.id ? { ...user, role: selectedRole } : user))
+      await refreshMembers()
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : '역할 변경에 실패했습니다')
     }
@@ -94,8 +83,7 @@ export function Members() {
     setSaving(true)
     try {
       await deactivateMember(id)
-      const updated = await getMembers()
-      loadMembers(updated)
+      await refreshMembers()
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : '비활성화에 실패했습니다')
     }
@@ -111,8 +99,7 @@ export function Members() {
     setSaving(true)
     try {
       await deactivateMember(id)
-      const updated = await getMembers()
-      loadMembers(updated)
+      await refreshMembers()
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : '퇴출에 실패했습니다')
     }
@@ -123,8 +110,7 @@ export function Members() {
     setSaving(true)
     try {
       await activateMember(id)
-      const updated = await getMembers()
-      loadMembers(updated)
+      await refreshMembers()
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : '활성화에 실패했습니다')
     }
@@ -136,8 +122,7 @@ export function Members() {
 
     setSaving(true)
     try {
-      const updated = await getMembers()
-      loadMembers(updated)
+      await refreshMembers()
       setInviteEmail('')
       setShowInvite(false)
     } catch (err) {
@@ -199,79 +184,16 @@ export function Members() {
       <div className="members-content">
         <div className="table-section glass">
           <h3>멤버 목록</h3>
-          <div className="members-table-wrap">
-            <table className="members-table">
-              <colgroup>
-                <col className="profile-col" />
-                <col className="team-col" />
-                <col className="role-col" />
-                {isAdmin && <col className="status-col" />}
-                {isAdmin && <col className="actions-col" />}
-              </colgroup>
-              <thead>
-                <tr>
-                  <th>프로필</th>
-                  <th>팀</th>
-                  <th>역할</th>
-                  {isAdmin && <th>상태</th>}
-                  {isAdmin && <th>관리</th>}
-                </tr>
-              </thead>
-              <tbody>
-                {filtered.map((user) => (
-                  <tr key={user.id}>
-                    <td>
-                      <div className="profile-cell">
-                        <span className="avatar">{user.name[0]}</span>
-                        <span className="profile-cell-name">{user.name}</span>
-                      </div>
-                    </td>
-                    <td><span className="team-tag">{formatTeamName(user.team)}</span></td>
-                    <td>
-                      <span className={`role-tag ${user.role}`}>
-                        {user.role === 'ADMIN' && <Crown size={14} />}
-                        {roleLabels[user.role] ?? user.role}
-                      </span>
-                    </td>
-                    {isAdmin && (
-                      <td className="status-cell">
-                        <div className="member-status-stack">
-                          <span className={`member-status-tag ${user.status ?? 'ACTIVE'}`}>
-                            {statusLabels[user.status ?? 'ACTIVE'] ?? (user.status ?? 'ACTIVE')}
-                          </span>
-                          {user.status === 'INACTIVE' ? (
-                            <button className="action-btn activate-btn" disabled={saving} onClick={() => handleActivate(user.id)}>
-                              활성화
-                            </button>
-                          ) : (
-                            <button className="action-btn mute-btn" disabled={saving} onClick={() => handleDeactivate(user.id)}>
-                              비활성화
-                            </button>
-                          )}
-                        </div>
-                      </td>
-                    )}
-                    {isAdmin && (
-                      <td className="actions-cell">
-                        <div className="member-actions-stack">
-                          <button className="action-btn action-btn-secondary" onClick={() => handleOpenChangeRole(user.id, user.name, user.role)}>
-                            역할 변경 <ChevronDown size={14} />
-                          </button>
-                          <button
-                            className="action-btn deactivate-btn"
-                            disabled={saving || user.status === 'INACTIVE'}
-                            onClick={() => handleExpel(user.id)}
-                          >
-                            {user.status === 'INACTIVE' ? '퇴출됨' : '퇴출'}
-                          </button>
-                        </div>
-                      </td>
-                    )}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+          <MemberManagementTable
+            members={filtered}
+            saving={saving}
+            showStatus={isAdmin}
+            showActions={isAdmin}
+            onOpenRoleChange={isAdmin ? (member) => handleOpenChangeRole(member.id, member.name, member.role) : undefined}
+            onDeactivate={isAdmin ? handleDeactivate : undefined}
+            onActivate={isAdmin ? handleActivate : undefined}
+            onExpel={isAdmin ? handleExpel : undefined}
+          />
         </div>
 
         <aside className="stats-sidebar glass">

--- a/src/pages/settings/__tests__/Settings.test.tsx
+++ b/src/pages/settings/__tests__/Settings.test.tsx
@@ -10,7 +10,11 @@ const mockNavigate = vi.fn()
 
 vi.mock('../../../features/auth/model', () => ({
   useApp: () => ({
-    state: { currentUser: { id: '1', name: '홍길동', role: 'member', team: '개발팀' }, users: [] },
+    state: {
+      currentUser: { id: '1', name: '홍길동', role: 'MEMBER', team: '1팀' },
+      users: [],
+      teams: [{ id: 1, name: '1팀' }],
+    },
     isAdmin: false,
     isTeamLead: false,
     logout: mockLogout,

--- a/src/pages/team-management/__tests__/TeamManagement.test.tsx
+++ b/src/pages/team-management/__tests__/TeamManagement.test.tsx
@@ -11,16 +11,28 @@ afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
 const mockLoadMembers = vi.fn()
+const mockRefreshMembers = vi.fn().mockResolvedValue([])
+const mockRefreshTeams = vi.fn().mockResolvedValue([])
 
 vi.mock('../../../features/auth/model', () => ({
   useApp: () => ({
     state: {
       currentUser: { id: '2', name: '박팀장', role: 'TEAM_LEAD', team: '2팀', email: 'lead@test.com' },
-      users: [],
+      users: [
+        { id: '2', name: '박팀장', role: 'TEAM_LEAD', team: '2팀', email: 'lead@test.com', status: 'ACTIVE' },
+        { id: '4', name: '이멤버', role: 'MEMBER', team: '1팀', email: 'member@test.com', status: 'ACTIVE' },
+      ],
+      teams: [
+        { id: 1, name: '1팀' },
+        { id: 2, name: '2팀' },
+        { id: 3, name: '3팀' },
+      ],
     },
     isAdmin: false,
     isTeamLead: true,
     loadMembers: mockLoadMembers,
+    refreshMembers: mockRefreshMembers,
+    refreshTeams: mockRefreshTeams,
   }),
 }))
 

--- a/src/pages/team-management/index.tsx
+++ b/src/pages/team-management/index.tsx
@@ -2,10 +2,8 @@ import { useEffect, useMemo, useState } from 'react'
 import { ArrowLeftRight, Users } from 'lucide-react'
 import { useApp } from '../../features/auth/model'
 import type { User } from '../../entities/user/model/types'
-import { getMembers, updateMemberTeam } from '../../shared/api/membersApi'
-import { getTeams } from '../../shared/api/teamsApi'
-import type { TeamResponse } from '../../shared/api/teamsApi'
-import { FALLBACK_TEAMS, formatTeamName, sortTeams, sortUsersByTeamAndName } from '../../shared/lib/team'
+import { updateMemberTeam } from '../../shared/api/membersApi'
+import { formatTeamName, sortUsersByTeamAndName } from '../../shared/lib/team'
 import { Toast } from '../../shared/ui/Toast'
 import './team-management.css'
 
@@ -21,9 +19,7 @@ const statusLabels = {
 }
 
 export function TeamManagement() {
-  const { state, loadMembers } = useApp()
-  const [members, setMembers] = useState<User[]>([])
-  const [teams, setTeams] = useState<TeamResponse[]>(FALLBACK_TEAMS)
+  const { state, refreshMembers, refreshTeams } = useApp()
   const [search, setSearch] = useState('')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
@@ -34,24 +30,23 @@ export function TeamManagement() {
   const currentTeam = state.currentUser?.team
 
   const loadTeamMembers = async () => {
-    if (!currentTeam) return
-
     try {
-      const [memberList, teamList] = await Promise.all([
-        getMembers({ teamName: currentTeam }),
-        getTeams().catch(() => FALLBACK_TEAMS),
-      ])
-      setMembers(sortUsersByTeamAndName(memberList))
-      setTeams(sortTeams(teamList))
-      loadMembers(memberList)
+      await Promise.all([refreshMembers(), refreshTeams()])
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : '팀 멤버를 불러오지 못했습니다')
     }
   }
 
   useEffect(() => {
+    if (!currentTeam) return
     loadTeamMembers()
   }, [currentTeam])
+
+  const members = useMemo(() => (
+    sortUsersByTeamAndName(
+      state.users.filter((member) => member.team === currentTeam),
+    )
+  ), [currentTeam, state.users])
 
   const filteredMembers = useMemo(() => (
     sortUsersByTeamAndName(members).filter((member) => {
@@ -63,7 +58,7 @@ export function TeamManagement() {
 
   const openTeamModal = (member: User) => {
     setChangeTeamFor(member)
-    const matchedTeam = teams.find((team) => team.name === member.team)
+    const matchedTeam = state.teams.find((team) => team.name === member.team)
     setSelectedTeamId(matchedTeam?.id ?? null)
   }
 
@@ -72,7 +67,7 @@ export function TeamManagement() {
 
     setSaving(true)
     try {
-      const nextTeam = teams.find((team) => team.id === selectedTeamId)
+      const nextTeam = state.teams.find((team) => team.id === selectedTeamId)
       await updateMemberTeam(changeTeamFor.id, { teamId: selectedTeamId })
       await loadTeamMembers()
       setSuccessMessage(`${changeTeamFor.name}의 팀을 ${formatTeamName(nextTeam?.name)}으로 변경했습니다`)
@@ -173,7 +168,7 @@ export function TeamManagement() {
             <h3>{changeTeamFor.name} 팀 변경</h3>
             <p>팀장은 멤버의 소속 팀만 변경할 수 있습니다.</p>
             <div className="team-select-list">
-              {teams.map((team) => (
+              {state.teams.map((team) => (
                 <button
                   key={team.id}
                   type="button"

--- a/src/shared/lib/__tests__/permissions.test.ts
+++ b/src/shared/lib/__tests__/permissions.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canAccessAdmin,
+  canAccessTeamManagement,
+  canManageMemberRoles,
+  canManageMemberStatus,
+  canExpelMembers,
+  canChangeMemberTeam,
+  canManageTeams,
+  canViewManagedAttendance,
+} from '../permissions'
+
+const admin = { role: 'ADMIN' as const }
+const teamLead = { role: 'TEAM_LEAD' as const }
+const member = { role: 'MEMBER' as const }
+
+describe('permissions', () => {
+  it('관리자 권한을 정확히 판별한다', () => {
+    expect(canAccessAdmin(admin)).toBe(true)
+    expect(canAccessAdmin(teamLead)).toBe(false)
+    expect(canAccessAdmin(member)).toBe(false)
+  })
+
+  it('팀장 전용 화면 접근을 정확히 판별한다', () => {
+    expect(canAccessTeamManagement(teamLead)).toBe(true)
+    expect(canAccessTeamManagement(admin)).toBe(false)
+    expect(canAccessTeamManagement(member)).toBe(false)
+  })
+
+  it('멤버 역할, 상태, 퇴출 관리는 관리자만 가능하다', () => {
+    expect(canManageMemberRoles(admin)).toBe(true)
+    expect(canManageMemberStatus(admin)).toBe(true)
+    expect(canExpelMembers(admin)).toBe(true)
+
+    expect(canManageMemberRoles(teamLead)).toBe(false)
+    expect(canManageMemberStatus(teamLead)).toBe(false)
+    expect(canExpelMembers(teamLead)).toBe(false)
+  })
+
+  it('팀 변경은 관리자와 팀장만 가능하다', () => {
+    expect(canChangeMemberTeam(admin)).toBe(true)
+    expect(canChangeMemberTeam(teamLead)).toBe(true)
+    expect(canChangeMemberTeam(member)).toBe(false)
+  })
+
+  it('팀 관리와 관리형 출퇴근 조회 권한을 정확히 판별한다', () => {
+    expect(canManageTeams(admin)).toBe(true)
+    expect(canManageTeams(teamLead)).toBe(false)
+    expect(canViewManagedAttendance(admin)).toBe(true)
+    expect(canViewManagedAttendance(teamLead)).toBe(true)
+    expect(canViewManagedAttendance(member)).toBe(false)
+  })
+})

--- a/src/shared/lib/permissions.ts
+++ b/src/shared/lib/permissions.ts
@@ -1,0 +1,35 @@
+import type { User } from '../../entities/user/model/types'
+
+type MaybeUser = Pick<User, 'role'> | null | undefined
+
+export function canAccessAdmin(user: MaybeUser) {
+  return user?.role === 'ADMIN'
+}
+
+export function canAccessTeamManagement(user: MaybeUser) {
+  return user?.role === 'TEAM_LEAD'
+}
+
+export function canManageMemberRoles(user: MaybeUser) {
+  return canAccessAdmin(user)
+}
+
+export function canManageMemberStatus(user: MaybeUser) {
+  return canAccessAdmin(user)
+}
+
+export function canExpelMembers(user: MaybeUser) {
+  return canAccessAdmin(user)
+}
+
+export function canChangeMemberTeam(user: MaybeUser) {
+  return canAccessAdmin(user) || canAccessTeamManagement(user)
+}
+
+export function canManageTeams(user: MaybeUser) {
+  return canAccessAdmin(user)
+}
+
+export function canViewManagedAttendance(user: MaybeUser) {
+  return canAccessAdmin(user) || canAccessTeamManagement(user)
+}

--- a/src/shared/ui/AdminRoute/AdminRoute.tsx
+++ b/src/shared/ui/AdminRoute/AdminRoute.tsx
@@ -1,7 +1,8 @@
 import { Navigate, Outlet } from 'react-router-dom'
 import { useApp } from '../../../features/auth/model'
+import { canAccessAdmin } from '../../lib/permissions'
 
 export function AdminRoute() {
-  const { isAdmin } = useApp()
-  return isAdmin ? <Outlet /> : <Navigate to="/" replace />
+  const { state } = useApp()
+  return canAccessAdmin(state.currentUser) ? <Outlet /> : <Navigate to="/" replace />
 }

--- a/src/shared/ui/AdminRoute/__tests__/AdminRoute.test.tsx
+++ b/src/shared/ui/AdminRoute/__tests__/AdminRoute.test.tsx
@@ -31,9 +31,15 @@ describe('AdminRoute', () => {
       isAdmin: true,
       isTeamLead: false,
       isInitializing: false,
-      state: { currentUser: null, users: [] },
+      isBootstrapping: false,
+      state: { currentUser: { id: '1', name: '관리자', email: 'admin@test.com', team: '1팀', role: 'ADMIN' }, users: [], teams: [] },
       loadUser: vi.fn(),
       loadMembers: vi.fn(),
+      loadTeams: vi.fn(),
+      refreshCurrentUser: vi.fn(),
+      refreshMembers: vi.fn(),
+      refreshTeams: vi.fn(),
+      setBootstrapping: vi.fn(),
       logout: vi.fn(),
     })
     render(<TestLayout />)
@@ -45,9 +51,15 @@ describe('AdminRoute', () => {
       isAdmin: false,
       isTeamLead: true,
       isInitializing: false,
-      state: { currentUser: null, users: [] },
+      isBootstrapping: false,
+      state: { currentUser: { id: '2', name: '팀장', email: 'lead@test.com', team: '1팀', role: 'TEAM_LEAD' }, users: [], teams: [] },
       loadUser: vi.fn(),
       loadMembers: vi.fn(),
+      loadTeams: vi.fn(),
+      refreshCurrentUser: vi.fn(),
+      refreshMembers: vi.fn(),
+      refreshTeams: vi.fn(),
+      setBootstrapping: vi.fn(),
       logout: vi.fn(),
     })
     render(<TestLayout />)

--- a/src/shared/ui/MemberManagementTable/MemberManagementTable.css
+++ b/src/shared/ui/MemberManagementTable/MemberManagementTable.css
@@ -1,0 +1,226 @@
+.member-management-table-wrap {
+  overflow-x: auto;
+  width: 100%;
+  padding-bottom: 6px;
+  min-width: 0;
+  scrollbar-width: thin;
+}
+
+.member-management-table {
+  width: 100%;
+  min-width: 920px;
+  table-layout: fixed;
+  border-collapse: collapse;
+}
+
+.member-management-table .member-profile-col {
+  width: 250px;
+}
+
+.member-management-table .member-team-col {
+  width: 150px;
+}
+
+.member-management-table .member-role-col {
+  width: 160px;
+}
+
+.member-management-table .member-status-col {
+  width: 170px;
+}
+
+.member-management-table .member-actions-col {
+  width: 220px;
+}
+
+.member-management-table th,
+.member-management-table td {
+  padding: 14px 16px;
+  text-align: left;
+  vertical-align: middle;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.member-management-table th {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.member-management-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.member-management-table tbody tr:hover td {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.member-profile-cell {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.member-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, var(--accent-purple), var(--accent-pink));
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.member-profile-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+}
+
+.member-team-tag {
+  display: inline-flex;
+  align-items: center;
+  max-width: 140px;
+  padding: 5px 12px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  background: color-mix(in srgb, var(--accent-purple) 14%, transparent);
+  color: var(--text-primary);
+  border: 1px solid color-mix(in srgb, var(--accent-purple) 18%, transparent);
+}
+
+.member-role-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.member-role-tag.ADMIN {
+  background: rgba(124, 58, 237, 0.2);
+  color: var(--accent-purple-light);
+}
+
+.member-role-tag.TEAM_LEAD {
+  background: rgba(59, 130, 246, 0.2);
+  color: var(--accent-blue);
+}
+
+.member-role-tag.MEMBER {
+  background: rgba(148, 163, 184, 0.2);
+  color: var(--text-secondary);
+}
+
+.member-table-status-cell,
+.member-table-actions-cell {
+  white-space: normal;
+}
+
+.member-status-stack,
+.member-actions-stack {
+  display: grid;
+  gap: 8px;
+  align-content: start;
+  justify-items: start;
+  width: 100%;
+  min-width: 0;
+}
+
+.member-status-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 68px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.member-status-tag.ACTIVE {
+  background: rgba(34, 197, 94, 0.16);
+  color: #86efac;
+}
+
+.member-status-tag.INACTIVE {
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--text-secondary);
+}
+
+.member-action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-width: 100px;
+  padding: 7px 12px;
+  border-radius: 8px;
+  background: rgba(124, 58, 237, 0.15);
+  color: var(--accent-purple-light);
+  font-size: 0.8rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.member-action-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.member-action-btn-secondary {
+  background: rgba(124, 58, 237, 0.1);
+  color: var(--accent-purple-light);
+}
+
+.member-action-btn.activate-btn {
+  background: rgba(34, 197, 94, 0.14);
+  color: #86efac;
+}
+
+.member-action-btn.mute-btn {
+  background: rgba(250, 204, 21, 0.12);
+  color: #fde047;
+}
+
+.member-action-btn.expel-btn {
+  background: rgba(239, 68, 68, 0.12);
+  color: #fca5a5;
+}
+
+.member-management-empty {
+  padding: 28px 16px;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+:root[data-theme='light'] .member-management-table th {
+  border-bottom-color: rgba(84, 102, 146, 0.14);
+}
+
+:root[data-theme='light'] .member-management-table td {
+  border-bottom-color: rgba(84, 102, 146, 0.1);
+}
+
+:root[data-theme='light'] .member-management-table tbody tr:hover td {
+  background: rgba(84, 102, 146, 0.05);
+}
+
+@media (max-width: 768px) {
+  .member-management-table {
+    min-width: 860px;
+  }
+}

--- a/src/shared/ui/MemberManagementTable/MemberManagementTable.tsx
+++ b/src/shared/ui/MemberManagementTable/MemberManagementTable.tsx
@@ -1,0 +1,170 @@
+import { ArrowLeftRight, ChevronDown, Crown } from 'lucide-react'
+import type { User } from '../../../entities/user/model/types'
+import { formatTeamName } from '../../lib/team'
+import './MemberManagementTable.css'
+
+const roleLabels: Record<string, string> = {
+  ADMIN: '관리자',
+  TEAM_LEAD: '팀장',
+  MEMBER: '멤버',
+}
+
+const statusLabels: Record<string, string> = {
+  ACTIVE: '활성',
+  INACTIVE: '비활성',
+}
+
+interface MemberManagementTableProps {
+  members: User[]
+  saving?: boolean
+  emptyMessage?: string
+  showStatus?: boolean
+  showActions?: boolean
+  onOpenRoleChange?: (member: User) => void
+  onOpenTeamChange?: (member: User) => void
+  onDeactivate?: (memberId: string) => void
+  onActivate?: (memberId: string) => void
+  onExpel?: (memberId: string) => void
+}
+
+export function MemberManagementTable({
+  members,
+  saving = false,
+  emptyMessage = '표시할 멤버가 없습니다.',
+  showStatus = false,
+  showActions = false,
+  onOpenRoleChange,
+  onOpenTeamChange,
+  onDeactivate,
+  onActivate,
+  onExpel,
+}: MemberManagementTableProps) {
+  const showRoleChange = typeof onOpenRoleChange === 'function'
+  const showTeamChange = typeof onOpenTeamChange === 'function'
+  const showStatusAction = typeof onDeactivate === 'function' || typeof onActivate === 'function'
+  const showExpel = typeof onExpel === 'function'
+
+  return (
+    <div className="member-management-table-wrap">
+      <table className="member-management-table">
+        <colgroup>
+          <col className="member-profile-col" />
+          <col className="member-team-col" />
+          <col className="member-role-col" />
+          {showStatus && <col className="member-status-col" />}
+          {showActions && <col className="member-actions-col" />}
+        </colgroup>
+        <thead>
+          <tr>
+            <th>프로필</th>
+            <th>팀</th>
+            <th>역할</th>
+            {showStatus && <th>상태</th>}
+            {showActions && <th>관리</th>}
+          </tr>
+        </thead>
+        <tbody>
+          {members.length === 0 ? (
+            <tr>
+              <td
+                colSpan={3 + (showStatus ? 1 : 0) + (showActions ? 1 : 0)}
+                className="member-management-empty"
+              >
+                {emptyMessage}
+              </td>
+            </tr>
+          ) : (
+            members.map((member) => {
+              const status = member.status ?? 'ACTIVE'
+              const isInactive = status === 'INACTIVE'
+
+              return (
+                <tr key={member.id}>
+                  <td>
+                    <div className="member-profile-cell">
+                      <span className="member-avatar">{member.name[0]}</span>
+                      <span className="member-profile-name">{member.name}</span>
+                    </div>
+                  </td>
+                  <td>
+                    <span className="member-team-tag">{formatTeamName(member.team)}</span>
+                  </td>
+                  <td>
+                    <span className={`member-role-tag ${member.role}`}>
+                      {member.role === 'ADMIN' && <Crown size={14} />}
+                      {roleLabels[member.role] ?? member.role}
+                    </span>
+                  </td>
+                  {showStatus && (
+                    <td className="member-table-status-cell">
+                      <div className="member-status-stack">
+                        <span className={`member-status-tag ${status}`}>
+                          {statusLabels[status] ?? status}
+                        </span>
+                        {showStatusAction && (
+                          isInactive ? (
+                            <button
+                              type="button"
+                              className="member-action-btn activate-btn"
+                              disabled={saving || !onActivate}
+                              onClick={() => onActivate?.(member.id)}
+                            >
+                              활성화
+                            </button>
+                          ) : (
+                            <button
+                              type="button"
+                              className="member-action-btn mute-btn"
+                              disabled={saving || !onDeactivate}
+                              onClick={() => onDeactivate?.(member.id)}
+                            >
+                              비활성화
+                            </button>
+                          )
+                        )}
+                      </div>
+                    </td>
+                  )}
+                  {showActions && (
+                    <td className="member-table-actions-cell">
+                      <div className="member-actions-stack">
+                        {showTeamChange && (
+                          <button
+                            type="button"
+                            className="member-action-btn member-action-btn-secondary"
+                            onClick={() => onOpenTeamChange?.(member)}
+                          >
+                            팀 변경 <ArrowLeftRight size={14} />
+                          </button>
+                        )}
+                        {showRoleChange && (
+                          <button
+                            type="button"
+                            className="member-action-btn member-action-btn-secondary"
+                            onClick={() => onOpenRoleChange?.(member)}
+                          >
+                            역할 변경 <ChevronDown size={14} />
+                          </button>
+                        )}
+                        {showExpel && (
+                          <button
+                            type="button"
+                            className="member-action-btn expel-btn"
+                            disabled={saving || isInactive}
+                            onClick={() => onExpel?.(member.id)}
+                          >
+                            {isInactive ? '퇴출됨' : '퇴출'}
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  )}
+                </tr>
+              )
+            })
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/shared/ui/MemberManagementTable/index.ts
+++ b/src/shared/ui/MemberManagementTable/index.ts
@@ -1,0 +1,1 @@
+export { MemberManagementTable } from './MemberManagementTable'

--- a/src/shared/ui/PrivateRoute/PrivateRoute.tsx
+++ b/src/shared/ui/PrivateRoute/PrivateRoute.tsx
@@ -2,10 +2,10 @@ import { Navigate, Outlet } from 'react-router-dom'
 import { useApp } from '../../../features/auth/model'
 
 export function PrivateRoute() {
-  const { isInitializing } = useApp()
+  const { isInitializing, isBootstrapping } = useApp()
   const isLoggedIn = !!localStorage.getItem('accessToken')
 
-  if (isInitializing) {
+  if (isInitializing || (isLoggedIn && isBootstrapping)) {
     return (
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh', background: 'var(--bg-primary, #111118)' }}>
         <div style={{ width: 40, height: 40, border: '3px solid rgba(255,255,255,0.1)', borderTopColor: 'var(--accent-purple, #9680cc)', borderRadius: '50%', animation: 'spin 0.8s linear infinite' }} />

--- a/src/shared/ui/TeamLeadRoute/TeamLeadRoute.tsx
+++ b/src/shared/ui/TeamLeadRoute/TeamLeadRoute.tsx
@@ -1,7 +1,8 @@
 import { Navigate, Outlet } from 'react-router-dom'
 import { useApp } from '../../../features/auth/model'
+import { canAccessTeamManagement } from '../../lib/permissions'
 
 export function TeamLeadRoute() {
-  const { isTeamLead } = useApp()
-  return isTeamLead ? <Outlet /> : <Navigate to="/" replace />
+  const { state } = useApp()
+  return canAccessTeamManagement(state.currentUser) ? <Outlet /> : <Navigate to="/" replace />
 }

--- a/src/shared/ui/TeamLeadRoute/__tests__/TeamLeadRoute.test.tsx
+++ b/src/shared/ui/TeamLeadRoute/__tests__/TeamLeadRoute.test.tsx
@@ -30,9 +30,15 @@ describe('TeamLeadRoute', () => {
       isAdmin: false,
       isTeamLead: true,
       isInitializing: false,
-      state: { currentUser: null, users: [] },
+      isBootstrapping: false,
+      state: { currentUser: { id: '2', name: '팀장', email: 'lead@test.com', team: '1팀', role: 'TEAM_LEAD' }, users: [], teams: [] },
       loadUser: vi.fn(),
       loadMembers: vi.fn(),
+      loadTeams: vi.fn(),
+      refreshCurrentUser: vi.fn(),
+      refreshMembers: vi.fn(),
+      refreshTeams: vi.fn(),
+      setBootstrapping: vi.fn(),
       logout: vi.fn(),
     })
     render(<TestLayout />)
@@ -44,9 +50,15 @@ describe('TeamLeadRoute', () => {
       isAdmin: true,
       isTeamLead: false,
       isInitializing: false,
-      state: { currentUser: null, users: [] },
+      isBootstrapping: false,
+      state: { currentUser: { id: '1', name: '관리자', email: 'admin@test.com', team: '1팀', role: 'ADMIN' }, users: [], teams: [] },
       loadUser: vi.fn(),
       loadMembers: vi.fn(),
+      loadTeams: vi.fn(),
+      refreshCurrentUser: vi.fn(),
+      refreshMembers: vi.fn(),
+      refreshTeams: vi.fn(),
+      setBootstrapping: vi.fn(),
       logout: vi.fn(),
     })
     render(<TestLayout />)

--- a/src/widgets/Layout/Layout.tsx
+++ b/src/widgets/Layout/Layout.tsx
@@ -1,6 +1,7 @@
 import { Home, MessageSquare, Calendar, RotateCw, FolderUp, Bot, Users, Settings, LogOut, ShieldCheck, Sun, Moon, ArrowLeftRight } from 'lucide-react'
 import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { useApp } from '../../features/auth/model'
+import { canAccessAdmin, canAccessTeamManagement } from '../../shared/lib/permissions'
 import { useTheme } from '../../shared/theme'
 import logoImg from '../../assets/logo.png'
 import './Layout.css'
@@ -19,12 +20,14 @@ const navItems = [
 export function Layout() {
   const location = useLocation()
   const navigate = useNavigate()
-  const { state, isAdmin, isTeamLead, logout } = useApp()
+  const { state, logout } = useApp()
   const { theme, toggleTheme } = useTheme()
   const { currentUser } = state
+  const canSeeAdmin = canAccessAdmin(currentUser)
+  const canSeeTeamManagement = canAccessTeamManagement(currentUser)
   const visibleNavItems = [
     ...navItems,
-    ...(isTeamLead ? [{ to: '/team-management', icon: ArrowLeftRight, label: '팀 관리' }] : []),
+    ...(canSeeTeamManagement ? [{ to: '/team-management', icon: ArrowLeftRight, label: '팀 관리' }] : []),
   ]
   const currentNav = visibleNavItems.find(({ to }) => (to === '/' ? location.pathname === '/' : location.pathname.startsWith(to)))
   const pageTitle = location.pathname === '/admin' ? '관리자' : currentNav?.label ?? '홈'
@@ -67,7 +70,7 @@ export function Layout() {
               <span className="nav-label">{label}</span>
             </NavLink>
           ))}
-          {isAdmin && (
+          {canSeeAdmin && (
             <NavLink
               to="/admin"
               className={({ isActive }) => `nav-item admin-nav-item ${isActive ? 'active' : ''}`}


### PR DESCRIPTION
## 작업 내용
- `develop`에 반영된 데이터 프리로드 구조 통합, 권한 정리, 대시보드 개선, QA 시나리오 테스트를 `main` 배포 기준으로 반영합니다.
- 최근 누적된 멤버 관리 UI 정리, 라이트 모드 보정, 동적 팀 관리, 리프레시 토큰 자동 로그아웃 개선도 함께 포함합니다.

## 변경 이유
- 로그인 직후와 첫 진입 시 데이터 로드 책임이 화면마다 흩어져 있어 초기 표시가 불안정했습니다.
- 관리자/팀장/멤버 권한 기준과 멤버 관리 UI 패턴을 한 번 더 통일할 필요가 있었습니다.
- `main` 배포 브랜치에 현재 `develop` 누적 안정화 작업을 버전2 기준으로 반영해야 했습니다.

## 상세 변경 사항
### 주요 변경
- [x] 로그인 후 공통 프리로드 + 화면별 추가 fetch 구조 통일
- [x] 멤버/관리 화면 공용 테이블 및 액션 패턴 적용
- [x] 권한 유틸 분리와 라우트/네비게이션/액션 기준 정리
- [x] 대시보드에서 일정 상세 보기, 할 일 즉시 완료, 근무 일정 요약 확인 지원
- [x] 앱 단위 QA 시나리오 테스트 추가
- [x] 직전 `develop` 누적 변경분 반영

### 추가 메모
- `main` 머지 후 release workflow 기준으로 GitHub Release가 생성됩니다.
- 이번 배포 PR 제목은 버전2 기준으로 `release: v0.2.0`을 사용합니다.

## 테스트
- [x] `npm run test:run`
- [x] `npm run build`
- [x] 브라우저에서 주요 동작 확인

## 리뷰 포인트
- 공통 프리로드 구조가 일정/할 일/채팅 초기 로드와 충돌하지 않는지
- 관리자, 팀장, 멤버 권한별 화면 접근과 액션 노출이 같은 기준으로 동작하는지
- 공용 멤버 관리 테이블이 멤버 화면과 관리자 화면에서 모두 안정적으로 보이는지
- 대시보드 상호작용과 QA 시나리오 테스트가 실제 사용 흐름을 잘 커버하는지

## 관련 이슈
- closes #209
