### PR TITLE
[fix] #216 - 권한별 멤버 관리 액션 노출을 정리

### DIFF
--- a/src/pages/admin/__tests__/Admin.test.tsx
+++ b/src/pages/admin/__tests__/Admin.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useEffect, type ReactNode } from 'react'
 import { MemoryRouter } from 'react-router-dom'
@@ -10,6 +10,7 @@ import type { User } from '../../../entities/user/model/types'
 import { Admin } from '../index'
 
 const mockMembers = [
+  { id: '99', name: '관리자', email: 'admin@yanus.kr', team: '1팀', role: 'ADMIN', status: 'ACTIVE' },
   { id: '1', name: '이서연', email: 'seo@yanus.kr', team: '2팀', role: 'TEAM_LEAD', status: 'ACTIVE' },
   { id: '2', name: '강민준', email: 'kang@yanus.kr', team: '1팀', role: 'MEMBER', status: 'ACTIVE' },
   { id: '3', name: '김민준', email: 'min@yanus.kr', team: '1팀', role: 'MEMBER', status: 'ACTIVE' },
@@ -114,6 +115,20 @@ describe('Admin 페이지', () => {
     expect(screen.getByText('멤버 목록')).toBeInTheDocument()
     expect(screen.getAllByRole('button', { name: '비활성화' }).length).toBeGreaterThan(0)
     expect(screen.getAllByLabelText('관리 메뉴 열기').length).toBeGreaterThan(0)
+  })
+
+  it('관리자는 본인 계정에 대해 역할, 상태, 퇴출 액션을 볼 수 없다', async () => {
+    const user = userEvent.setup()
+    renderAdmin()
+    await user.click(screen.getByRole('button', { name: '멤버 관리' }))
+
+    const selfRow = screen.getAllByText('관리자')[0]?.closest('tr')
+    expect(selfRow).not.toBeNull()
+    const scoped = within(selfRow as HTMLTableRowElement)
+
+    expect(scoped.getByText('관리 불가')).toBeInTheDocument()
+    expect(scoped.queryByRole('button', { name: '비활성화' })).not.toBeInTheDocument()
+    expect(scoped.queryByLabelText('관리 메뉴 열기')).not.toBeInTheDocument()
   })
 
   it('멤버 목록은 팀 순, 이름 순이며 비활성 멤버는 마지막에 표시된다', async () => {

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -12,6 +12,12 @@ import { getTodayStr } from '../../shared/lib/date'
 import { createTeam, deleteTeam } from '../../shared/api/teamsApi'
 import type { TeamResponse } from '../../shared/api/teamsApi'
 import { formatTeamName, getTeamOptions, sortUsersByTeamAndName } from '../../shared/lib/team'
+import {
+  canChangeMemberTeamFor,
+  canExpelMembersFor,
+  canManageMemberRolesFor,
+  canManageMemberStatusFor,
+} from '../../shared/lib/permissions'
 import { MemberManagementTable } from '../../shared/ui/MemberManagementTable'
 import { SectionHeader } from '../../shared/ui/SectionHeader'
 import './admin.css'
@@ -59,6 +65,12 @@ export function Admin() {
   }
 
   const handleOpenRoleChange = (id: string, name: string, current: UserRole) => {
+    const targetMember = members.find((member) => member.id === id)
+    if (!canManageMemberRolesFor(state.currentUser, targetMember)) {
+      setErrorMessage('본인 계정의 역할은 변경할 수 없습니다')
+      return
+    }
+
     setChangeRoleFor({ id, name, current })
     setSelectedRole(current)
   }
@@ -79,6 +91,12 @@ export function Admin() {
   }
 
   const handleDeactivate = async (id: string) => {
+    const targetMember = members.find((member) => member.id === id)
+    if (!canManageMemberStatusFor(state.currentUser, targetMember)) {
+      setErrorMessage('본인 계정은 비활성화할 수 없습니다')
+      return
+    }
+
     setSaving(true)
     try {
       await deactivateMember(id)
@@ -91,6 +109,11 @@ export function Admin() {
 
   const handleExpel = async (id: string) => {
     const member = members.find((item) => item.id === id)
+    if (!canExpelMembersFor(state.currentUser, member)) {
+      setErrorMessage('본인 계정은 퇴출할 수 없습니다')
+      return
+    }
+
     if (!window.confirm(`${member?.name ?? '선택한 멤버'}를 퇴출하시겠습니까?`)) {
       return
     }
@@ -107,6 +130,12 @@ export function Admin() {
   }
 
   const handleActivate = async (id: string) => {
+    const targetMember = members.find((member) => member.id === id)
+    if (!canManageMemberStatusFor(state.currentUser, targetMember)) {
+      setErrorMessage('본인 계정은 활성화 상태를 변경할 수 없습니다')
+      return
+    }
+
     setSaving(true)
     try {
       await activateMember(id)
@@ -118,6 +147,11 @@ export function Admin() {
   }
 
   const handleOpenTeamChange = (member: User) => {
+    if (!canChangeMemberTeamFor(state.currentUser, member)) {
+      setErrorMessage('본인 계정의 팀은 여기서 변경할 수 없습니다')
+      return
+    }
+
     setChangeTeamFor(member)
     const currentTeam = teamOptions.find((team) => team.name === member.team)
     setSelectedTeamId(currentTeam?.id ?? null)
@@ -261,6 +295,10 @@ export function Admin() {
             onDeactivate={handleDeactivate}
             onActivate={handleActivate}
             onExpel={handleExpel}
+            canManageRoleFor={(member) => canManageMemberRolesFor(state.currentUser, member)}
+            canChangeTeamFor={(member) => canChangeMemberTeamFor(state.currentUser, member)}
+            canManageStatusFor={(member) => canManageMemberStatusFor(state.currentUser, member)}
+            canExpelFor={(member) => canExpelMembersFor(state.currentUser, member)}
           />
         </div>
       )}

--- a/src/pages/members/__tests__/Members.test.tsx
+++ b/src/pages/members/__tests__/Members.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll, afterEach, afterAll } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { setupServer } from 'msw/node'
 import { membersHandlers } from '../../../shared/api/mock/handlers/members'
@@ -71,6 +71,22 @@ describe('Members 페이지', () => {
 
     await user.click(screen.getAllByLabelText('관리 메뉴 열기')[0])
     expect(screen.getByRole('menuitem', { name: '퇴출' })).toBeInTheDocument()
+  })
+
+  it('관리자는 본인 계정에 대해 관리 액션을 볼 수 없다', async () => {
+    render(<Members />)
+
+    await waitFor(() => {
+      expect(screen.getByText('김리더')).toBeInTheDocument()
+    })
+
+    const selfRow = screen.getByText('김리더').closest('tr')
+    expect(selfRow).not.toBeNull()
+    const scoped = within(selfRow as HTMLTableRowElement)
+
+    expect(scoped.getByText('관리 불가')).toBeInTheDocument()
+    expect(scoped.queryByRole('button', { name: '비활성화' })).not.toBeInTheDocument()
+    expect(scoped.queryByLabelText('관리 메뉴 열기')).not.toBeInTheDocument()
   })
 
   it('팀별 멤버 수는 활성 멤버만 집계한다', () => {

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -4,7 +4,12 @@ import { useApp } from '../../features/auth/model'
 import { updateMemberRole, deactivateMember, activateMember } from '../../shared/api/membersApi'
 import type { UserRole } from '../../entities/user/model/types'
 import { getTeamOptions, formatTeamName, sortUsersByTeamAndName } from '../../shared/lib/team'
-import { canAccessAdmin } from '../../shared/lib/permissions'
+import {
+  canAccessAdmin,
+  canExpelMembersFor,
+  canManageMemberRolesFor,
+  canManageMemberStatusFor,
+} from '../../shared/lib/permissions'
 import { MemberManagementTable } from '../../shared/ui/MemberManagementTable'
 import { SectionHeader } from '../../shared/ui/SectionHeader'
 import { Toast } from '../../shared/ui/Toast'
@@ -62,6 +67,12 @@ export function Members() {
   const maxActiveTeamCount = Math.max(...activeCountsByTeam.map((team) => team.count), 1)
 
   const handleOpenChangeRole = (id: string, name: string, currentRole: string) => {
+    const targetUser = state.users.find((user) => user.id === id)
+    if (!canManageMemberRolesFor(state.currentUser, targetUser)) {
+      setErrorMessage('본인 계정의 역할은 변경할 수 없습니다')
+      return
+    }
+
     setChangeRoleFor({ id, name })
     setSelectedRole(currentRole as UserRole)
   }
@@ -81,6 +92,12 @@ export function Members() {
   }
 
   const handleDeactivate = async (id: string) => {
+    const targetUser = state.users.find((user) => user.id === id)
+    if (!canManageMemberStatusFor(state.currentUser, targetUser)) {
+      setErrorMessage('본인 계정은 비활성화할 수 없습니다')
+      return
+    }
+
     setSaving(true)
     try {
       await deactivateMember(id)
@@ -93,6 +110,11 @@ export function Members() {
 
   const handleExpel = async (id: string) => {
     const member = state.users.find((item) => item.id === id)
+    if (!canExpelMembersFor(state.currentUser, member)) {
+      setErrorMessage('본인 계정은 퇴출할 수 없습니다')
+      return
+    }
+
     if (!window.confirm(`${member?.name ?? '선택한 멤버'}를 퇴출하시겠습니까?`)) {
       return
     }
@@ -108,6 +130,12 @@ export function Members() {
   }
 
   const handleActivate = async (id: string) => {
+    const targetUser = state.users.find((user) => user.id === id)
+    if (!canManageMemberStatusFor(state.currentUser, targetUser)) {
+      setErrorMessage('본인 계정의 상태는 변경할 수 없습니다')
+      return
+    }
+
     setSaving(true)
     try {
       await activateMember(id)
@@ -197,6 +225,9 @@ export function Members() {
             onDeactivate={isAdmin ? handleDeactivate : undefined}
             onActivate={isAdmin ? handleActivate : undefined}
             onExpel={isAdmin ? handleExpel : undefined}
+            canManageRoleFor={(member) => canManageMemberRolesFor(state.currentUser, member)}
+            canManageStatusFor={(member) => canManageMemberStatusFor(state.currentUser, member)}
+            canExpelFor={(member) => canExpelMembersFor(state.currentUser, member)}
           />
         </div>
 

--- a/src/pages/team-management/__tests__/TeamManagement.test.tsx
+++ b/src/pages/team-management/__tests__/TeamManagement.test.tsx
@@ -19,8 +19,11 @@ vi.mock('../../../features/auth/model', () => ({
     state: {
       currentUser: { id: '2', name: '박팀장', role: 'TEAM_LEAD', team: '2팀', email: 'lead@test.com' },
       users: [
+        { id: '1', name: '김관리자', role: 'ADMIN', team: '2팀', email: 'admin@test.com', status: 'ACTIVE' },
         { id: '2', name: '박팀장', role: 'TEAM_LEAD', team: '2팀', email: 'lead@test.com', status: 'ACTIVE' },
+        { id: '3', name: '한멤버', role: 'MEMBER', team: '2팀', email: 'member2@test.com', status: 'ACTIVE' },
         { id: '4', name: '이멤버', role: 'MEMBER', team: '1팀', email: 'member@test.com', status: 'ACTIVE' },
+        { id: '5', name: '휴면멤버', role: 'MEMBER', team: '2팀', email: 'inactive@test.com', status: 'INACTIVE' },
       ],
       teams: [
         { id: 1, name: '1팀' },
@@ -46,19 +49,24 @@ describe('TeamManagement 페이지', () => {
     render(<TeamManagement />)
 
     await waitFor(() => {
-      expect(screen.getByText('박팀장')).toBeInTheDocument()
+      expect(screen.getByText('한멤버')).toBeInTheDocument()
     })
 
+    expect(screen.queryByText('박팀장')).not.toBeInTheDocument()
+    expect(screen.queryByText('김관리자')).not.toBeInTheDocument()
     expect(screen.queryByText('김리더')).not.toBeInTheDocument()
     expect(screen.queryByText('이멤버')).not.toBeInTheDocument()
+    expect(screen.queryByText('휴면멤버')).not.toBeInTheDocument()
   })
 
-  it('팀 변경 액션이 렌더링된다', async () => {
+  it('팀 변경 액션은 이동 가능한 일반 멤버에게만 렌더링된다', async () => {
     render(<TeamManagement />)
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /팀 변경/ })).toBeInTheDocument()
     })
+
+    expect(screen.getAllByRole('button', { name: /팀 변경/ })).toHaveLength(1)
   })
 
   it('팀 변경 저장 시 성공 메시지가 표시된다', async () => {
@@ -66,7 +74,7 @@ describe('TeamManagement 페이지', () => {
     render(<TeamManagement />)
 
     await waitFor(() => {
-      expect(screen.getByText('박팀장')).toBeInTheDocument()
+      expect(screen.getByText('한멤버')).toBeInTheDocument()
     })
 
     await user.click(screen.getByRole('button', { name: /팀 변경/ }))
@@ -74,7 +82,7 @@ describe('TeamManagement 페이지', () => {
     await user.click(screen.getByRole('button', { name: '팀 변경 저장' }))
 
     await waitFor(() => {
-      expect(screen.getByText(/박팀장의 팀을 3팀으로 변경했습니다/)).toBeInTheDocument()
+      expect(screen.getByText(/한멤버의 팀을 3팀으로 변경했습니다/)).toBeInTheDocument()
     })
   })
 })

--- a/src/pages/team-management/index.tsx
+++ b/src/pages/team-management/index.tsx
@@ -4,6 +4,7 @@ import { useApp } from '../../features/auth/model'
 import type { User } from '../../entities/user/model/types'
 import { updateMemberTeam } from '../../shared/api/membersApi'
 import { formatTeamName, sortUsersByTeamAndName } from '../../shared/lib/team'
+import { canChangeMemberTeamFor } from '../../shared/lib/permissions'
 import { EmptyState } from '../../shared/ui/EmptyState'
 import { SectionHeader } from '../../shared/ui/SectionHeader'
 import { Toast } from '../../shared/ui/Toast'
@@ -50,15 +51,24 @@ export function TeamManagement() {
     )
   ), [currentTeam, state.users])
 
+  const manageableMembers = useMemo(() => (
+    members.filter((member) => canChangeMemberTeamFor(state.currentUser, member))
+  ), [members, state.currentUser])
+
   const filteredMembers = useMemo(() => (
-    sortUsersByTeamAndName(members).filter((member) => {
+    sortUsersByTeamAndName(manageableMembers).filter((member) => {
       if (!search.trim()) return true
       const keyword = search.trim().toLowerCase()
       return member.name.toLowerCase().includes(keyword) || member.email.toLowerCase().includes(keyword)
     })
-  ), [members, search])
+  ), [manageableMembers, search])
 
   const openTeamModal = (member: User) => {
+    if (!canChangeMemberTeamFor(state.currentUser, member)) {
+      setErrorMessage('팀장은 같은 팀의 활성 일반 멤버만 이동할 수 있습니다')
+      return
+    }
+
     setChangeTeamFor(member)
     const matchedTeam = state.teams.find((team) => team.name === member.team)
     setSelectedTeamId(matchedTeam?.id ?? null)
@@ -103,7 +113,7 @@ export function TeamManagement() {
       <section className="team-management-panel glass">
         <SectionHeader
           title="팀 멤버 목록"
-          description="팀장은 소속 멤버의 팀 이동만 관리할 수 있습니다."
+          description="팀장은 같은 팀의 활성 일반 멤버만 다른 팀으로 이동할 수 있습니다."
         />
         <div className="team-management-toolbar">
           <div className="team-management-search">

--- a/src/shared/lib/__tests__/permissions.test.ts
+++ b/src/shared/lib/__tests__/permissions.test.ts
@@ -3,16 +3,23 @@ import {
   canAccessAdmin,
   canAccessTeamManagement,
   canManageMemberRoles,
+  canManageMemberRolesFor,
   canManageMemberStatus,
+  canManageMemberStatusFor,
   canExpelMembers,
+  canExpelMembersFor,
   canChangeMemberTeam,
+  canChangeMemberTeamFor,
   canManageTeams,
   canViewManagedAttendance,
 } from '../permissions'
 
-const admin = { role: 'ADMIN' as const }
-const teamLead = { role: 'TEAM_LEAD' as const }
-const member = { role: 'MEMBER' as const }
+const admin = { id: '1', role: 'ADMIN' as const, team: '1팀' }
+const teamLead = { id: '2', role: 'TEAM_LEAD' as const, team: '1팀' }
+const member = { id: '3', role: 'MEMBER' as const, team: '1팀' }
+const otherMember = { id: '4', role: 'MEMBER' as const, team: '1팀', status: 'ACTIVE' as const }
+const inactiveMember = { id: '5', role: 'MEMBER' as const, team: '1팀', status: 'INACTIVE' as const }
+const otherLead = { id: '6', role: 'TEAM_LEAD' as const, team: '1팀', status: 'ACTIVE' as const }
 
 describe('permissions', () => {
   it('관리자 권한을 정확히 판별한다', () => {
@@ -37,10 +44,33 @@ describe('permissions', () => {
     expect(canExpelMembers(teamLead)).toBe(false)
   })
 
+  it('관리자는 본인 계정의 역할, 상태, 퇴출 액션을 수행할 수 없다', () => {
+    expect(canManageMemberRolesFor(admin, admin)).toBe(false)
+    expect(canManageMemberStatusFor(admin, admin)).toBe(false)
+    expect(canExpelMembersFor(admin, admin)).toBe(false)
+    expect(canManageMemberRolesFor(admin, otherMember)).toBe(true)
+    expect(canManageMemberStatusFor(admin, otherMember)).toBe(true)
+    expect(canExpelMembersFor(admin, otherMember)).toBe(true)
+  })
+
   it('팀 변경은 관리자와 팀장만 가능하다', () => {
     expect(canChangeMemberTeam(admin)).toBe(true)
     expect(canChangeMemberTeam(teamLead)).toBe(true)
     expect(canChangeMemberTeam(member)).toBe(false)
+  })
+
+  it('팀장은 같은 팀의 활성 일반 멤버만 팀 변경할 수 있다', () => {
+    expect(canChangeMemberTeamFor(teamLead, otherMember)).toBe(true)
+    expect(canChangeMemberTeamFor(teamLead, inactiveMember)).toBe(false)
+    expect(canChangeMemberTeamFor(teamLead, otherLead)).toBe(false)
+    expect(canChangeMemberTeamFor(teamLead, admin)).toBe(false)
+    expect(canChangeMemberTeamFor(teamLead, { ...otherMember, team: '2팀' })).toBe(false)
+    expect(canChangeMemberTeamFor(teamLead, teamLead)).toBe(false)
+  })
+
+  it('관리자는 본인 외 멤버의 팀을 변경할 수 있다', () => {
+    expect(canChangeMemberTeamFor(admin, otherMember)).toBe(true)
+    expect(canChangeMemberTeamFor(admin, admin)).toBe(false)
   })
 
   it('팀 관리와 관리형 출퇴근 조회 권한을 정확히 판별한다', () => {

--- a/src/shared/lib/permissions.ts
+++ b/src/shared/lib/permissions.ts
@@ -1,6 +1,7 @@
 import type { User } from '../../entities/user/model/types'
 
-type MaybeUser = Pick<User, 'role'> | null | undefined
+type MaybeUser = Pick<User, 'id' | 'role' | 'team'> | null | undefined
+type MaybeTargetUser = Pick<User, 'id' | 'role' | 'team' | 'status'> | null | undefined
 
 export function canAccessAdmin(user: MaybeUser) {
   return user?.role === 'ADMIN'
@@ -14,16 +15,47 @@ export function canManageMemberRoles(user: MaybeUser) {
   return canAccessAdmin(user)
 }
 
+export function canManageMemberRolesFor(user: MaybeUser, target: MaybeTargetUser) {
+  if (!canAccessAdmin(user) || !target) return false
+  return user?.id !== target.id
+}
+
 export function canManageMemberStatus(user: MaybeUser) {
   return canAccessAdmin(user)
+}
+
+export function canManageMemberStatusFor(user: MaybeUser, target: MaybeTargetUser) {
+  if (!canAccessAdmin(user) || !target) return false
+  return user?.id !== target.id
 }
 
 export function canExpelMembers(user: MaybeUser) {
   return canAccessAdmin(user)
 }
 
+export function canExpelMembersFor(user: MaybeUser, target: MaybeTargetUser) {
+  if (!canAccessAdmin(user) || !target) return false
+  return user?.id !== target.id
+}
+
 export function canChangeMemberTeam(user: MaybeUser) {
   return canAccessAdmin(user) || canAccessTeamManagement(user)
+}
+
+export function canChangeMemberTeamFor(user: MaybeUser, target: MaybeTargetUser) {
+  if (!user || !target || user.id === target.id) return false
+
+  if (canAccessAdmin(user)) {
+    return true
+  }
+
+  if (!canAccessTeamManagement(user)) {
+    return false
+  }
+
+  return target.role === 'MEMBER'
+    && target.team === user.team
+    && (target.status ?? 'ACTIVE') === 'ACTIVE'
 }
 
 export function canManageTeams(user: MaybeUser) {

--- a/src/shared/ui/MemberManagementTable/MemberManagementTable.css
+++ b/src/shared/ui/MemberManagementTable/MemberManagementTable.css
@@ -153,6 +153,12 @@
   line-height: 1.4;
 }
 
+.member-actions-disabled {
+  color: var(--text-tertiary);
+  font-size: 0.74rem;
+  line-height: 1.4;
+}
+
 .member-status-tag {
   display: inline-flex;
   align-items: center;

--- a/src/shared/ui/MemberManagementTable/MemberManagementTable.tsx
+++ b/src/shared/ui/MemberManagementTable/MemberManagementTable.tsx
@@ -26,6 +26,10 @@ interface MemberManagementTableProps {
   onDeactivate?: (memberId: string) => void
   onActivate?: (memberId: string) => void
   onExpel?: (memberId: string) => void
+  canManageRoleFor?: (member: User) => boolean
+  canChangeTeamFor?: (member: User) => boolean
+  canManageStatusFor?: (member: User) => boolean
+  canExpelFor?: (member: User) => boolean
 }
 
 export function MemberManagementTable({
@@ -39,6 +43,10 @@ export function MemberManagementTable({
   onDeactivate,
   onActivate,
   onExpel,
+  canManageRoleFor,
+  canChangeTeamFor,
+  canManageStatusFor,
+  canExpelFor,
 }: MemberManagementTableProps) {
   const showRoleChange = typeof onOpenRoleChange === 'function'
   const showTeamChange = typeof onOpenTeamChange === 'function'
@@ -78,6 +86,27 @@ export function MemberManagementTable({
             members.map((member) => {
               const status = member.status ?? 'ACTIVE'
               const isInactive = status === 'INACTIVE'
+              const canManageRole = showRoleChange && (canManageRoleFor ? canManageRoleFor(member) : true)
+              const canChangeTeam = showTeamChange && (canChangeTeamFor ? canChangeTeamFor(member) : true)
+              const canManageStatus = showStatusAction && (canManageStatusFor ? canManageStatusFor(member) : true)
+              const canExpel = showExpel && (canExpelFor ? canExpelFor(member) : true)
+              const menuItems = [
+                ...(canManageRole
+                  ? [{
+                      label: '역할 변경',
+                      onSelect: () => onOpenRoleChange?.(member),
+                    }]
+                  : []),
+                ...(canExpel
+                  ? [{
+                      label: isInactive ? '퇴출됨' : '퇴출',
+                      tone: 'danger' as const,
+                      disabled: saving || isInactive,
+                      onSelect: () => onExpel?.(member.id),
+                    }]
+                  : []),
+              ]
+              const hasActionControls = canChangeTeam || menuItems.length > 0
 
               return (
                 <tr key={member.id}>
@@ -102,7 +131,7 @@ export function MemberManagementTable({
                         <span className={`member-status-tag ${status}`}>
                           {statusLabels[status] ?? status}
                         </span>
-                        {showStatusAction && (
+                        {canManageStatus && (
                           isInactive ? (
                             <button
                               type="button"
@@ -130,7 +159,7 @@ export function MemberManagementTable({
                     <td className="member-table-actions-cell">
                       <div className="member-actions-stack">
                         <div className="member-actions-inline">
-                          {showTeamChange && (
+                          {canChangeTeam && (
                             <button
                               type="button"
                               className="member-action-btn member-action-btn-secondary"
@@ -139,29 +168,16 @@ export function MemberManagementTable({
                               팀 변경 <ArrowLeftRight size={14} />
                             </button>
                           )}
-                          <ActionMenu
-                            items={[
-                              ...(showRoleChange
-                                ? [{
-                                    label: '역할 변경',
-                                    onSelect: () => onOpenRoleChange?.(member),
-                                  }]
-                                : []),
-                              ...(showExpel
-                                ? [{
-                                    label: isInactive ? '퇴출됨' : '퇴출',
-                                    tone: 'danger' as const,
-                                    disabled: saving || isInactive,
-                                    onSelect: () => onExpel?.(member.id),
-                                  }]
-                                : []),
-                            ]}
-                          />
+                          {menuItems.length > 0 && (
+                            <ActionMenu items={menuItems} />
+                          )}
                         </div>
-                        {showRoleChange && (
+                        {hasActionControls ? (
                           <span className="member-actions-caption">
-                            역할 변경 {showExpel ? '및 퇴출 관리' : '가능'}
+                            {canManageRole && canExpel ? '역할 변경 및 퇴출 관리' : '추가 관리 가능'}
                           </span>
+                        ) : (
+                          <span className="member-actions-disabled">관리 불가</span>
                         )}
                       </div>
                     </td>


### PR DESCRIPTION
## 작업 내용
- 관리자와 팀장 화면에서 권한별로 보여야 할 액션만 노출되도록 정리했습니다.
- 공용 멤버 관리 테이블에서 권한이 없는 액션은 숨기고 `관리 불가` 상태를 보여주도록 했습니다.
- 팀 관리 페이지는 팀장이 같은 팀의 활성 일반 멤버만 이동할 수 있도록 제한했습니다.

## 변경 이유
- 기존 화면에서는 관리자 본인 계정에도 역할 변경, 상태 변경, 퇴출 액션이 노출될 수 있었습니다.
- 팀장 화면에서도 같은 팀의 관리자나 팀장, 비활성 멤버까지 팀 이동 대상에 포함될 수 있었습니다.
- 실서버 점검 결과 팀장과 일반 멤버의 관리형 API 호출이 서버에서 200으로 응답해 프론트에서도 더 강한 가드가 필요했습니다.

## 상세 변경 사항
### 주요 변경
- [x] 관리자 본인 계정 보호 액션 숨김
- [x] 팀장 팀 이동 대상 제한과 예외 처리 추가
- [x] 공용 멤버 관리 테이블의 권한별 액션 렌더링 정리

### 추가 메모
- 실서버에서 팀장 역할 변경, 팀장 활성화, 일반 멤버 팀 변경 요청이 모두 200으로 응답하는 서버 권한 누락을 확인했습니다.
- 프론트에서는 숨김과 핸들러 가드로 보호했지만, 백엔드 권한 검증도 별도로 보강되어야 합니다.

## 테스트
- [x] npm run test:run -- src/shared/lib/__tests__/permissions.test.ts src/pages/admin/__tests__/Admin.test.tsx src/pages/members/__tests__/Members.test.tsx src/pages/team-management/__tests__/TeamManagement.test.tsx
- [x] npm run build
- [x] 실서버 관리자/팀장/멤버 토큰으로 관리형 API 호출 검증

## 리뷰 포인트
- 관리자 본인 행에 관리 액션이 노출되지 않는지
- 팀장이 같은 팀의 활성 일반 멤버에게만 팀 변경 버튼을 보는지
- 공용 멤버 관리 테이블이 권한 없는 액션에서 레이아웃이 깨지지 않는지

## 관련 이슈
- closes #216
