### PR TITLE
[feat] #260 - 출퇴근 기간 조회와 CSV 내보내기 연결

### DIFF
--- a/src/pages/attendance/__tests__/Attendance.test.tsx
+++ b/src/pages/attendance/__tests__/Attendance.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll, afterEach, afterAll } from 'vitest'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
 import { attendanceHandlers } from '../../../shared/api/mock/handlers/attendance'
@@ -64,6 +64,16 @@ describe('Attendance 페이지', () => {
     expect(screen.getByText('이번 달')).toBeInTheDocument()
   })
 
+  it('기본 범위 라벨로 이번 달이 표시된다', async () => {
+    render(<Attendance />)
+
+    const [year, month] = TODAY.split('-')
+    const monthStart = `${year}-${month}-01`
+    await waitFor(() => {
+      expect(screen.getAllByText(new RegExp(`${monthStart} ~ ${year}-${month}`)).length).toBeGreaterThan(0)
+    })
+  })
+
   it('관리자에게 팀 근무 일정 패널이 표시된다', () => {
     render(<Attendance />)
     expect(screen.getByTestId('team-work-schedule-panel')).toBeInTheDocument()
@@ -100,6 +110,37 @@ describe('Attendance 페이지', () => {
       const scheduledDaysCell = screen.getByTestId('scheduled-days-1')
       expect(within(scheduledDaysCell).getAllByLabelText(/근무 예정/)).toHaveLength(3)
       expect(within(scheduledDaysCell).getAllByLabelText(/휴무/)).toHaveLength(4)
+    })
+  })
+
+  it('직접 선택 기간 조회가 날짜 범위 기준으로 동작한다', async () => {
+    const requestedDates: string[] = []
+
+    server.use(
+      http.get('/api/v1/attendances', ({ request }) => {
+        const url = new URL(request.url)
+        const date = url.searchParams.get('date') ?? TODAY
+        requestedDates.push(date)
+
+        const data = date === '2026-03-01'
+          ? [{ id: 11, memberId: 1, memberName: '김리더', workDate: date, checkInTime: `${date}T09:00:00`, checkOutTime: `${date}T18:00:00`, status: 'LEFT' }]
+          : []
+
+        return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data })
+      }),
+    )
+
+    render(<Attendance />)
+
+    fireEvent.click(screen.getByRole('button', { name: '직접 선택' }))
+    fireEvent.change(screen.getByLabelText('조회 시작일'), { target: { value: '2026-03-01' } })
+    fireEvent.change(screen.getByLabelText('조회 종료일'), { target: { value: '2026-03-03' } })
+    fireEvent.click(screen.getByRole('button', { name: '조회' }))
+
+    await waitFor(() => {
+      expect(requestedDates).toEqual(expect.arrayContaining(['2026-03-01', '2026-03-02', '2026-03-03']))
+      expect(screen.getByText('2026-03-01 ~ 2026-03-03')).toBeInTheDocument()
+      expect(screen.getAllByText('김리더').length).toBeGreaterThan(0)
     })
   })
 })

--- a/src/pages/attendance/attendance.css
+++ b/src/pages/attendance/attendance.css
@@ -39,6 +39,12 @@
   flex-wrap: wrap;
 }
 
+.date-range-separator {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
 .date-input {
   min-height: 40px;
   padding: 9px 12px;
@@ -431,6 +437,10 @@
   .custom-date-filter {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .date-range-separator {
+    display: none;
   }
 
   .team-status-section,

--- a/src/pages/attendance/index.tsx
+++ b/src/pages/attendance/index.tsx
@@ -5,6 +5,7 @@ import { SetWorkDaysPersonal, TeamAttendanceStatus, TeamWorkSchedulePanel } from
 import { LeaveSection } from '../../features/leave/ui/LeaveSection'
 import {
   getAttendanceByDate,
+  getAttendanceByDates,
   getMyAttendance,
   getAllWorkSchedules,
   getTeamWorkSchedules,
@@ -15,6 +16,14 @@ import { sortUsersByTeamAndName } from '../../shared/lib/team'
 import { DataTableScroll, DataTableSection } from '../../shared/ui/DataTableSection'
 import { Toast } from '../../shared/ui/Toast'
 import { canViewManagedAttendance } from '../../shared/lib/permissions'
+import {
+  formatDateRangeLabel,
+  formatDateRangeToken,
+  getDateStringsBetween,
+  getMonthRange,
+  getTodayStr,
+  getWeekRange,
+} from '../../shared/lib/date'
 import './attendance.css'
 
 const DAY_LABELS: Record<string, string> = {
@@ -42,18 +51,48 @@ const ATTENDANCE_STATUS_LABEL = {
   WORKING: '근무 중',
 } as const
 
+function dedupeAndSortRecords(records: AttendanceRecord[]) {
+  const unique = new Map<string, AttendanceRecord>()
+  records.forEach((record) => {
+    unique.set(`${record.id}-${record.memberId}-${record.workDate}`, record)
+  })
+
+  return Array.from(unique.values()).sort((left, right) => {
+    if (left.workDate !== right.workDate) {
+      return right.workDate.localeCompare(left.workDate)
+    }
+    const nameOrder = left.memberName.localeCompare(right.memberName, 'ko')
+    if (nameOrder !== 0) {
+      return nameOrder
+    }
+    return right.id - left.id
+  })
+}
+
 export function Attendance() {
   const { state } = useApp()
   const [filter, setFilter] = useState<'week' | 'month' | 'custom'>('month')
   const [records, setRecords] = useState<AttendanceRecord[]>([])
+  const [todayRecords, setTodayRecords] = useState<AttendanceRecord[]>([])
   const [myRecords, setMyRecords] = useState<AttendanceRecord[]>([])
   const [teamSchedules, setTeamSchedules] = useState<MemberWorkScheduleItem[]>([])
   const [page, setPage] = useState(1)
-  const [dateInput, setDateInput] = useState('')
+  const [dateFrom, setDateFrom] = useState('')
+  const [dateTo, setDateTo] = useState('')
+  const [activeRange, setActiveRange] = useState(() => {
+    const today = getTodayStr()
+    const monthRange = getMonthRange(today)
+    return {
+      start: monthRange.start,
+      end: monthRange.end,
+      label: formatDateRangeLabel(monthRange.start, monthRange.end),
+      token: formatDateRangeToken(monthRange.start, monthRange.end),
+    }
+  })
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const PAGE_SIZE = 10
 
-  const todayStr = new Date().toISOString().slice(0, 10)
+  const todayStr = getTodayStr()
   const isAdmin = state.currentUser?.role === 'ADMIN'
   const canSeeManagedAttendance = canViewManagedAttendance(state.currentUser)
   const members = sortUsersByTeamAndName(
@@ -61,6 +100,12 @@ export function Attendance() {
       ? state.users.filter((member) => member.team === state.currentUser?.team)
       : state.users,
   )
+  const usersScopeKey = state.users
+    .map((member) => `${member.id}:${member.team}:${member.status}:${member.role}`)
+    .join('|')
+  const teamsScopeKey = state.teams
+    .map((team) => `${team.id}:${team.name}`)
+    .join('|')
 
   const loadTeamSchedules = async () => {
     if (!canSeeManagedAttendance || !state.currentUser) return
@@ -86,34 +131,76 @@ export function Attendance() {
     }
   }
 
-  const loadManagedAttendance = async (targetDate: string) => {
+  const filterRecordsByScope = (attendanceList: AttendanceRecord[]) => {
+    if (!canSeeManagedAttendance || !state.currentUser) return
+
+    if (state.currentUser.role === 'ADMIN') {
+      return dedupeAndSortRecords(attendanceList)
+    }
+
+    const currentTeam = state.currentUser.team
+    const memberIds = new Set(
+      state.users
+        .filter((member) => member.team === currentTeam)
+        .map((member) => Number(member.id)),
+    )
+
+    return dedupeAndSortRecords(attendanceList.filter((record) => memberIds.has(record.memberId)))
+  }
+
+  const loadTodayManagedAttendance = async () => {
     if (!canSeeManagedAttendance || !state.currentUser) return
 
     try {
-      const attendanceList = await getAttendanceByDate(targetDate)
-      if (state.currentUser.role === 'ADMIN') {
-        setRecords(attendanceList)
-        return
-      }
+      const attendanceList = await getAttendanceByDate(todayStr)
+      setTodayRecords(filterRecordsByScope(attendanceList) ?? [])
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '오늘 출퇴근 기록을 불러오지 못했습니다')
+    }
+  }
 
-      const currentTeam = state.currentUser.team
-      const memberIds = new Set(
-        state.users
-          .filter((member) => member.team === currentTeam)
-          .map((member) => Number(member.id)),
-      )
-      setRecords(attendanceList.filter((record) => memberIds.has(record.memberId)))
+  const loadManagedAttendanceRange = async (startDate: string, endDate: string) => {
+    if (!canSeeManagedAttendance || !state.currentUser) return
+
+    try {
+      const dates = getDateStringsBetween(startDate, endDate)
+      const attendanceList = await getAttendanceByDates(dates)
+      setRecords(filterRecordsByScope(attendanceList) ?? [])
+      setActiveRange({
+        start: startDate,
+        end: endDate,
+        label: formatDateRangeLabel(startDate, endDate),
+        token: formatDateRangeToken(startDate, endDate),
+      })
+      setPage(1)
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : '출퇴근 기록을 불러오지 못했습니다')
     }
   }
 
-  // 관리자/팀장: 날짜별 관리 대상 기록 + 멤버 목록
   useEffect(() => {
-    loadManagedAttendance(todayStr)
-  }, [canSeeManagedAttendance, todayStr, state.currentUser?.id, state.currentUser?.team, state.users])
+    loadTodayManagedAttendance()
+  }, [canSeeManagedAttendance, todayStr, state.currentUser?.id, state.currentUser?.team, usersScopeKey])
 
-  // 일반 사용자: 내 출퇴근 기록 전체 이력
+  useEffect(() => {
+    if (!canSeeManagedAttendance) return
+
+    if (filter === 'week') {
+      const range = getWeekRange(todayStr)
+      setDateFrom(range.start)
+      setDateTo(range.end)
+      loadManagedAttendanceRange(range.start, range.end)
+      return
+    }
+
+    if (filter === 'month') {
+      const range = getMonthRange(todayStr)
+      setDateFrom(range.start)
+      setDateTo(range.end)
+      loadManagedAttendanceRange(range.start, range.end)
+    }
+  }, [filter, canSeeManagedAttendance, todayStr, state.currentUser?.id, state.currentUser?.team, usersScopeKey])
+
   useEffect(() => {
     getMyAttendance()
       .then(setMyRecords)
@@ -122,9 +209,8 @@ export function Attendance() {
 
   useEffect(() => {
     loadTeamSchedules()
-  }, [canSeeManagedAttendance, state.currentUser, state.teams])
+  }, [canSeeManagedAttendance, state.currentUser?.id, state.currentUser?.role, state.currentUser?.team, teamsScopeKey])
 
-  const todayRecords = records.filter((r) => r.workDate === todayStr)
   const totalPages = Math.max(1, Math.ceil(records.length / PAGE_SIZE))
   const pageRecords = records.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)
 
@@ -134,8 +220,17 @@ export function Attendance() {
   }
 
   const handleDateFilter = () => {
-    if (!dateInput) return
-    loadManagedAttendance(dateInput)
+    if (!dateFrom || !dateTo) {
+      setErrorMessage('조회 시작일과 종료일을 모두 선택해 주세요')
+      return
+    }
+
+    if (dateFrom > dateTo) {
+      setErrorMessage('시작일이 종료일보다 늦을 수 없습니다')
+      return
+    }
+
+    loadManagedAttendanceRange(dateFrom, dateTo)
   }
 
   const handleExport = () => {
@@ -149,7 +244,7 @@ export function Attendance() {
         clockOut: r.checkOutTime?.slice(11, 16),
         status: r.status === 'LEFT' ? 'done' : 'working',
       })),
-      todayStr
+      activeRange.token
     )
   }
 
@@ -169,7 +264,7 @@ export function Attendance() {
               CSV 내보내기
             </button>
           )}
-          <div className="date-range glass">{todayStr}</div>
+          <div className="date-range glass">{activeRange.label}</div>
           <div className="filter-tabs">
             <button className={filter === 'week' ? 'active' : ''} onClick={() => setFilter('week')}>
               이번 주
@@ -177,7 +272,16 @@ export function Attendance() {
             <button className={filter === 'month' ? 'active' : ''} onClick={() => setFilter('month')}>
               이번 달
             </button>
-            <button className={filter === 'custom' ? 'active' : ''} onClick={() => setFilter('custom')}>
+            <button
+              className={filter === 'custom' ? 'active' : ''}
+              onClick={() => {
+                if (!dateFrom || !dateTo) {
+                  setDateFrom(todayStr)
+                  setDateTo(todayStr)
+                }
+                setFilter('custom')
+              }}
+            >
               직접 선택
             </button>
           </div>
@@ -185,9 +289,18 @@ export function Attendance() {
             <div className="custom-date-filter">
               <input
                 type="date"
-                value={dateInput}
-                onChange={(e) => setDateInput(e.target.value)}
+                value={dateFrom}
+                onChange={(e) => setDateFrom(e.target.value)}
                 className="date-input"
+                aria-label="조회 시작일"
+              />
+              <span className="date-range-separator">~</span>
+              <input
+                type="date"
+                value={dateTo}
+                onChange={(e) => setDateTo(e.target.value)}
+                className="date-input"
+                aria-label="조회 종료일"
               />
               <button className="filter-apply-btn" onClick={handleDateFilter}>조회</button>
             </div>
@@ -198,7 +311,7 @@ export function Attendance() {
       <div className="attendance-content">
         {canSeeManagedAttendance && members.length > 0 && (
           <section className="team-status-section glass">
-            <TeamAttendanceStatus members={members} records={records} date={todayStr} />
+            <TeamAttendanceStatus members={members} records={todayRecords} date={todayStr} />
           </section>
         )}
 
@@ -219,7 +332,7 @@ export function Attendance() {
             <DataTableSection
               className="records-section"
               title="출퇴근 기록"
-              description="관리 대상 멤버의 근무 일정과 출퇴근 상태를 날짜 기준으로 확인합니다."
+              description={`${activeRange.label} 기준으로 관리 대상 멤버의 근무 일정과 출퇴근 상태를 확인합니다.`}
             >
               <DataTableScroll className="records-table-wrap">
                 <table className="records-table">

--- a/src/shared/api/attendanceApi.ts
+++ b/src/shared/api/attendanceApi.ts
@@ -17,6 +17,11 @@ export const getMyAttendance = () =>
 export const getAttendanceByDate = (date: string) =>
   baseClient.get<AttendanceRecord[]>(`/api/v1/attendances?date=${date}`)
 
+export const getAttendanceByDates = async (dates: string[]) => {
+  const responses = await Promise.all(dates.map((date) => getAttendanceByDate(date)))
+  return responses.flat()
+}
+
 export const clockIn = () =>
   baseClient.post<AttendanceRecord>('/api/v1/attendances/check-in', {})
 

--- a/src/shared/lib/date.ts
+++ b/src/shared/lib/date.ts
@@ -3,6 +3,69 @@ export function getTodayStr(): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
 }
 
+export function toDateString(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+}
+
+export function parseDateString(dateStr: string): Date {
+  return new Date(`${dateStr}T12:00:00`)
+}
+
+export function getWeekRange(baseDateStr: string): { start: string; end: string } {
+  const baseDate = parseDateString(baseDateStr)
+  const start = new Date(baseDate)
+  const day = start.getDay()
+  const diffToMonday = day === 0 ? -6 : 1 - day
+  start.setDate(start.getDate() + diffToMonday)
+
+  const end = new Date(start)
+  end.setDate(start.getDate() + 6)
+
+  return {
+    start: toDateString(start),
+    end: toDateString(end),
+  }
+}
+
+export function getMonthRange(baseDateStr: string): { start: string; end: string } {
+  const baseDate = parseDateString(baseDateStr)
+  const start = new Date(baseDate.getFullYear(), baseDate.getMonth(), 1, 12)
+  const end = new Date(baseDate.getFullYear(), baseDate.getMonth() + 1, 0, 12)
+
+  return {
+    start: toDateString(start),
+    end: toDateString(end),
+  }
+}
+
+export function getDateStringsBetween(startDateStr: string, endDateStr: string): string[] {
+  const start = parseDateString(startDateStr)
+  const end = parseDateString(endDateStr)
+  const dates: string[] = []
+  const cursor = new Date(start)
+
+  while (cursor <= end) {
+    dates.push(toDateString(cursor))
+    cursor.setDate(cursor.getDate() + 1)
+  }
+
+  return dates
+}
+
+export function formatDateRangeLabel(startDateStr: string, endDateStr: string): string {
+  if (startDateStr === endDateStr) {
+    return startDateStr
+  }
+  return `${startDateStr} ~ ${endDateStr}`
+}
+
+export function formatDateRangeToken(startDateStr: string, endDateStr: string): string {
+  if (startDateStr === endDateStr) {
+    return startDateStr
+  }
+  return `${startDateStr}_to_${endDateStr}`
+}
+
 export function formatDateDisplay(dateStr: string, baseDate: Date): string {
   const d = new Date(dateStr + 'T12:00:00')
   const today = new Date(baseDate.getFullYear(), baseDate.getMonth(), baseDate.getDate())


### PR DESCRIPTION
## 작업 내용
- 출퇴근 페이지에 이번 주, 이번 달, 직접 선택 기간 조회를 실제 데이터 로드와 연결했습니다.
- CSV 내보내기가 현재 선택한 기간 범위를 기준으로 동작하도록 수정했습니다.
- 직접 선택은 시작일과 종료일을 받아 범위 조회와 파일명을 함께 맞추도록 정리했습니다.

## 변경 이유
- 기존에는 기본적으로 오늘 데이터만 로드되어 기간 필터와 CSV 내보내기 기대와 실제 동작이 달랐기 때문입니다.

## 상세 변경 사항
- 하루 조회 API를 날짜 범위 순회 방식으로 묶는 기간 조회 로직 추가
- 기본 범위를 이번 달로 변경하고 범위 라벨 표시 추가
- 직접 선택 범위 조회와 CSV 파일명 토큰 정리
- 관련 테스트 추가

## 테스트
- npm run test:run -- src/pages/attendance/__tests__/Attendance.test.tsx src/pages/admin/__tests__/Admin.test.tsx
- npm run build

## 리뷰 포인트
- 이번 주, 이번 달, 직접 선택이 실제 데이터와 페이지네이션에 반영되는지
- CSV 파일명이 선택한 기간 범위 기준으로 내려가는지

## 관련 이슈
- closes #260
