### PR TITLE
[fix] #217 - 근무 일정 저장과 조회를 서버 기준으로 정리

### DIFF
--- a/src/features/attendance/model/__tests__/useWorkSchedule.test.ts
+++ b/src/features/attendance/model/__tests__/useWorkSchedule.test.ts
@@ -156,13 +156,27 @@ describe('useWorkSchedule', () => {
       expect(JSON.parse(stored!)[0]).toBe('THIRD')
     })
 
-    it('localStorage에 저장된 workDays를 마운트 시 복원한다', async () => {
+    it('서버에 저장된 근무 일정이 있으면 localStorage보다 API 응답을 우선한다', async () => {
       localStorage.setItem('yanus-work-days', JSON.stringify(
         [false, true, true, true, true, false, false],
       ))
       const { result } = await mountHook()
-      expect(result.current.workDays[0]).toBe(false)
-      expect(result.current.workDays[1]).toBe(true)
+      expect(result.current.workDays.slice(0, 5)).toEqual([true, true, true, true, true])
+    })
+
+    it('근무 일정 조회가 실패하면 localStorage 저장값을 fallback으로 복원한다', async () => {
+      server.use(
+        http.get('/api/v1/work-schedules/me', () =>
+          HttpResponse.json({ code: 'ERROR', message: '불러오기 실패' }, { status: 500 }),
+        ),
+      )
+
+      localStorage.setItem('yanus-work-days', JSON.stringify(
+        [false, true, true, false, false, false, false],
+      ))
+
+      const { result } = await mountHook()
+      expect(result.current.workDays).toEqual([false, true, true, false, false, false, false])
     })
 
     it('localStorage에 저장된 weekPatterns를 마운트 시 복원한다', async () => {

--- a/src/features/attendance/model/useWorkSchedule.ts
+++ b/src/features/attendance/model/useWorkSchedule.ts
@@ -38,15 +38,18 @@ export function useWorkSchedule() {
   const [savedWorkDays, setSavedWorkDays] = useState<boolean[]>(DEFAULT_WORK_DAYS)
 
   useEffect(() => {
-    // localStorage에서 근무 요일 토글 상태 복원
     const storedDays = localStorage.getItem(WORK_DAYS_STORAGE_KEY)
+    let parsedStoredDays: boolean[] | null = null
     if (storedDays) {
       try {
         const parsed = JSON.parse(storedDays) as boolean[]
-        if (Array.isArray(parsed) && parsed.length === 7) setWorkDays(parsed)
+        if (Array.isArray(parsed) && parsed.length === 7) {
+          parsedStoredDays = parsed
+        }
       } catch {}
     }
 
+    // localStorage에서 근무 요일 토글 상태는 API 조회 실패 시에만 fallback으로 사용
     const storedWeekPatterns = localStorage.getItem(WORK_WEEK_PATTERNS_STORAGE_KEY)
     if (storedWeekPatterns) {
       try {
@@ -58,6 +61,13 @@ export function useWorkSchedule() {
     // API에서 요일별 근무 시간 불러오기
     getMyWorkSchedule()
       .then((items) => {
+        const activeDays = INDEX_TO_DOW.map((dow) =>
+          items.some((item) => item.dayOfWeek === dow),
+        )
+
+        setSavedWorkDays(activeDays)
+        setWorkDays(activeDays)
+
         if (items.length === 0) return
         setDaySchedules((prev) => {
           const next = [...prev]
@@ -72,20 +82,13 @@ export function useWorkSchedule() {
           }
           return next
         })
-        // localStorage에 저장된 토글 없으면 API 응답 기반으로 활성 요일 설정
-        if (!storedDays) {
-          const activeDays = INDEX_TO_DOW.map((dow) =>
-            items.some((item) => item.dayOfWeek === dow),
-          )
-          setSavedWorkDays(activeDays)
-          if (activeDays.some(Boolean)) setWorkDays(activeDays)
-        } else {
-          setSavedWorkDays(
-            INDEX_TO_DOW.map((dow) => items.some((item) => item.dayOfWeek === dow)),
-          )
+      })
+      .catch(() => {
+        if (parsedStoredDays) {
+          setWorkDays(parsedStoredDays)
+          setSavedWorkDays(parsedStoredDays)
         }
       })
-      .catch(() => {})
       .finally(() => setIsLoading(false))
   }, [])
 
@@ -104,6 +107,7 @@ export function useWorkSchedule() {
   const saveSchedule = async () => {
     setIsSaving(true)
     setError(null)
+    let saved = false
     try {
       const upsertPromises = workDays
         .map((active, i) => {
@@ -127,6 +131,7 @@ export function useWorkSchedule() {
       setSavedWorkDays([...workDays])
       localStorage.setItem(WORK_DAYS_STORAGE_KEY, JSON.stringify(workDays))
       localStorage.setItem(WORK_WEEK_PATTERNS_STORAGE_KEY, JSON.stringify(weekPatterns))
+      saved = true
     } catch (err) {
       if (err instanceof ApiError) {
         setError(err.message)
@@ -136,6 +141,8 @@ export function useWorkSchedule() {
     } finally {
       setIsSaving(false)
     }
+
+    return saved
   }
 
   return {

--- a/src/features/attendance/ui/SetWorkDaysPersonal.tsx
+++ b/src/features/attendance/ui/SetWorkDaysPersonal.tsx
@@ -13,7 +13,11 @@ const WEEK_PATTERN_OPTIONS: { value: WeekPattern; label: string }[] = [
   { value: 'LAST', label: '마지막 주' },
 ]
 
-export function SetWorkDaysPersonal() {
+interface SetWorkDaysPersonalProps {
+  onSaved?: () => void | Promise<void>
+}
+
+export function SetWorkDaysPersonal({ onSaved }: SetWorkDaysPersonalProps) {
   const { state } = useApp()
   const {
     workDays,
@@ -28,6 +32,13 @@ export function SetWorkDaysPersonal() {
     saveSchedule,
   } =
     useWorkSchedule()
+
+  const handleSave = async () => {
+    const saved = await saveSchedule()
+    if (saved) {
+      await onSaved?.()
+    }
+  }
 
   return (
     <div className="set-work-days-personal">
@@ -118,7 +129,7 @@ export function SetWorkDaysPersonal() {
 
       {error && <p className="schedule-error">{error}</p>}
 
-      <button className="schedule-save-btn" onClick={saveSchedule} disabled={isSaving}>
+      <button className="schedule-save-btn" onClick={handleSave} disabled={isSaving}>
         {isSaving ? '저장 중...' : '저장'}
       </button>
     </div>

--- a/src/features/attendance/ui/__tests__/SetWorkDaysPersonal.test.tsx
+++ b/src/features/attendance/ui/__tests__/SetWorkDaysPersonal.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterEach, afterAll, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
@@ -99,6 +99,22 @@ describe('SetWorkDaysPersonal', () => {
     render(<SetWorkDaysPersonal />, { wrapper })
     await waitFor(() => {
       expect(screen.getByText('저장')).toBeInTheDocument()
+    })
+  })
+
+  it('저장 성공 후 onSaved 콜백을 호출한다', async () => {
+    const onSaved = vi.fn()
+
+    render(<SetWorkDaysPersonal onSaved={onSaved} />, { wrapper })
+
+    await waitFor(() => {
+      expect(screen.getByText('저장')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('저장'))
+
+    await waitFor(() => {
+      expect(onSaved).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/pages/attendance/index.tsx
+++ b/src/pages/attendance/index.tsx
@@ -61,6 +61,30 @@ export function Attendance() {
       : state.users,
   )
 
+  const loadTeamSchedules = async () => {
+    if (!canSeeManagedAttendance || !state.currentUser) return
+
+    try {
+      if (state.currentUser.role === 'ADMIN') {
+        const schedules = await getAllWorkSchedules()
+        setTeamSchedules(schedules)
+        return
+      }
+
+      if (state.currentUser.role === 'TEAM_LEAD') {
+        const currentTeam = state.teams.find((team) => team.name === state.currentUser?.team)
+        if (!currentTeam) {
+          setTeamSchedules([])
+          return
+        }
+        const schedules = await getTeamWorkSchedules(currentTeam.id)
+        setTeamSchedules(schedules)
+      }
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '팀 근무 일정을 불러오지 못했습니다')
+    }
+  }
+
   const loadManagedAttendance = async (targetDate: string) => {
     if (!canSeeManagedAttendance || !state.currentUser) return
 
@@ -96,31 +120,7 @@ export function Attendance() {
   }, [])
 
   useEffect(() => {
-    if (!canSeeManagedAttendance || !state.currentUser) return
-
-    const loadSchedules = async () => {
-      try {
-        if (state.currentUser?.role === 'ADMIN') {
-          const schedules = await getAllWorkSchedules()
-          setTeamSchedules(schedules)
-          return
-        }
-
-        if (state.currentUser?.role === 'TEAM_LEAD') {
-          const currentTeam = state.teams.find((team) => team.name === state.currentUser?.team)
-          if (!currentTeam) {
-            setTeamSchedules([])
-            return
-          }
-          const schedules = await getTeamWorkSchedules(currentTeam.id)
-          setTeamSchedules(schedules)
-        }
-      } catch (err) {
-        setErrorMessage(err instanceof Error ? err.message : '팀 근무 일정을 불러오지 못했습니다')
-      }
-    }
-
-    loadSchedules()
+    loadTeamSchedules()
   }, [canSeeManagedAttendance, state.currentUser, state.teams])
 
   const todayRecords = records.filter((r) => r.workDate === todayStr)
@@ -212,7 +212,7 @@ export function Attendance() {
 
         <div className={`two-cards-row ${canSeeManagedAttendance ? 'admin-wide' : 'single'}`}>
           <section className="set-work-days-section glass">
-            <SetWorkDaysPersonal />
+            <SetWorkDaysPersonal onSaved={loadTeamSchedules} />
           </section>
           {canSeeManagedAttendance && (
             <section className="records-section glass">


### PR DESCRIPTION
## 작업 내용
- 근무 일정 훅에서 활성 요일은 서버 조회 결과를 우선하도록 정리했습니다.
- 근무 일정 조회 실패 시에만 브라우저 저장값을 fallback으로 사용하도록 바꿨습니다.
- 저장 후 출퇴근 페이지의 팀 근무 일정 패널이 즉시 다시 조회되도록 연결했습니다.

## 변경 이유
- 기존 구조는 localStorage의 요일 토글이 서버에 저장된 최신 근무 일정보다 먼저 적용될 수 있었습니다.
- 이 경우 실서버에서 저장된 일정과 화면에 보이는 일정이 달라질 수 있어 저장/조회 흐름이 흔들렸습니다.
- 관리자와 팀장이 자신의 일정을 저장한 직후 팀 근무 일정 패널에는 즉시 반영되지 않는 문제도 있었습니다.

## 상세 변경 사항
### 주요 변경
- [x] 서버 응답 기반 활성 요일 우선화
- [x] 조회 실패 시 localStorage fallback 처리
- [x] 저장 후 팀 근무 일정 패널 재조회 연결

### 추가 메모
- 실서버에서 테스트 멤버 계정으로 근무 일정 저장, 조회, 삭제 흐름을 확인했습니다.
- 임시 저장한 일정은 삭제로 원복했습니다.

## 테스트
- [x] npm run test:run -- src/features/attendance/model/__tests__/useWorkSchedule.test.ts src/features/attendance/ui/__tests__/SetWorkDaysPersonal.test.tsx src/pages/attendance/__tests__/Attendance.test.tsx
- [x] npm run build
- [x] 실서버 근무 일정 저장, 조회, 삭제 검증

## 리뷰 포인트
- 서버에 저장된 근무 일정이 브라우저 저장값보다 항상 우선하는지
- 조회 실패 상황에서만 localStorage fallback이 동작하는지
- 저장 후 관리자/팀장 화면의 팀 근무 일정 패널이 즉시 갱신되는지

## 관련 이슈
- closes #217
