### PR TITLE
[refactor] #222 - 공용 table 섹션 패턴을 확장 적용

### DIFF
--- a/src/pages/attendance/index.tsx
+++ b/src/pages/attendance/index.tsx
@@ -12,6 +12,7 @@ import {
 import type { AttendanceRecord, MemberWorkScheduleItem } from '../../shared/api/attendanceApi'
 import { exportAttendanceToCsv } from '../../shared/lib/exportCsv'
 import { sortUsersByTeamAndName } from '../../shared/lib/team'
+import { DataTableScroll, DataTableSection } from '../../shared/ui/DataTableSection'
 import { Toast } from '../../shared/ui/Toast'
 import { canViewManagedAttendance } from '../../shared/lib/permissions'
 import './attendance.css'
@@ -215,9 +216,12 @@ export function Attendance() {
             <SetWorkDaysPersonal onSaved={loadTeamSchedules} />
           </section>
           {canSeeManagedAttendance && (
-            <section className="records-section glass">
-              <h3>출퇴근 기록</h3>
-              <div className="records-table-wrap">
+            <DataTableSection
+              className="records-section"
+              title="출퇴근 기록"
+              description="관리 대상 멤버의 근무 일정과 출퇴근 상태를 날짜 기준으로 확인합니다."
+            >
+              <DataTableScroll className="records-table-wrap">
                 <table className="records-table">
                   <thead>
                     <tr>
@@ -264,20 +268,23 @@ export function Attendance() {
                     ))}
                   </tbody>
                 </table>
-              </div>
+              </DataTableScroll>
               <div className="pagination">
                 <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}><ChevronLeft size={18} /></button>
                 <span>{page} / {totalPages} 페이지</span>
                 <button disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}><ChevronRight size={18} /></button>
               </div>
-            </section>
+            </DataTableSection>
           )}
         </div>
 
         {/* 내 출퇴근 이력 — 모든 유저 */}
-        <section className="my-history-section glass">
-          <h3>내 출퇴근 이력</h3>
-          <div className="records-table-wrap">
+        <DataTableSection
+          className="my-history-section"
+          title="내 출퇴근 이력"
+          description="개인 출퇴근 기록을 최근 순서대로 확인할 수 있습니다."
+        >
+          <DataTableScroll className="records-table-wrap">
             <table className="records-table">
               <thead>
                 <tr>
@@ -306,8 +313,8 @@ export function Attendance() {
                 )}
               </tbody>
             </table>
-          </div>
-        </section>
+          </DataTableScroll>
+        </DataTableSection>
 
         {canSeeManagedAttendance && (
           <div className="summary-stats">

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -10,6 +10,7 @@ import {
   canManageMemberRolesFor,
   canManageMemberStatusFor,
 } from '../../shared/lib/permissions'
+import { DataTableSection } from '../../shared/ui/DataTableSection'
 import { MemberManagementTable } from '../../shared/ui/MemberManagementTable'
 import { SectionHeader } from '../../shared/ui/SectionHeader'
 import { Toast } from '../../shared/ui/Toast'
@@ -211,11 +212,11 @@ export function Members() {
       </div>
 
       <div className="members-content">
-        <div className="table-section glass">
-          <SectionHeader
-            title="멤버 목록"
-            description="활성 멤버를 팀과 역할 기준으로 빠르게 확인할 수 있습니다."
-          />
+        <DataTableSection
+          className="table-section"
+          title="멤버 목록"
+          description="활성 멤버를 팀과 역할 기준으로 빠르게 확인할 수 있습니다."
+        >
           <MemberManagementTable
             members={filtered}
             saving={saving}
@@ -229,7 +230,7 @@ export function Members() {
             canManageStatusFor={(member) => canManageMemberStatusFor(state.currentUser, member)}
             canExpelFor={(member) => canExpelMembersFor(state.currentUser, member)}
           />
-        </div>
+        </DataTableSection>
 
         <aside className="stats-sidebar glass">
           <SectionHeader

--- a/src/pages/team-management/index.tsx
+++ b/src/pages/team-management/index.tsx
@@ -5,8 +5,8 @@ import type { User } from '../../entities/user/model/types'
 import { updateMemberTeam } from '../../shared/api/membersApi'
 import { formatTeamName, sortUsersByTeamAndName } from '../../shared/lib/team'
 import { canChangeMemberTeamFor } from '../../shared/lib/permissions'
+import { DataTableScroll, DataTableSection } from '../../shared/ui/DataTableSection'
 import { EmptyState } from '../../shared/ui/EmptyState'
-import { SectionHeader } from '../../shared/ui/SectionHeader'
 import { Toast } from '../../shared/ui/Toast'
 import './team-management.css'
 
@@ -110,11 +110,11 @@ export function TeamManagement() {
         </div>
       </header>
 
-      <section className="team-management-panel glass">
-        <SectionHeader
-          title="팀 멤버 목록"
-          description="팀장은 같은 팀의 활성 일반 멤버만 다른 팀으로 이동할 수 있습니다."
-        />
+      <DataTableSection
+        className="team-management-panel"
+        title="팀 멤버 목록"
+        description="팀장은 같은 팀의 활성 일반 멤버만 다른 팀으로 이동할 수 있습니다."
+      >
         <div className="team-management-toolbar">
           <div className="team-management-search">
             <input
@@ -126,7 +126,7 @@ export function TeamManagement() {
           <p className="team-management-caption">역할 변경, 상태 변경, 퇴출은 관리자만 가능합니다.</p>
         </div>
 
-        <div className="team-management-table-wrap">
+        <DataTableScroll className="team-management-table-wrap">
           <table className="team-management-table">
             <thead>
               <tr>
@@ -181,8 +181,8 @@ export function TeamManagement() {
               )}
             </tbody>
           </table>
-        </div>
-      </section>
+        </DataTableScroll>
+      </DataTableSection>
 
       {changeTeamFor && (
         <div className="team-management-modal-overlay" onClick={() => setChangeTeamFor(null)}>

--- a/src/shared/ui/DataTableSection/DataTableSection.css
+++ b/src/shared/ui/DataTableSection/DataTableSection.css
@@ -1,0 +1,23 @@
+.data-table-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.data-table-scroll {
+  overflow-x: auto;
+  max-width: 100%;
+  width: 100%;
+  min-width: 0;
+  padding-bottom: 6px;
+  scrollbar-width: thin;
+}
+
+@media (max-width: 768px) {
+  .data-table-section {
+    padding: 18px;
+  }
+}

--- a/src/shared/ui/DataTableSection/DataTableSection.tsx
+++ b/src/shared/ui/DataTableSection/DataTableSection.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from 'react'
+import { SectionHeader } from '../SectionHeader'
+import './DataTableSection.css'
+
+interface DataTableSectionProps {
+  title: string
+  description?: string
+  className?: string
+  children: ReactNode
+}
+
+interface DataTableScrollProps {
+  className?: string
+  children: ReactNode
+}
+
+export function DataTableSection({ title, description, className = '', children }: DataTableSectionProps) {
+  return (
+    <section className={`data-table-section glass ${className}`.trim()}>
+      <SectionHeader title={title} description={description} />
+      {children}
+    </section>
+  )
+}
+
+export function DataTableScroll({ className = '', children }: DataTableScrollProps) {
+  return (
+    <div className={`data-table-scroll ${className}`.trim()}>
+      {children}
+    </div>
+  )
+}

--- a/src/shared/ui/DataTableSection/index.ts
+++ b/src/shared/ui/DataTableSection/index.ts
@@ -1,0 +1,1 @@
+export { DataTableSection, DataTableScroll } from './DataTableSection'


### PR DESCRIPTION
## 작업 내용
- 공용 DataTableSection, DataTableScroll 컴포넌트를 추가했습니다.
- 멤버, 팀 관리, 출퇴근 이력 섹션에 같은 테이블 섹션 패턴을 적용했습니다.
- 테이블 섹션의 헤더, 패딩, 스크롤 래퍼 구조를 공통화했습니다.

## 변경 이유
- 멤버/팀관리/출퇴근 이력 화면은 비슷한 테이블 구조를 각각 따로 꾸미고 있어 CSS 수정이 반복될수록 다시 흔들릴 여지가 있었습니다.
- 공용 섹션 틀을 두면 이후 디자인 수정이나 반응형 보정이 한 곳에서 더 쉽게 관리됩니다.

## 상세 변경 사항
### 주요 변경
- [x] DataTableSection 추가
- [x] DataTableScroll 추가
- [x] 멤버, 팀 관리, 출퇴근 이력에 공통 패턴 적용

### 추가 메모
- 기존 MemberManagementTable은 내부 테이블 패턴이 이미 분리되어 있어, 이번에는 바깥 섹션 레벨 공통화에 집중했습니다.

## 테스트
- [x] npm run test:run -- src/pages/members/__tests__/Members.test.tsx src/pages/team-management/__tests__/TeamManagement.test.tsx src/pages/attendance/__tests__/Attendance.test.tsx
- [x] npm run build

## 리뷰 포인트
- 멤버, 팀 관리, 출퇴근 이력 섹션이 같은 패딩/헤더/스크롤 감각으로 보이는지
- 테이블 래퍼를 공용화해도 반응형 스크롤이 깨지지 않는지

## 관련 이슈
- closes #222
