### PR TITLE
[fix] #242 - 초광폭 모니터 반응형 레이아웃 정리

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -46,6 +46,12 @@
   --nav-hover: rgba(138, 114, 216, 0.12);
   --nav-active: rgba(138, 114, 216, 0.2);
   --bg-dark: var(--bg-app);
+  --page-max-regular: 1200px;
+  --page-max-wide: 1480px;
+  --page-max-ultra: 1760px;
+  --page-shell-padding: clamp(20px, 2vw, 36px);
+  --panel-width-md: clamp(280px, 20vw, 340px);
+  --panel-width-lg: clamp(300px, 24vw, 380px);
 }
 
 :root[data-theme='light'] {

--- a/src/pages/admin/admin.css
+++ b/src/pages/admin/admin.css
@@ -1,5 +1,6 @@
 .admin-page {
-  max-width: 1200px;
+  width: 100%;
+  max-width: var(--page-max-wide);
   margin: 0 auto;
   display: flex;
   flex-direction: column;
@@ -97,7 +98,7 @@
 /* ── 탭 콘텐츠 ── */
 .admin-tab-content {
   border-radius: 16px;
-  padding: 24px;
+  padding: clamp(22px, 1.8vw, 28px);
   border: 1px solid rgba(255, 255, 255, 0.06);
 }
 
@@ -245,6 +246,13 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 16px;
+}
+
+@media (min-width: 1680px) {
+  .admin-team-grid {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 20px;
+  }
 }
 
 .admin-team-card {

--- a/src/pages/ai-chat/ai-chat.css
+++ b/src/pages/ai-chat/ai-chat.css
@@ -4,6 +4,9 @@
   display: flex;
   flex-direction: column;
   gap: 18px;
+  width: 100%;
+  max-width: var(--page-max-wide);
+  margin: 0 auto;
 }
 
 .ai-header {
@@ -28,7 +31,7 @@
 }
 
 .ai-chat-area {
-  padding: 24px;
+  padding: clamp(22px, 2vw, 30px);
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -42,12 +45,14 @@
   min-height: 200px;
   margin-bottom: 20px;
   padding: 4px 4px 0;
+  width: min(100%, 1260px);
+  margin-inline: auto;
 }
 
 .msg-bubble {
   display: flex;
   gap: 12px;
-  max-width: 85%;
+  max-width: min(760px, 82%);
   margin-bottom: 16px;
 }
 
@@ -81,6 +86,8 @@
   background: var(--bg-soft);
   border: 1px solid var(--border-color);
   border-radius: 20px;
+  width: min(100%, 1260px);
+  margin-inline: auto;
 }
 
 .suggestions p {
@@ -112,6 +119,14 @@
   display: flex;
   gap: 12px;
   padding-top: 4px;
+  width: min(100%, 1260px);
+  margin: 0 auto;
+}
+
+@media (min-width: 1680px) {
+  .ai-chat-area {
+    padding: clamp(24px, 2.2vw, 34px);
+  }
 }
 
 .input-area input {

--- a/src/pages/attendance/attendance.css
+++ b/src/pages/attendance/attendance.css
@@ -1,6 +1,7 @@
 .attendance-page {
-  max-width: 1400px;
+  max-width: var(--page-max-ultra);
   width: 100%;
+  margin: 0 auto;
 }
 
 .attendance-header {
@@ -123,7 +124,7 @@
 
 .two-cards-row {
   display: grid;
-  grid-template-columns: 1fr 1.5fr;
+  grid-template-columns: minmax(360px, 0.94fr) minmax(520px, 1.26fr);
   gap: 24px;
   min-width: 0;
 }
@@ -151,6 +152,13 @@
   padding: 24px;
   min-width: 0;
   overflow: hidden;
+}
+
+@media (min-width: 1680px) {
+  .two-cards-row {
+    grid-template-columns: minmax(400px, 0.92fr) minmax(640px, 1.3fr);
+    gap: 28px;
+  }
 }
 
 .records-section h3 {

--- a/src/pages/calendar/calendar.css
+++ b/src/pages/calendar/calendar.css
@@ -11,13 +11,13 @@
 
 .calendar-main {
   flex: 1;
-  padding: 36px 40px 48px;
+  padding: clamp(32px, 2.6vw, 44px) clamp(28px, 3vw, 48px) clamp(40px, 3vw, 56px);
   position: relative;
   overflow: auto;
 }
 
 .fullcalendar-wrapper {
-  max-width: 85%;
+  width: min(100%, 1360px);
   margin: 0 auto;
   position: relative;
 }
@@ -488,7 +488,7 @@
 
 /* Tasks Sidebar - dark grey, integrated - 사진처럼 뚜렷한 세로 구분선 */
 .tasks-sidebar {
-  width: 340px;
+  width: clamp(320px, 22vw, 400px);
   padding: 24px;
   overflow-y: auto;
   flex-shrink: 0;
@@ -940,6 +940,17 @@
 :root[data-theme='light'] .task-item:hover,
 :root[data-theme='light'] .event-item:hover {
   background: rgba(107, 79, 196, 0.05);
+}
+
+@media (min-width: 1680px) {
+  .fullcalendar-wrapper {
+    width: min(100%, 1480px);
+  }
+
+  .tasks-sidebar {
+    width: clamp(340px, 21vw, 420px);
+    padding: 28px;
+  }
 }
 
 @media (max-width: 900px) {

--- a/src/pages/chat/chat.css
+++ b/src/pages/chat/chat.css
@@ -1,5 +1,7 @@
 .chat-page {
   display: flex;
+  width: 100%;
+  max-width: var(--page-max-ultra);
   min-height: 0;
   height: clamp(620px, calc(100dvh - 180px), 860px);
   max-height: calc(100dvh - 180px);
@@ -9,6 +11,7 @@
   background: var(--bg-card);
   box-shadow: var(--shadow-soft);
   overflow: hidden;
+  margin: 0 auto;
 }
 
 .chat-page > * {
@@ -16,7 +19,7 @@
 }
 
 .chat-sidebar {
-  width: 280px;
+  width: clamp(280px, 20vw, 360px);
   flex-shrink: 0;
   min-height: 0;
   overflow-y: auto;
@@ -263,7 +266,7 @@
 .chat-messages {
   flex: 1;
   overflow-y: auto;
-  padding: 24px;
+  padding: 24px clamp(24px, 2.8vw, 42px);
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.01) 0%, rgba(255, 255, 255, 0) 100%),
     radial-gradient(circle at top right, rgba(212, 74, 153, 0.08), transparent 30%);
@@ -333,7 +336,7 @@
 }
 
 .msg-content {
-  max-width: 75%;
+  max-width: min(760px, 72%);
   padding: 12px 16px;
   background: var(--bg-soft);
   border: 1px solid var(--border-color);
@@ -448,7 +451,7 @@
 }
 
 .chat-input-area {
-  padding: 18px 24px 22px;
+  padding: 18px clamp(24px, 2.8vw, 42px) 22px;
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -460,16 +463,20 @@
 
 .input-preview {
   margin-bottom: 4px;
+  width: min(100%, 1260px);
+  margin-inline: auto;
 }
 
 .input-preview-content {
-  max-width: 70%;
+  max-width: min(720px, 68%);
 }
 
 .input-row {
   display: flex;
   gap: 12px;
   align-items: center;
+  width: min(100%, 1260px);
+  margin: 0 auto;
 }
 
 .chat-input-area .chat-input {
@@ -493,6 +500,8 @@
 .format-toolbar {
   display: flex;
   gap: 4px;
+  width: min(100%, 1260px);
+  margin: 0 auto;
 }
 
 .format-toolbar button {
@@ -555,6 +564,8 @@
   flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 8px;
+  width: min(100%, 1260px);
+  margin-inline: auto;
 }
 
 .attach-tag {
@@ -667,6 +678,24 @@
 :root[data-theme='light'] .msg.own .msg-content {
   background: rgba(107, 79, 196, 0.16);
   border-color: rgba(107, 79, 196, 0.2);
+}
+
+@media (min-width: 1680px) {
+  .chat-page {
+    height: clamp(700px, calc(100dvh - 180px), 920px);
+  }
+
+  .chat-header {
+    padding-inline: clamp(28px, 2.6vw, 42px);
+  }
+
+  .chat-messages {
+    padding-inline: clamp(30px, 3vw, 48px);
+  }
+
+  .chat-input-area {
+    padding-inline: clamp(30px, 3vw, 48px);
+  }
 }
 
 @media (max-width: 768px) {

--- a/src/pages/dashboard/dashboard.css
+++ b/src/pages/dashboard/dashboard.css
@@ -1,14 +1,16 @@
 .dashboard {
-  max-width: 1200px;
+  width: 100%;
+  max-width: var(--page-max-ultra);
   min-height: calc(100vh - 180px);
   height: auto;
   display: flex;
   flex-direction: column;
+  margin: 0 auto;
 }
 
 .dashboard-grid {
   display: grid;
-  grid-template-columns: 240px 1fr 1fr;
+  grid-template-columns: minmax(240px, 300px) minmax(0, 1.12fr) minmax(0, 1fr);
   grid-template-rows: 1fr 1fr;
   gap: 20px;
   flex: 1;
@@ -224,6 +226,17 @@
   grid-column: 3;
   grid-row: 2;
   min-height: 160px;
+}
+
+@media (min-width: 1680px) {
+  .dashboard-grid {
+    grid-template-columns: minmax(260px, 320px) minmax(0, 1.18fr) minmax(0, 1.02fr);
+    gap: 24px;
+  }
+
+  .card {
+    padding: 24px 26px;
+  }
 }
 
 .card {

--- a/src/pages/drive/drive.css
+++ b/src/pages/drive/drive.css
@@ -1,8 +1,10 @@
 .drive-page {
-  max-width: 1180px;
+  width: 100%;
+  max-width: var(--page-max-wide);
   display: flex;
   flex-direction: column;
   gap: 24px;
+  margin: 0 auto;
 }
 
 .drive-header {
@@ -106,7 +108,7 @@
 
 .drive-layout {
   display: grid;
-  grid-template-columns: 320px minmax(0, 1fr);
+  grid-template-columns: var(--panel-width-md) minmax(0, 1fr);
   gap: 20px;
 }
 
@@ -202,7 +204,14 @@
 }
 
 .drive-content {
-  padding: 24px;
+  padding: clamp(22px, 1.8vw, 28px);
+}
+
+@media (min-width: 1680px) {
+  .drive-layout {
+    grid-template-columns: var(--panel-width-lg) minmax(0, 1fr);
+    gap: 24px;
+  }
 }
 
 .drive-section-head {

--- a/src/pages/members/members.css
+++ b/src/pages/members/members.css
@@ -1,6 +1,7 @@
 .members-page {
-  max-width: 1400px;
+  max-width: var(--page-max-ultra);
   width: 100%;
+  margin: 0 auto;
 }
 
 .members-header {
@@ -105,16 +106,23 @@
 
 .members-content {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 320px;
+  grid-template-columns: minmax(0, 1fr) var(--panel-width-md);
   gap: 24px;
   align-items: start;
 }
 
 .table-section {
-  padding: 24px;
+  padding: clamp(22px, 1.8vw, 28px);
   overflow: hidden;
   overflow-y: hidden;
   min-width: 0;
+}
+
+@media (min-width: 1680px) {
+  .members-content {
+    grid-template-columns: minmax(0, 1fr) clamp(320px, 21vw, 380px);
+    gap: 28px;
+  }
 }
 
 .table-section h3 {

--- a/src/pages/settings/settings.css
+++ b/src/pages/settings/settings.css
@@ -2,12 +2,14 @@
   display: flex;
   flex-direction: column;
   gap: 24px;
-  max-width: 1160px;
+  width: 100%;
+  max-width: var(--page-max-wide);
+  margin: 0 auto;
 }
 
 .settings-header {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(280px, 380px);
+  grid-template-columns: minmax(0, 1fr) clamp(320px, 28vw, 420px);
   align-items: end;
   gap: 20px;
 }
@@ -68,7 +70,7 @@
 
 .settings-layout {
   display: grid;
-  grid-template-columns: 220px minmax(0, 1fr);
+  grid-template-columns: clamp(220px, 18vw, 260px) minmax(0, 1fr);
   gap: 24px;
   align-items: start;
 }
@@ -111,8 +113,19 @@
 
 .settings-content {
   border-radius: 24px;
-  padding: 30px;
+  padding: clamp(28px, 2vw, 34px);
   min-width: 0;
+}
+
+@media (min-width: 1680px) {
+  .settings-page {
+    gap: 28px;
+  }
+
+  .settings-layout {
+    grid-template-columns: clamp(240px, 17vw, 280px) minmax(0, 1fr);
+    gap: 28px;
+  }
 }
 
 .settings-section h3 {

--- a/src/widgets/Layout/Layout.css
+++ b/src/widgets/Layout/Layout.css
@@ -149,7 +149,7 @@
 .main-content {
   flex: 1;
   margin-left: var(--sidebar-width);
-  padding: 24px 28px 28px;
+  padding: 24px var(--page-shell-padding) 28px;
   min-height: 100vh;
   height: auto;
   display: flex;
@@ -185,6 +185,7 @@
 .content-body {
   flex: 1;
   min-height: 0;
+  width: 100%;
 }
 
 .sidebar-bottom {


### PR DESCRIPTION
## 작업 내용
- 초광폭 모니터와 큰 데스크톱 화면에서 답답하거나 어색하던 레이아웃 폭을 공통 기준으로 정리했습니다.
- 대시보드, 설정, 멤버, 관리자, 출퇴근, 드라이브, 채팅, 캘린더, AI 채팅 화면의 넓은 화면 대응을 보정했습니다.

## 변경 이유
- 페이지마다 최대 폭과 패널 폭 기준이 제각각이라 34인치 같은 큰 화면에서 여백만 커지거나, 반대로 한쪽 패널이 과하게 좁아 보이는 문제가 있었습니다.
- 채팅과 캘린더처럼 읽기성이 중요한 화면은 넓게 늘리되 실제 내용 폭은 적절히 제한할 필요가 있었습니다.

## 상세 변경 사항
- 공통 페이지 폭 토큰과 콘텐츠 패딩 변수를 추가했습니다.
- 주요 업무 페이지의 최대 폭과 사이드 패널 폭을 clamp 기반으로 조정했습니다.
- 채팅과 AI 채팅은 메시지와 입력 영역의 내부 읽기 폭을 제한했습니다.
- 캘린더는 본문과 사이드바 폭을 재조정해 넓은 화면에서도 균형 있게 보이도록 했습니다.

## 테스트
- npm run build
- Playwright screenshot으로 1366px, 1720px 로그인 화면 확인

## 리뷰 포인트
- 27인치 이상 화면에서 카드 간 간격과 좌우 균형이 자연스러운지
- 채팅과 캘린더가 너무 퍼지지 않고 읽기성이 유지되는지

## 관련 이슈
- closes #242