### PR TITLE
release: v0.2.5

### DIFF
--- a/src/pages/attendance/attendance.css
+++ b/src/pages/attendance/attendance.css
@@ -178,6 +178,39 @@
   width: 100%;
   border-collapse: collapse;
   min-width: 720px;
+  table-layout: fixed;
+}
+
+.records-table .records-member-col {
+  width: 180px;
+}
+
+.records-table .records-scheduled-col {
+  width: 148px;
+}
+
+.records-table .records-time-col {
+  width: 104px;
+}
+
+.records-table .records-date-col {
+  width: 132px;
+}
+
+.records-table .records-status-col {
+  width: 120px;
+}
+
+.records-table .my-records-date-col {
+  width: 180px;
+}
+
+.records-table .my-records-time-col {
+  width: 120px;
+}
+
+.records-table .my-records-status-col {
+  width: 140px;
 }
 
 .set-work-days-section .set-work-days-personal {
@@ -205,6 +238,8 @@
 .records-table td {
   color: var(--text-primary);
   font-size: 0.9rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .records-table tr.late {

--- a/src/pages/attendance/index.tsx
+++ b/src/pages/attendance/index.tsx
@@ -223,6 +223,14 @@ export function Attendance() {
             >
               <DataTableScroll className="records-table-wrap">
                 <table className="records-table">
+                  <colgroup>
+                    <col className="records-member-col" />
+                    <col className="records-scheduled-col" />
+                    <col className="records-time-col" />
+                    <col className="records-time-col" />
+                    <col className="records-date-col" />
+                    <col className="records-status-col" />
+                  </colgroup>
                   <thead>
                     <tr>
                       <th>멤버 ↕</th>
@@ -286,6 +294,12 @@ export function Attendance() {
         >
           <DataTableScroll className="records-table-wrap">
             <table className="records-table">
+              <colgroup>
+                <col className="my-records-date-col" />
+                <col className="my-records-time-col" />
+                <col className="my-records-time-col" />
+                <col className="my-records-status-col" />
+              </colgroup>
               <thead>
                 <tr>
                   <th>날짜</th>

--- a/src/pages/team-management/index.tsx
+++ b/src/pages/team-management/index.tsx
@@ -128,6 +128,14 @@ export function TeamManagement() {
 
         <DataTableScroll className="team-management-table-wrap">
           <table className="team-management-table">
+            <colgroup>
+              <col className="team-management-name-col" />
+              <col className="team-management-email-col" />
+              <col className="team-management-team-col" />
+              <col className="team-management-role-col" />
+              <col className="team-management-status-col" />
+              <col className="team-management-action-col" />
+            </colgroup>
             <thead>
               <tr>
                 <th>이름</th>

--- a/src/pages/team-management/team-management.css
+++ b/src/pages/team-management/team-management.css
@@ -68,6 +68,31 @@
   width: 100%;
   min-width: 760px;
   border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.team-management-table .team-management-name-col {
+  width: 220px;
+}
+
+.team-management-table .team-management-email-col {
+  width: 240px;
+}
+
+.team-management-table .team-management-team-col {
+  width: 130px;
+}
+
+.team-management-table .team-management-role-col {
+  width: 110px;
+}
+
+.team-management-table .team-management-status-col {
+  width: 110px;
+}
+
+.team-management-table .team-management-action-col {
+  width: 140px;
 }
 
 .team-management-table th,
@@ -79,9 +104,18 @@
 }
 
 .team-member-cell {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 10px;
+  min-width: 0;
+}
+
+.team-member-cell span:last-child,
+.team-management-table td:nth-child(2) {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .team-member-avatar {
@@ -107,7 +141,9 @@
 .team-change-btn {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 8px;
+  min-height: 40px;
   padding: 10px 14px;
   border: 1px solid var(--border-color);
   border-radius: 12px;

--- a/src/shared/ui/MemberManagementTable/MemberManagementTable.css
+++ b/src/shared/ui/MemberManagementTable/MemberManagementTable.css
@@ -30,12 +30,12 @@
 }
 
 .member-management-table .member-actions-col {
-  width: 220px;
+  width: 208px;
 }
 
 .member-management-table th,
 .member-management-table td {
-  padding: 14px 16px;
+  padding: 16px;
   text-align: left;
   vertical-align: middle;
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
@@ -132,39 +132,35 @@
 
 .member-status-stack,
 .member-actions-stack {
-  display: grid;
-  gap: 8px;
-  align-content: start;
-  justify-items: start;
+  display: flex;
+  align-items: center;
+  min-height: 40px;
   width: 100%;
   min-width: 0;
 }
 
 .member-status-stack {
-  display: flex;
-  align-items: center;
   justify-content: flex-start;
-  flex-wrap: nowrap;
-  width: 100%;
 }
 
 .member-actions-inline {
   display: flex;
   align-items: center;
+  justify-content: flex-start;
   gap: 8px;
-  width: 100%;
-}
-
-.member-actions-caption {
-  color: var(--text-tertiary);
-  font-size: 0.74rem;
-  line-height: 1.4;
+  min-height: 40px;
+  width: auto;
 }
 
 .member-actions-disabled {
   color: var(--text-tertiary);
-  font-size: 0.74rem;
-  line-height: 1.4;
+  font-size: 0.82rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.member-actions-inline.is-disabled {
+  justify-content: flex-start;
 }
 
 .member-status-tag {
@@ -356,7 +352,6 @@
   border-color: rgba(239, 68, 68, 0.14);
 }
 
-:root[data-theme='light'] .member-actions-caption,
 :root[data-theme='light'] .member-actions-disabled {
   color: #6f7d99;
 }

--- a/src/shared/ui/MemberManagementTable/MemberManagementTable.tsx
+++ b/src/shared/ui/MemberManagementTable/MemberManagementTable.tsx
@@ -160,7 +160,7 @@ export function MemberManagementTable({
                   {showActions && (
                     <td className="member-table-actions-cell">
                       <div className="member-actions-stack">
-                        <div className="member-actions-inline">
+                        <div className={`member-actions-inline ${hasActionControls ? '' : 'is-disabled'}`.trim()}>
                           {canChangeTeam && (
                             <button
                               type="button"
@@ -173,14 +173,10 @@ export function MemberManagementTable({
                           {menuItems.length > 0 && (
                             <ActionMenu items={menuItems} />
                           )}
+                          {!hasActionControls && (
+                            <span className="member-actions-disabled">관리 불가</span>
+                          )}
                         </div>
-                        {hasActionControls ? (
-                          <span className="member-actions-caption">
-                            {canManageRole && canExpel ? '역할 변경 및 퇴출 관리' : '추가 관리 가능'}
-                          </span>
-                        ) : (
-                          <span className="member-actions-disabled">관리 불가</span>
-                        )}
                       </div>
                     </td>
                   )}


### PR DESCRIPTION
## 작업 내용
- 멤버 관리 테이블 상태/관리 열 정렬을 공용 패턴 기준으로 통일했습니다.
- 팀 관리와 출퇴근 이력 표의 열 폭과 셀 정렬 기준을 안정화했습니다.
- 라이트 모드와 다크 모드 모두에서 테이블 기준선이 어긋나지 않도록 보정했습니다.

## 변경 이유
- 최근 테이블 UI에서 상태와 관리 셀 위치가 반복해서 어긋나던 문제를 배포본에 반영하기 위해서입니다.

## 상세 변경 사항
- 공용 MemberManagementTable 액션 구조 단순화
- 팀 관리 표 열 폭 고정 및 텍스트 정렬 보정
- 출퇴근 이력 표 열 폭 고정 및 말줄임 처리 적용

## 테스트
- npm run test:run -- src/pages/members/__tests__/Members.test.tsx src/pages/admin/__tests__/Admin.test.tsx src/pages/team-management/__tests__/TeamManagement.test.tsx src/pages/attendance/__tests__/Attendance.test.tsx
- npm run build

## 리뷰 포인트
- 멤버 관리 표 상태/관리 열이 같은 기준선으로 보이는지
- 팀 관리/출퇴근 표에서 헤더와 셀 위치가 자연스럽게 맞는지

## 관련 이슈
- #254
