### PR TITLE
release: v0.2.3

### DIFF
--- a/src/pages/settings/settings.css
+++ b/src/pages/settings/settings.css
@@ -224,6 +224,16 @@
   transform: translateY(-1px);
 }
 
+.save-btn:disabled,
+.danger-btn:disabled,
+.danger-confirm-btn:disabled,
+.danger-cancel-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  transform: none;
+  box-shadow: none;
+}
+
 .password-error {
   color: var(--error);
   font-size: 13px;
@@ -535,6 +545,18 @@
   color: #6f7d99;
 }
 
+:root[data-theme='light'] .save-btn {
+  background: linear-gradient(135deg, #6f57c5 0%, #8e69d9 100%);
+  color: #ffffff;
+  box-shadow: 0 16px 30px rgba(107, 79, 196, 0.22);
+}
+
+:root[data-theme='light'] .save-btn:disabled {
+  background: rgba(107, 79, 196, 0.18);
+  color: #4d3f8d;
+  border: 1px solid rgba(107, 79, 196, 0.14);
+}
+
 :root[data-theme='light'] .theme-option-card {
   background: rgba(255, 255, 255, 0.9);
   border-color: rgba(84, 102, 146, 0.16);
@@ -575,6 +597,17 @@
 :root[data-theme='light'] .danger-cancel-btn {
   background: rgba(84, 102, 146, 0.08);
   color: #4f5f7f;
+}
+
+:root[data-theme='light'] .danger-btn:disabled,
+:root[data-theme='light'] .danger-confirm-btn:disabled {
+  background: rgba(239, 68, 68, 0.1);
+  color: rgba(180, 35, 24, 0.7);
+}
+
+:root[data-theme='light'] .danger-cancel-btn:disabled {
+  background: rgba(84, 102, 146, 0.06);
+  color: rgba(79, 95, 127, 0.72);
 }
 
 @media (max-width: 1080px) {

--- a/src/shared/ui/MemberManagementTable/MemberManagementTable.css
+++ b/src/shared/ui/MemberManagementTable/MemberManagementTable.css
@@ -26,7 +26,7 @@
 }
 
 .member-management-table .member-status-col {
-  width: 170px;
+  width: 210px;
 }
 
 .member-management-table .member-actions-col {
@@ -140,6 +140,15 @@
   min-width: 0;
 }
 
+.member-status-stack {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: nowrap;
+  width: auto;
+}
+
 .member-actions-inline {
   display: flex;
   align-items: center;
@@ -168,6 +177,7 @@
   border-radius: 999px;
   font-size: 0.75rem;
   font-weight: 700;
+  white-space: nowrap;
 }
 
 .member-status-tag.ACTIVE {
@@ -193,6 +203,11 @@
   font-size: 0.8rem;
   font-weight: 600;
   white-space: nowrap;
+}
+
+.member-status-stack .member-action-btn {
+  min-width: 92px;
+  padding: 6px 12px;
 }
 
 .member-action-btn:disabled {


### PR DESCRIPTION
## 작업 내용
- 설정 화면의 라이트 모드 버튼 가독성을 보정했습니다.
- 멤버 관리 테이블의 상태 셀을 한 줄 구조로 정리했습니다.

## 변경 이유
- 라이트 모드에서 저장과 위험 버튼의 라벨이 흐려 보이는 문제가 있었습니다.
- 멤버 상태 영역은 활성 배지와 상태 변경 버튼이 두 줄로 쌓여 보여 시각적으로 무거웠습니다.

## 상세 변경 사항
- 설정: 저장 버튼과 위험 버튼의 라이트 모드 대비를 강화하고 비활성 버튼 색을 정리했습니다.
- 멤버: 상태 컬럼 폭과 배지/버튼 간격을 조정해 한 줄에서 자연스럽게 보이도록 정리했습니다.

## 테스트
- npm run test:run -- src/pages/settings/__tests__/Settings.test.tsx src/pages/members/__tests__/Members.test.tsx
- npm run build

## 리뷰 포인트
- 라이트 모드에서 설정 버튼 텍스트가 바로 읽히는지
- 멤버 상태 셀이 다크/라이트 모두에서 한 줄로 안정적으로 보이는지

## 관련 PR
- #248