### PR TITLE
[fix] #257 - 멤버 테이블 상태 관리 열 축 정렬 보정

### DIFF
--- a/src/shared/ui/MemberManagementTable/MemberManagementTable.css
+++ b/src/shared/ui/MemberManagementTable/MemberManagementTable.css
@@ -47,6 +47,10 @@
   font-weight: 600;
 }
 
+.member-table-heading-center {
+  text-align: center !important;
+}
+
 .member-management-table tbody tr:last-child td {
   border-bottom: none;
 }
@@ -128,51 +132,60 @@
 .member-table-status-cell,
 .member-table-actions-cell {
   white-space: normal;
+  text-align: center;
 }
 
 .member-status-stack,
 .member-actions-stack {
   display: flex;
   align-items: center;
+  justify-content: center;
   min-height: 40px;
   width: 100%;
   min-width: 0;
 }
 
-.member-status-stack {
-  justify-content: flex-start;
-}
-
 .member-actions-inline {
   display: flex;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: center;
   gap: 8px;
   min-height: 40px;
-  width: auto;
+  width: 100%;
 }
 
 .member-actions-disabled {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 108px;
+  min-height: 34px;
+  padding: 7px 12px;
+  border-radius: 10px;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.16);
   color: var(--text-tertiary);
-  font-size: 0.82rem;
+  font-size: 0.78rem;
   font-weight: 600;
   white-space: nowrap;
 }
 
 .member-actions-inline.is-disabled {
-  justify-content: flex-start;
+  justify-content: center;
 }
 
 .member-status-tag {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 68px;
-  padding: 4px 10px;
+  min-width: 112px;
+  min-height: 38px;
+  padding: 8px 14px;
   border-radius: 999px;
-  font-size: 0.75rem;
+  font-size: 0.8rem;
   font-weight: 700;
   white-space: nowrap;
+  border: 1px solid transparent;
 }
 
 .member-status-toggle {
@@ -353,6 +366,8 @@
 }
 
 :root[data-theme='light'] .member-actions-disabled {
+  background: rgba(84, 102, 146, 0.08);
+  border-color: rgba(84, 102, 146, 0.12);
   color: #6f7d99;
 }
 

--- a/src/shared/ui/MemberManagementTable/MemberManagementTable.tsx
+++ b/src/shared/ui/MemberManagementTable/MemberManagementTable.tsx
@@ -73,8 +73,8 @@ export function MemberManagementTable({
             <th>프로필</th>
             <th>팀</th>
             <th>역할</th>
-            {showStatus && <th>상태</th>}
-            {showActions && <th>관리</th>}
+            {showStatus && <th className="member-table-heading-center">상태</th>}
+            {showActions && <th className="member-table-heading-center">관리</th>}
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
## 작업 내용
- 멤버 테이블 상태 열과 관리 열의 헤더/셀 축을 가운데 기준으로 통일했습니다.
- 활성 상태 배지와 관리 불가 문구를 버튼과 같은 규격으로 맞췄습니다.
- 관리 열 액션 영역 정렬을 통일해 행과 열 기준선이 어긋나지 않게 조정했습니다.

## 변경 이유
- 멤버 테이블에서 상태 버튼과 관리 영역이 제각각 보여 UI가 흐트러져 보이던 문제를 바로잡기 위해서입니다.

## 상세 변경 사항
- MemberManagementTable 상태/관리 헤더 가운데 정렬
- 상태 배지 규격을 상태 토글 버튼과 동일한 크기로 보정
- 관리 불가 문구를 고정 폭 액션 박스로 변경

## 테스트
- npm run test:run -- src/pages/members/__tests__/Members.test.tsx src/pages/admin/__tests__/Admin.test.tsx
- npm run build

## 리뷰 포인트
- 멤버 테이블에서 상태 열과 관리 열이 수직선상으로 안정적으로 보이는지
- 자기 계정 행의 활성 상태 배지와 관리 불가 표시가 다른 행과 같은 축으로 보이는지

## 관련 이슈
- closes #257
