### PR TITLE
[fix] #218 - 리프레시 토큰 만료 안내를 보강

### DIFF
--- a/src/pages/login/__tests__/Login.test.tsx
+++ b/src/pages/login/__tests__/Login.test.tsx
@@ -34,6 +34,7 @@ describe('Login 페이지', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
+    sessionStorage.clear()
     mockGetMe.mockResolvedValue({ id: '1', name: '홍길동', email: 'user@test.com', team: 'BACKEND', role: 'MEMBER', online: true })
   })
 
@@ -107,5 +108,14 @@ describe('Login 페이지', () => {
     await userEvent.type(screen.getByLabelText('비밀번호'), 'password123')
     await userEvent.click(screen.getByRole('button', { name: '로그인' }))
     expect(screen.getByRole('button', { name: /로그인/ })).toBeDisabled()
+  })
+
+  it('세션 만료 후 로그인 화면에 진입하면 안내 메시지를 표시한다', () => {
+    sessionStorage.setItem('yanus-session-expired-message', '세션이 만료되어 다시 로그인해 주세요')
+
+    renderLogin()
+
+    expect(screen.getByText('세션이 만료되어 다시 로그인해 주세요')).toBeInTheDocument()
+    expect(sessionStorage.getItem('yanus-session-expired-message')).toBeNull()
   })
 })

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { Mail, Lock, Eye, EyeOff, AlertCircle } from 'lucide-react'
 import { login, getMe } from '../../features/auth/api/authClient'
 import { useApp } from '../../features/auth/model'
+import { consumeSessionExpiredMessage } from '../../shared/lib/authStorage'
 import logoSrc from '../../assets/logo.png'
 import './login.css'
 
@@ -33,6 +34,13 @@ export function Login() {
   const [errors, setErrors] = useState<FormErrors>({})
   const [serverError, setServerError] = useState('')
   const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    const expiredMessage = consumeSessionExpiredMessage()
+    if (expiredMessage) {
+      setServerError(expiredMessage)
+    }
+  }, [])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/src/shared/api/__tests__/baseClient.test.ts
+++ b/src/shared/api/__tests__/baseClient.test.ts
@@ -9,6 +9,7 @@ beforeAll(() => server.listen())
 afterEach(() => {
   server.resetHandlers()
   localStorage.clear()
+  sessionStorage.clear()
 })
 afterAll(() => server.close())
 
@@ -97,6 +98,7 @@ describe('baseClient', () => {
     })
     expect(localStorage.getItem('accessToken')).toBeNull()
     expect(localStorage.getItem('refreshToken')).toBeNull()
+    expect(sessionStorage.getItem('yanus-session-expired-message')).toBe('세션이 만료되어 다시 로그인해 주세요')
   })
 
   it('4xx 응답 시 ApiError를 던진다', async () => {

--- a/src/shared/api/baseClient.ts
+++ b/src/shared/api/baseClient.ts
@@ -1,5 +1,11 @@
 const BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? ''
-import { clearAuthTokens, getAccessToken, getRefreshToken, storeAuthTokens } from '../lib/authStorage'
+import {
+  clearAuthTokens,
+  getAccessToken,
+  getRefreshToken,
+  markSessionExpired,
+  storeAuthTokens,
+} from '../lib/authStorage'
 
 export class ApiError extends Error {
   status: number
@@ -17,8 +23,9 @@ function getAuthHeaders(): Record<string, string> {
   return token ? { Authorization: `Bearer ${token}` } : {}
 }
 
-function handleUnauthorized() {
+function handleUnauthorized(message = '세션이 만료되어 다시 로그인해 주세요') {
   clearAuthTokens()
+  markSessionExpired(message)
   window.location.href = '/login'
 }
 
@@ -98,7 +105,7 @@ async function request<T>(path: string, options: RequestInit = {}, canRetry = tr
       if (refreshed) {
         return request<T>(path, options, false)
       }
-      handleUnauthorized()
+      handleUnauthorized('세션이 만료되어 다시 로그인해 주세요')
     }
     throw new ApiError(res.status, message, code)
   }
@@ -127,7 +134,7 @@ async function requestBlob(path: string, canRetry = true): Promise<Blob> {
       if (refreshed) {
         return requestBlob(path, false)
       }
-      handleUnauthorized()
+      handleUnauthorized('세션이 만료되어 다시 로그인해 주세요')
     }
     throw new ApiError(401, '인증이 필요합니다', 'UNAUTHORIZED')
   }
@@ -148,7 +155,7 @@ async function requestUpload<T>(path: string, formData: FormData, canRetry = tru
       if (refreshed) {
         return requestUpload<T>(path, formData, false)
       }
-      handleUnauthorized()
+      handleUnauthorized('세션이 만료되어 다시 로그인해 주세요')
     }
     throw new ApiError(401, '인증이 필요합니다', 'UNAUTHORIZED')
   }

--- a/src/shared/lib/authStorage.ts
+++ b/src/shared/lib/authStorage.ts
@@ -4,6 +4,8 @@ export interface AuthTokens {
   tokenType: string
 }
 
+const SESSION_EXPIRED_KEY = 'yanus-session-expired-message'
+
 export function getAccessToken() {
   return localStorage.getItem('accessToken')
 }
@@ -20,4 +22,16 @@ export function storeAuthTokens(tokens: AuthTokens) {
 export function clearAuthTokens() {
   localStorage.removeItem('accessToken')
   localStorage.removeItem('refreshToken')
+}
+
+export function markSessionExpired(message = '세션이 만료되어 다시 로그인해 주세요') {
+  sessionStorage.setItem(SESSION_EXPIRED_KEY, message)
+}
+
+export function consumeSessionExpiredMessage() {
+  const message = sessionStorage.getItem(SESSION_EXPIRED_KEY)
+  if (message) {
+    sessionStorage.removeItem(SESSION_EXPIRED_KEY)
+  }
+  return message
 }


### PR DESCRIPTION
## 작업 내용
- 세션 만료 시 로그인 화면에 안내 메시지가 남도록 정리했습니다.
- 리프레시 토큰 만료 후 자동 로그아웃 시 세션 만료 메시지를 sessionStorage에 저장하도록 추가했습니다.
- 로그인 화면 진입 시 남아 있는 세션 만료 메시지를 표시하고 소비하도록 연결했습니다.

## 변경 이유
- 기존 흐름은 리프레시 토큰이 만료되면 로그인 화면으로 이동하긴 했지만, 사용자는 왜 튕겼는지 바로 알기 어려웠습니다.
- 자동 로그아웃이 정상 동작해도 세션 만료 원인을 보여주지 않으면 UX가 거칠게 느껴질 수 있었습니다.

## 상세 변경 사항
### 주요 변경
- [x] 세션 만료 메시지 저장/소비 유틸 추가
- [x] baseClient 자동 로그아웃 시 세션 만료 메시지 기록
- [x] 로그인 화면 세션 만료 안내 표시와 테스트 보강

### 추가 메모
- 실서버에서 잘못된 refresh token으로 재발급 요청 시 401 응답을 확인했습니다.
- 프론트는 이 경우 토큰을 지우고 로그인 화면으로 보내며, 이제 만료 안내까지 같이 표시합니다.

## 테스트
- [x] npm run test:run -- src/shared/api/__tests__/baseClient.test.ts src/pages/login/__tests__/Login.test.tsx
- [x] npm run build
- [x] 실서버 refresh token invalid 401 응답 확인

## 리뷰 포인트
- 리프레시 토큰 만료 후 로그인 화면에 안내 메시지가 한 번만 표시되는지
- 세션 만료 메시지가 일반 로그인 실패 메시지와 충돌하지 않는지
- 토큰 정리 후 재진입 시 무한 리다이렉트가 없는지

## 관련 이슈
- closes #218
