### PR TITLE
release: v0.2.4

### DIFF
--- a/src/pages/admin/__tests__/Admin.test.tsx
+++ b/src/pages/admin/__tests__/Admin.test.tsx
@@ -113,7 +113,7 @@ describe('Admin 페이지', () => {
     renderAdmin()
     await user.click(screen.getByRole('button', { name: '멤버 관리' }))
     expect(screen.getByText('멤버 목록')).toBeInTheDocument()
-    expect(screen.getAllByRole('button', { name: '비활성화' }).length).toBeGreaterThan(0)
+    expect(screen.getAllByRole('button', { name: '활성화' }).length).toBeGreaterThan(0)
     expect(screen.getAllByLabelText('관리 메뉴 열기').length).toBeGreaterThan(0)
   })
 
@@ -127,7 +127,7 @@ describe('Admin 페이지', () => {
     const scoped = within(selfRow as HTMLTableRowElement)
 
     expect(scoped.getByText('관리 불가')).toBeInTheDocument()
-    expect(scoped.queryByRole('button', { name: '비활성화' })).not.toBeInTheDocument()
+    expect(scoped.queryByRole('button', { name: '활성화' })).not.toBeInTheDocument()
     expect(scoped.queryByLabelText('관리 메뉴 열기')).not.toBeInTheDocument()
   })
 

--- a/src/pages/members/__tests__/Members.test.tsx
+++ b/src/pages/members/__tests__/Members.test.tsx
@@ -65,7 +65,7 @@ describe('Members 페이지', () => {
     render(<Members />)
 
     await waitFor(() => {
-      expect(screen.getAllByRole('button', { name: '비활성화' }).length).toBeGreaterThan(0)
+      expect(screen.getAllByRole('button', { name: '활성화' }).length).toBeGreaterThan(0)
       expect(screen.getAllByLabelText('관리 메뉴 열기').length).toBeGreaterThan(0)
     })
 
@@ -85,7 +85,7 @@ describe('Members 페이지', () => {
     const scoped = within(selfRow as HTMLTableRowElement)
 
     expect(scoped.getByText('관리 불가')).toBeInTheDocument()
-    expect(scoped.queryByRole('button', { name: '비활성화' })).not.toBeInTheDocument()
+    expect(scoped.queryByRole('button', { name: '활성화' })).not.toBeInTheDocument()
     expect(scoped.queryByLabelText('관리 메뉴 열기')).not.toBeInTheDocument()
   })
 

--- a/src/pages/settings/settings.css
+++ b/src/pages/settings/settings.css
@@ -547,13 +547,13 @@
 
 :root[data-theme='light'] .save-btn {
   background: linear-gradient(135deg, #6f57c5 0%, #8e69d9 100%);
-  color: #ffffff;
+  color: #19243d;
   box-shadow: 0 16px 30px rgba(107, 79, 196, 0.22);
 }
 
 :root[data-theme='light'] .save-btn:disabled {
   background: rgba(107, 79, 196, 0.18);
-  color: #4d3f8d;
+  color: #19243d;
   border: 1px solid rgba(107, 79, 196, 0.14);
 }
 
@@ -591,23 +591,23 @@
 :root[data-theme='light'] .danger-btn,
 :root[data-theme='light'] .danger-confirm-btn {
   background: rgba(239, 68, 68, 0.12);
-  color: #b42318;
+  color: #19243d;
 }
 
 :root[data-theme='light'] .danger-cancel-btn {
   background: rgba(84, 102, 146, 0.08);
-  color: #4f5f7f;
+  color: #19243d;
 }
 
 :root[data-theme='light'] .danger-btn:disabled,
 :root[data-theme='light'] .danger-confirm-btn:disabled {
   background: rgba(239, 68, 68, 0.1);
-  color: rgba(180, 35, 24, 0.7);
+  color: rgba(25, 36, 61, 0.72);
 }
 
 :root[data-theme='light'] .danger-cancel-btn:disabled {
   background: rgba(84, 102, 146, 0.06);
-  color: rgba(79, 95, 127, 0.72);
+  color: rgba(25, 36, 61, 0.72);
 }
 
 @media (max-width: 1080px) {

--- a/src/shared/ui/MemberManagementTable/MemberManagementTable.css
+++ b/src/shared/ui/MemberManagementTable/MemberManagementTable.css
@@ -141,12 +141,11 @@
 }
 
 .member-status-stack {
-  display: inline-flex;
-  flex-direction: row;
+  display: flex;
   align-items: center;
-  gap: 10px;
+  justify-content: flex-start;
   flex-wrap: nowrap;
-  width: auto;
+  width: 100%;
 }
 
 .member-actions-inline {
@@ -178,6 +177,36 @@
   font-size: 0.75rem;
   font-weight: 700;
   white-space: nowrap;
+}
+
+.member-status-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 112px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  white-space: nowrap;
+  border: 1px solid transparent;
+}
+
+.member-status-toggle.ACTIVE {
+  background: rgba(34, 197, 94, 0.14);
+  border-color: rgba(34, 197, 94, 0.2);
+  color: #86efac;
+}
+
+.member-status-toggle.INACTIVE {
+  background: rgba(250, 204, 21, 0.12);
+  border-color: rgba(250, 204, 21, 0.18);
+  color: #fde047;
+}
+
+.member-status-toggle:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .member-status-tag.ACTIVE {
@@ -283,6 +312,18 @@
 :root[data-theme='light'] .member-status-tag.INACTIVE {
   background: rgba(84, 102, 146, 0.12);
   color: #5f6f8d;
+}
+
+:root[data-theme='light'] .member-status-toggle.ACTIVE {
+  background: rgba(34, 197, 94, 0.14);
+  border-color: rgba(34, 197, 94, 0.18);
+  color: #18794e;
+}
+
+:root[data-theme='light'] .member-status-toggle.INACTIVE {
+  background: rgba(234, 179, 8, 0.12);
+  border-color: rgba(234, 179, 8, 0.16);
+  color: #9a6700;
 }
 
 :root[data-theme='light'] .member-action-btn {

--- a/src/shared/ui/MemberManagementTable/MemberManagementTable.tsx
+++ b/src/shared/ui/MemberManagementTable/MemberManagementTable.tsx
@@ -15,6 +15,11 @@ const statusLabels: Record<string, string> = {
   INACTIVE: '비활성',
 }
 
+const statusToggleLabels: Record<string, string> = {
+  ACTIVE: '활성화',
+  INACTIVE: '비활성화',
+}
+
 interface MemberManagementTableProps {
   members: User[]
   saving?: boolean
@@ -128,29 +133,26 @@ export function MemberManagementTable({
                   {showStatus && (
                     <td className="member-table-status-cell">
                       <div className="member-status-stack">
-                        <span className={`member-status-tag ${status}`}>
-                          {statusLabels[status] ?? status}
-                        </span>
-                        {canManageStatus && (
-                          isInactive ? (
-                            <button
-                              type="button"
-                              className="member-action-btn activate-btn"
-                              disabled={saving || !onActivate}
-                              onClick={() => onActivate?.(member.id)}
-                            >
-                              활성화
-                            </button>
-                          ) : (
-                            <button
-                              type="button"
-                              className="member-action-btn mute-btn"
-                              disabled={saving || !onDeactivate}
-                              onClick={() => onDeactivate?.(member.id)}
-                            >
-                              비활성화
-                            </button>
-                          )
+                        {canManageStatus ? (
+                          <button
+                            type="button"
+                            className={`member-status-toggle ${status}`}
+                            aria-pressed={!isInactive}
+                            disabled={saving || (isInactive ? !onActivate : !onDeactivate)}
+                            onClick={() => {
+                              if (isInactive) {
+                                onActivate?.(member.id)
+                                return
+                              }
+                              onDeactivate?.(member.id)
+                            }}
+                          >
+                            {statusToggleLabels[status] ?? status}
+                          </button>
+                        ) : (
+                          <span className={`member-status-tag ${status}`}>
+                            {statusLabels[status] ?? status}
+                          </span>
                         )}
                       </div>
                     </td>


### PR DESCRIPTION
## 작업 내용
- 설정 화면 라이트 모드 버튼 글자색을 보정했습니다.
- 멤버 관리 테이블의 상태 영역을 단일 토글 버튼 구조로 정리했습니다.

## 변경 이유
- 라이트 모드에서 저장과 위험 버튼 라벨이 흐리게 보였습니다.
- 멤버 상태 영역은 상태 배지와 상태 변경 버튼이 함께 보여 시각적으로 복잡했습니다.

## 상세 변경 사항
- 설정: 라이트 모드 저장/위험 버튼과 비활성 버튼의 글자색을 검정 계열로 조정했습니다.
- 멤버: 상태 셀에 단일 토글 버튼만 노출되도록 정리해 활성화/비활성화 상태가 버튼 하나에서 전환되게 했습니다.
- 테스트: 멤버/관리 화면 테스트 기대값을 새 토글 구조에 맞게 정리했습니다.

## 테스트
- npm run test:run -- src/pages/settings/__tests__/Settings.test.tsx src/pages/members/__tests__/Members.test.tsx src/pages/admin/__tests__/Admin.test.tsx
- npm run build

## 리뷰 포인트
- 라이트 모드에서 설정 버튼 텍스트가 또렷하게 보이는지
- 멤버 상태 버튼이 다크/라이트 모두에서 단일 토글 UI로 자연스럽게 보이는지

## 관련 PR
- #251