### PR TITLE
[fix] #240 - 라이트 모드 대비와 버튼 가독성을 정리

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -26,6 +26,8 @@
   --bg-soft: rgba(255, 255, 255, 0.06);
   --bg-soft-strong: rgba(255, 255, 255, 0.1);
   --bg-input: rgba(10, 14, 28, 0.42);
+  --surface-elevated: rgba(26, 31, 51, 0.9);
+  --surface-muted: rgba(255, 255, 255, 0.08);
   --bg-sidebar: rgba(11, 15, 28, 0.88);
   --bg-sidebar-solid: #101426;
   --bg-overlay: rgba(6, 10, 22, 0.62);
@@ -36,6 +38,7 @@
   --text-primary: #edf1ff;
   --text-secondary: #a8b4d3;
   --text-muted: #72809d;
+  --text-tertiary: #8d9ab7;
   --text-on-accent: #f8f7ff;
   --shadow-soft: 0 20px 60px rgba(0, 0, 0, 0.24);
   --shadow-strong: 0 24px 80px rgba(0, 0, 0, 0.34);
@@ -56,6 +59,8 @@
   --bg-soft: rgba(77, 92, 132, 0.1);
   --bg-soft-strong: rgba(77, 92, 132, 0.18);
   --bg-input: rgba(244, 247, 253, 0.98);
+  --surface-elevated: rgba(255, 255, 255, 0.98);
+  --surface-muted: rgba(84, 102, 146, 0.08);
   --bg-sidebar: rgba(248, 251, 255, 0.94);
   --bg-sidebar-solid: #f8fbff;
   --bg-overlay: rgba(73, 88, 126, 0.18);
@@ -66,6 +71,7 @@
   --text-primary: #19243d;
   --text-secondary: #4f5f7f;
   --text-muted: #6f7d99;
+  --text-tertiary: #8692ad;
   --text-on-accent: #ffffff;
   --shadow-soft: 0 18px 40px rgba(97, 114, 150, 0.16);
   --shadow-strong: 0 24px 64px rgba(97, 114, 150, 0.24);

--- a/src/pages/attendance/attendance.css
+++ b/src/pages/attendance/attendance.css
@@ -66,7 +66,7 @@
   padding: 10px 18px;
   border-radius: 10px;
   background: var(--gradient-purple);
-  color: var(--text-primary);
+  color: var(--text-on-accent);
   font-weight: 500;
 }
 
@@ -87,6 +87,17 @@
 .filter-tabs button.active {
   background: rgba(124, 58, 237, 0.3);
   color: var(--accent-purple-light);
+}
+
+:root[data-theme='light'] .filter-apply-btn {
+  background: rgba(107, 79, 196, 0.12);
+  border-color: rgba(107, 79, 196, 0.22);
+  color: var(--accent-purple-dark);
+}
+
+:root[data-theme='light'] .filter-tabs button.active {
+  background: rgba(107, 79, 196, 0.16);
+  color: var(--accent-purple-dark);
 }
 
 .team-status-section {

--- a/src/pages/calendar/calendar.css
+++ b/src/pages/calendar/calendar.css
@@ -474,7 +474,7 @@
 .edit-task-actions .add-btn {
   padding: 8px 20px;
   background: var(--accent-purple);
-  color: var(--text-primary);
+  color: var(--text-on-accent);
   border-radius: 8px;
   font-weight: 600;
 }
@@ -588,7 +588,7 @@
 .add-task-inline-btn {
   padding: 12px 16px;
   background: var(--accent-purple);
-  color: var(--text-primary);
+  color: var(--text-on-accent);
   border-radius: 10px;
   font-weight: 600;
   font-size: 0.9rem;
@@ -725,7 +725,7 @@
   width: 100%;
   padding: 12px;
   background: var(--accent-purple);
-  color: var(--text-primary);
+  color: var(--text-on-accent);
   border-radius: 10px;
   font-weight: 600;
   font-size: 0.9rem;
@@ -920,7 +920,7 @@
 
 :root[data-theme='light'] .fullcalendar-wrapper .fc-button:disabled {
   background: rgba(255, 255, 255, 0.72);
-  color: var(--text-muted);
+  color: var(--text-secondary);
 }
 
 :root[data-theme='light'] .tasks-tabs span {

--- a/src/pages/chat/chat.css
+++ b/src/pages/chat/chat.css
@@ -644,6 +644,7 @@
 .link-modal-actions button.primary {
   background: var(--gradient-purple);
   border: none;
+  color: var(--text-on-accent);
 }
 
 .send-btn {

--- a/src/pages/login/login.css
+++ b/src/pages/login/login.css
@@ -26,9 +26,9 @@
   position: relative;
   z-index: 1;
   box-shadow:
-    0 0 0 1px rgba(124, 58, 237, 0.18),
-    0 24px 48px rgba(0, 0, 0, 0.4),
-    0 4px 16px rgba(124, 58, 237, 0.12);
+    0 0 0 1px color-mix(in srgb, var(--accent-purple) 18%, transparent),
+    var(--shadow-strong),
+    0 4px 16px color-mix(in srgb, var(--accent-purple) 12%, transparent);
 }
 
 .login-logo {
@@ -101,8 +101,8 @@
 .form-input {
   width: 100%;
   padding: 11px 44px 11px 40px;
-  background: rgba(10, 8, 22, 0.7);
-  border: 1px solid rgba(148, 163, 184, 0.14);
+  background: var(--bg-input);
+  border: 1px solid var(--border-color);
   border-radius: 10px;
   color: var(--text-primary);
   font-size: 0.93rem;
@@ -120,8 +120,8 @@
 
 .form-input:focus {
   border-color: var(--accent-purple);
-  background: rgba(15, 10, 30, 0.85);
-  box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.18);
+  background: var(--bg-card-solid);
+  box-shadow: 0 0 0 3px var(--ring-color);
 }
 
 .form-input.error {
@@ -156,7 +156,7 @@
 
 .pw-toggle:hover {
   color: var(--text-secondary);
-  background: rgba(148, 163, 184, 0.08);
+  background: var(--bg-soft);
 }
 
 .login-btn {
@@ -197,10 +197,10 @@
   align-items: center;
   gap: 8px;
   padding: 11px 14px;
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.28);
+  background: color-mix(in srgb, var(--error) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--error) 24%, transparent);
   border-radius: 8px;
-  color: #fca5a5;
+  color: var(--error);
   font-size: 0.85rem;
   line-height: 1.4;
 }
@@ -240,7 +240,29 @@
 }
 
 .login-footer a:hover {
-  color: #c4b5fd;
+  color: var(--accent-purple);
+}
+
+:root[data-theme='light'] .login-page::after {
+  background:
+    radial-gradient(ellipse 80% 60% at 15% 15%, rgba(107, 79, 196, 0.14), transparent),
+    radial-gradient(ellipse 55% 55% at 85% 85%, rgba(59, 130, 246, 0.12), transparent),
+    radial-gradient(ellipse 40% 40% at 60% 10%, rgba(236, 72, 153, 0.08), transparent);
+}
+
+:root[data-theme='light'] .login-card {
+  box-shadow:
+    0 0 0 1px rgba(107, 79, 196, 0.12),
+    0 24px 52px rgba(97, 114, 150, 0.18),
+    0 6px 18px rgba(107, 79, 196, 0.08);
+}
+
+:root[data-theme='light'] .login-logo-img {
+  filter: drop-shadow(0 8px 18px rgba(107, 79, 196, 0.16));
+}
+
+:root[data-theme='light'] .login-btn {
+  box-shadow: 0 10px 24px rgba(107, 79, 196, 0.18);
 }
 
 @media (max-width: 480px) {

--- a/src/pages/members/members.css
+++ b/src/pages/members/members.css
@@ -478,7 +478,7 @@
 .confirm-btn {
   padding: 10px 24px;
   background: var(--gradient-purple);
-  color: var(--text-primary);
+  color: var(--text-on-accent);
   border-radius: 8px;
   font-weight: 600;
 }

--- a/src/pages/register/register.css
+++ b/src/pages/register/register.css
@@ -26,9 +26,9 @@
   position: relative;
   z-index: 1;
   box-shadow:
-    0 0 0 1px rgba(124, 58, 237, 0.18),
-    0 24px 48px rgba(0, 0, 0, 0.4),
-    0 4px 16px rgba(124, 58, 237, 0.12);
+    0 0 0 1px color-mix(in srgb, var(--accent-purple) 18%, transparent),
+    var(--shadow-strong),
+    0 4px 16px color-mix(in srgb, var(--accent-purple) 12%, transparent);
 }
 
 .register-logo {
@@ -118,10 +118,10 @@
   align-items: center;
   gap: 8px;
   padding: 11px 14px;
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.28);
+  background: color-mix(in srgb, var(--error) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--error) 24%, transparent);
   border-radius: 8px;
-  color: #fca5a5;
+  color: var(--error);
   font-size: 0.85rem;
   line-height: 1.4;
 }
@@ -148,7 +148,29 @@
 }
 
 .register-footer a:hover {
-  color: #c4b5fd;
+  color: var(--accent-purple);
+}
+
+:root[data-theme='light'] .register-page::after {
+  background:
+    radial-gradient(ellipse 72% 58% at 12% 18%, rgba(107, 79, 196, 0.14), transparent),
+    radial-gradient(ellipse 55% 55% at 84% 82%, rgba(59, 130, 246, 0.12), transparent),
+    radial-gradient(ellipse 40% 40% at 50% 8%, rgba(16, 185, 129, 0.08), transparent);
+}
+
+:root[data-theme='light'] .register-card {
+  box-shadow:
+    0 0 0 1px rgba(107, 79, 196, 0.12),
+    0 24px 52px rgba(97, 114, 150, 0.18),
+    0 6px 18px rgba(107, 79, 196, 0.08);
+}
+
+:root[data-theme='light'] .register-logo-img {
+  filter: drop-shadow(0 8px 18px rgba(107, 79, 196, 0.16));
+}
+
+:root[data-theme='light'] .register-btn {
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.16);
 }
 
 @media (max-width: 480px) {

--- a/src/widgets/StickyChatWidget/StickyChatWidget.css
+++ b/src/widgets/StickyChatWidget/StickyChatWidget.css
@@ -64,7 +64,7 @@
 .chat-msg.user {
   align-self: flex-end;
   background: var(--accent-purple);
-  color: var(--text-primary);
+  color: var(--text-on-accent);
 }
 
 .chat-msg.ai {


### PR DESCRIPTION
## 작업 내용
- 라이트 모드에서 남아 있던 다크모드 스타일 잔재를 정리했습니다.
- 로그인/회원가입 화면 배경과 입력 필드 스타일을 테마 토큰 기준으로 보강했습니다.
- 강조 버튼과 공용 위젯 말풍선의 텍스트 대비를 라이트 모드에서도 읽히도록 수정했습니다.

## 변경 이유
- 라이트 모드에서 버튼 텍스트가 배경과 겹쳐 잘 보이지 않는 구간이 있었습니다.
- 로그인/회원가입 화면에는 어두운 배경 하드코딩이 남아 있었습니다.
- 누락된 공통 토큰 때문에 일부 공용 UI가 라이트 모드에서 일관되지 않았습니다.

## 상세 변경 사항
- `src/index.css`에 누락된 공통 surface/text 토큰을 추가했습니다.
- `src/pages/login/login.css`, `src/pages/register/register.css`에서 하드코딩된 어두운 입력/카드 배경을 테마 변수 기준으로 정리했습니다.
- `src/pages/attendance/attendance.css`, `src/pages/calendar/calendar.css`, `src/pages/chat/chat.css`, `src/pages/members/members.css`, `src/widgets/StickyChatWidget/StickyChatWidget.css`에서 강조 버튼과 말풍선 대비를 수정했습니다.

## 테스트
- `npm run test:run -- src/pages/login/__tests__/Login.test.tsx src/shared/theme/__tests__/ThemeProvider.test.tsx`
- `npm run build`

## 리뷰 포인트
- 라이트 모드에서 로그인/회원가입 화면 입력 필드와 카드가 자연스럽게 보이는지 확인 부탁드립니다.
- 보라/그라데이션 버튼의 텍스트 대비가 충분한지 봐주세요.

## 관련 이슈
- #240