### PR TITLE
[fix] #254 - 테이블 열 정렬 기준 통일

### DIFF
--- a/src/pages/attendance/attendance.css
+++ b/src/pages/attendance/attendance.css
@@ -178,6 +178,39 @@
   width: 100%;
   border-collapse: collapse;
   min-width: 720px;
+  table-layout: fixed;
+}
+
+.records-table .records-member-col {
+  width: 180px;
+}
+
+.records-table .records-scheduled-col {
+  width: 148px;
+}
+
+.records-table .records-time-col {
+  width: 104px;
+}
+
+.records-table .records-date-col {
+  width: 132px;
+}
+
+.records-table .records-status-col {
+  width: 120px;
+}
+
+.records-table .my-records-date-col {
+  width: 180px;
+}
+
+.records-table .my-records-time-col {
+  width: 120px;
+}
+
+.records-table .my-records-status-col {
+  width: 140px;
 }
 
 .set-work-days-section .set-work-days-personal {
@@ -205,6 +238,8 @@
 .records-table td {
   color: var(--text-primary);
   font-size: 0.9rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .records-table tr.late {

--- a/src/pages/attendance/index.tsx
+++ b/src/pages/attendance/index.tsx
@@ -223,6 +223,14 @@ export function Attendance() {
             >
               <DataTableScroll className="records-table-wrap">
                 <table className="records-table">
+                  <colgroup>
+                    <col className="records-member-col" />
+                    <col className="records-scheduled-col" />
+                    <col className="records-time-col" />
+                    <col className="records-time-col" />
+                    <col className="records-date-col" />
+                    <col className="records-status-col" />
+                  </colgroup>
                   <thead>
                     <tr>
                       <th>멤버 ↕</th>
@@ -286,6 +294,12 @@ export function Attendance() {
         >
           <DataTableScroll className="records-table-wrap">
             <table className="records-table">
+              <colgroup>
+                <col className="my-records-date-col" />
+                <col className="my-records-time-col" />
+                <col className="my-records-time-col" />
+                <col className="my-records-status-col" />
+              </colgroup>
               <thead>
                 <tr>
                   <th>날짜</th>

--- a/src/pages/team-management/index.tsx
+++ b/src/pages/team-management/index.tsx
@@ -128,6 +128,14 @@ export function TeamManagement() {
 
         <DataTableScroll className="team-management-table-wrap">
           <table className="team-management-table">
+            <colgroup>
+              <col className="team-management-name-col" />
+              <col className="team-management-email-col" />
+              <col className="team-management-team-col" />
+              <col className="team-management-role-col" />
+              <col className="team-management-status-col" />
+              <col className="team-management-action-col" />
+            </colgroup>
             <thead>
               <tr>
                 <th>이름</th>

--- a/src/pages/team-management/team-management.css
+++ b/src/pages/team-management/team-management.css
@@ -68,6 +68,31 @@
   width: 100%;
   min-width: 760px;
   border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.team-management-table .team-management-name-col {
+  width: 220px;
+}
+
+.team-management-table .team-management-email-col {
+  width: 240px;
+}
+
+.team-management-table .team-management-team-col {
+  width: 130px;
+}
+
+.team-management-table .team-management-role-col {
+  width: 110px;
+}
+
+.team-management-table .team-management-status-col {
+  width: 110px;
+}
+
+.team-management-table .team-management-action-col {
+  width: 140px;
 }
 
 .team-management-table th,
@@ -79,9 +104,18 @@
 }
 
 .team-member-cell {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 10px;
+  min-width: 0;
+}
+
+.team-member-cell span:last-child,
+.team-management-table td:nth-child(2) {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .team-member-avatar {
@@ -107,7 +141,9 @@
 .team-change-btn {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 8px;
+  min-height: 40px;
   padding: 10px 14px;
   border: 1px solid var(--border-color);
   border-radius: 12px;

--- a/src/shared/ui/MemberManagementTable/MemberManagementTable.css
+++ b/src/shared/ui/MemberManagementTable/MemberManagementTable.css
@@ -30,12 +30,12 @@
 }
 
 .member-management-table .member-actions-col {
-  width: 220px;
+  width: 208px;
 }
 
 .member-management-table th,
 .member-management-table td {
-  padding: 14px 16px;
+  padding: 16px;
   text-align: left;
   vertical-align: middle;
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
@@ -132,39 +132,35 @@
 
 .member-status-stack,
 .member-actions-stack {
-  display: grid;
-  gap: 8px;
-  align-content: start;
-  justify-items: start;
+  display: flex;
+  align-items: center;
+  min-height: 40px;
   width: 100%;
   min-width: 0;
 }
 
 .member-status-stack {
-  display: flex;
-  align-items: center;
   justify-content: flex-start;
-  flex-wrap: nowrap;
-  width: 100%;
 }
 
 .member-actions-inline {
   display: flex;
   align-items: center;
+  justify-content: flex-start;
   gap: 8px;
-  width: 100%;
-}
-
-.member-actions-caption {
-  color: var(--text-tertiary);
-  font-size: 0.74rem;
-  line-height: 1.4;
+  min-height: 40px;
+  width: auto;
 }
 
 .member-actions-disabled {
   color: var(--text-tertiary);
-  font-size: 0.74rem;
-  line-height: 1.4;
+  font-size: 0.82rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.member-actions-inline.is-disabled {
+  justify-content: flex-start;
 }
 
 .member-status-tag {
@@ -356,7 +352,6 @@
   border-color: rgba(239, 68, 68, 0.14);
 }
 
-:root[data-theme='light'] .member-actions-caption,
 :root[data-theme='light'] .member-actions-disabled {
   color: #6f7d99;
 }

--- a/src/shared/ui/MemberManagementTable/MemberManagementTable.tsx
+++ b/src/shared/ui/MemberManagementTable/MemberManagementTable.tsx
@@ -160,7 +160,7 @@ export function MemberManagementTable({
                   {showActions && (
                     <td className="member-table-actions-cell">
                       <div className="member-actions-stack">
-                        <div className="member-actions-inline">
+                        <div className={`member-actions-inline ${hasActionControls ? '' : 'is-disabled'}`.trim()}>
                           {canChangeTeam && (
                             <button
                               type="button"
@@ -173,14 +173,10 @@ export function MemberManagementTable({
                           {menuItems.length > 0 && (
                             <ActionMenu items={menuItems} />
                           )}
+                          {!hasActionControls && (
+                            <span className="member-actions-disabled">관리 불가</span>
+                          )}
                         </div>
-                        {hasActionControls ? (
-                          <span className="member-actions-caption">
-                            {canManageRole && canExpel ? '역할 변경 및 퇴출 관리' : '추가 관리 가능'}
-                          </span>
-                        ) : (
-                          <span className="member-actions-disabled">관리 불가</span>
-                        )}
                       </div>
                     </td>
                   )}


### PR DESCRIPTION
## 작업 내용
- 멤버 관리 테이블의 상태/관리 셀을 한 줄 컨트롤 기준으로 정리했습니다.
- 팀 관리와 출퇴근 이력 표에 열 폭 고정 기준을 적용해 헤더와 본문 기준선을 통일했습니다.
- 공용 테이블 셀의 높이와 정렬 규칙을 맞춰 라이트 모드와 다크 모드 모두에서 위치가 흔들리지 않게 보정했습니다.

## 변경 이유
- 상태와 관리 열의 시선이 맞지 않아 테이블이 비뚤어져 보이던 문제를 공용 패턴 수준에서 해결하기 위해서입니다.

## 상세 변경 사항
- MemberManagementTable 관리 열 보조 문구를 제거하고 단일 라인 액션 구조로 단순화
- MemberManagementTable 상태/관리 셀 공통 높이와 패딩 기준 통일
- 출퇴근 이력 표 열 폭 고정 및 말줄임 처리 추가
- 팀 관리 표 열 폭 고정 및 이름/이메일 셀 정렬 안정화

## 테스트
- npm run test:run -- src/pages/members/__tests__/Members.test.tsx src/pages/admin/__tests__/Admin.test.tsx src/pages/team-management/__tests__/TeamManagement.test.tsx src/pages/attendance/__tests__/Attendance.test.tsx
- npm run build

## 리뷰 포인트
- 멤버 관리 표에서 상태 버튼과 관리 버튼의 세로 기준선이 동일하게 보이는지
- 팀 관리/출퇴근 이력 표에서 열 제목과 본문 셀 위치가 자연스럽게 맞는지

## 관련 이슈
- closes #254
