### PR TITLE
[feat] #284 - 근무 일정 캘린더 고도화

### DIFF
--- a/src/features/attendance/model/__tests__/useWorkSchedule.test.ts
+++ b/src/features/attendance/model/__tests__/useWorkSchedule.test.ts
@@ -5,11 +5,11 @@ import { http, HttpResponse } from 'msw'
 import { useWorkSchedule } from '../useWorkSchedule'
 
 const DEFAULT_SCHEDULES = [
-  { id: 1, dayOfWeek: 'MONDAY', startTime: '09:00:00', endTime: '18:00:00' },
-  { id: 2, dayOfWeek: 'TUESDAY', startTime: '09:00:00', endTime: '18:00:00' },
-  { id: 3, dayOfWeek: 'WEDNESDAY', startTime: '09:00:00', endTime: '18:00:00' },
-  { id: 4, dayOfWeek: 'THURSDAY', startTime: '09:00:00', endTime: '18:00:00' },
-  { id: 5, dayOfWeek: 'FRIDAY', startTime: '09:00:00', endTime: '18:00:00' },
+  { id: 1, dayOfWeek: 'MONDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'EVERY' },
+  { id: 2, dayOfWeek: 'TUESDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'EVERY' },
+  { id: 3, dayOfWeek: 'WEDNESDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'SECOND' },
+  { id: 4, dayOfWeek: 'THURSDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'EVERY' },
+  { id: 5, dayOfWeek: 'FRIDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'LAST' },
 ]
 
 const server = setupServer(
@@ -61,9 +61,9 @@ describe('useWorkSchedule', () => {
       expect(result.current.weekPatterns).toEqual([
         'EVERY',
         'EVERY',
+        'SECOND',
         'EVERY',
-        'EVERY',
-        'EVERY',
+        'LAST',
         'EVERY',
         'EVERY',
       ])
@@ -180,6 +180,12 @@ describe('useWorkSchedule', () => {
     })
 
     it('localStorage에 저장된 weekPatterns를 마운트 시 복원한다', async () => {
+      server.use(
+        http.get('/api/v1/work-schedules/me', () =>
+          HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: [] }),
+        ),
+      )
+
       localStorage.setItem('yanus-work-week-patterns', JSON.stringify([
         'LAST',
         'EVERY',
@@ -213,6 +219,12 @@ describe('useWorkSchedule', () => {
       })
 
       expect(deletedDay).toBe('MONDAY')
+    })
+
+    it('API 응답의 weekPattern 값을 우선 반영한다', async () => {
+      const { result } = await mountHook()
+      expect(result.current.weekPatterns[2]).toBe('SECOND')
+      expect(result.current.weekPatterns[4]).toBe('LAST')
     })
 
     it('API 에러 시 error 메시지가 설정된다', async () => {

--- a/src/features/attendance/model/useWorkSchedule.ts
+++ b/src/features/attendance/model/useWorkSchedule.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { deleteWorkScheduleDay, getMyWorkSchedule, upsertWorkScheduleDay } from '../../../shared/api/attendanceApi'
-import type { DayOfWeek } from '../../../shared/api/attendanceApi'
+import type { DayOfWeek, WeekPattern } from '../../../shared/api/attendanceApi'
 import { ApiError } from '../../../shared/api/baseClient'
 
 export interface DaySchedule {
@@ -8,7 +8,7 @@ export interface DaySchedule {
   checkOutTime: string  // "HH:mm"
 }
 
-export type WeekPattern = 'EVERY' | 'FIRST' | 'SECOND' | 'THIRD' | 'FOURTH' | 'LAST'
+export type { WeekPattern } from '../../../shared/api/attendanceApi'
 
 // 배열 인덱스 ↔ DayOfWeek 매핑 (0=Mon, 1=Tue, ..., 6=Sun)
 const INDEX_TO_DOW: DayOfWeek[] = [
@@ -82,6 +82,16 @@ export function useWorkSchedule() {
           }
           return next
         })
+        setWeekPatterns((prev) => {
+          const next = [...prev]
+          for (const item of items) {
+            const idx = INDEX_TO_DOW.indexOf(item.dayOfWeek)
+            if (idx >= 0) {
+              next[idx] = item.weekPattern ?? 'EVERY'
+            }
+          }
+          return next
+        })
       })
       .catch(() => {
         if (parsedStoredDays) {
@@ -116,6 +126,7 @@ export function useWorkSchedule() {
             dayOfWeek: INDEX_TO_DOW[i],
             startTime: daySchedules[i].checkInTime + ':00',
             endTime: daySchedules[i].checkOutTime + ':00',
+            weekPattern: weekPatterns[i],
           })
         })
         .filter(Boolean)

--- a/src/features/attendance/ui/SetWorkDaysPersonal.css
+++ b/src/features/attendance/ui/SetWorkDaysPersonal.css
@@ -89,13 +89,9 @@
 }
 
 .schedule-calendar-layout {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 18px;
-  align-items: start;
+  display: block;
 }
 
-.schedule-calendar-board,
 .schedule-day-editor {
   display: flex;
   flex-direction: column;
@@ -108,88 +104,6 @@
 
 .schedule-day-editor.active {
   background: color-mix(in srgb, var(--accent-purple) 8%, var(--bg-soft));
-}
-
-.schedule-calendar-head {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.schedule-calendar-head strong {
-  font-size: 1rem;
-}
-
-.schedule-calendar-head span {
-  color: var(--text-secondary);
-  font-size: 0.84rem;
-  line-height: 1.5;
-}
-
-.schedule-calendar-grid {
-  display: grid;
-  grid-template-columns: repeat(7, minmax(0, 1fr));
-  gap: 10px;
-}
-
-.schedule-calendar-days {
-  align-items: stretch;
-}
-
-.schedule-calendar-weekday {
-  padding-bottom: 4px;
-  text-align: center;
-  color: var(--text-secondary);
-  font-size: 0.8rem;
-  font-weight: 700;
-}
-
-.schedule-calendar-cell {
-  min-height: 96px;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 10px;
-  border-radius: 18px;
-  border: 1px solid var(--border-color);
-  background: var(--bg-card-solid);
-  color: var(--text-primary);
-  cursor: pointer;
-  text-align: left;
-  transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
-}
-
-.schedule-calendar-cell:hover {
-  transform: translateY(-1px);
-}
-
-.schedule-calendar-cell.outside {
-  opacity: 0.52;
-}
-
-.schedule-calendar-cell.active {
-  border-color: rgba(138, 114, 216, 0.32);
-  background: color-mix(in srgb, var(--accent-purple) 11%, var(--bg-card-solid));
-}
-
-.schedule-calendar-cell.selected {
-  box-shadow: 0 0 0 1px var(--accent-purple), 0 16px 32px rgba(15, 23, 42, 0.14);
-}
-
-.schedule-calendar-date {
-  font-size: 0.9rem;
-  font-weight: 700;
-}
-
-.schedule-calendar-state {
-  font-size: 0.74rem;
-  line-height: 1.45;
-  color: var(--text-secondary);
-}
-
-.schedule-calendar-cell.active .schedule-calendar-state {
-  color: var(--text-primary);
 }
 
 .schedule-day-tabs {
@@ -427,18 +341,6 @@
     grid-template-columns: 1fr;
   }
 
-  .schedule-calendar-grid,
-  .schedule-day-tabs {
-    gap: 6px;
-  }
-
-  .schedule-calendar-cell {
-    min-height: 78px;
-    padding: 8px;
-    border-radius: 14px;
-  }
-
-  .schedule-calendar-board,
   .schedule-day-editor {
     padding: 14px;
   }

--- a/src/features/attendance/ui/SetWorkDaysPersonal.tsx
+++ b/src/features/attendance/ui/SetWorkDaysPersonal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import { useApp } from '../../auth/model/AppProvider'
 import { useWorkSchedule } from '../model/useWorkSchedule'
 import type { WeekPattern } from '../model/useWorkSchedule'
@@ -13,66 +13,6 @@ const WEEK_PATTERN_OPTIONS: { value: WeekPattern; label: string }[] = [
   { value: 'FOURTH', label: '4주차' },
   { value: 'LAST', label: '마지막 주' },
 ]
-
-interface MonthPreviewCell {
-  isoDate: string
-  dayIndex: number
-  isCurrentMonth: boolean
-  occurrencePattern: Exclude<WeekPattern, 'EVERY' | 'LAST'>
-  isLastOccurrence: boolean
-  dayNumber: number
-}
-
-function toMondayIndex(jsDay: number) {
-  return (jsDay + 6) % 7
-}
-
-function getOccurrencePattern(date: Date): Exclude<WeekPattern, 'EVERY' | 'LAST'> {
-  const occurrence = Math.floor((date.getDate() - 1) / 7) + 1
-
-  if (occurrence === 1) return 'FIRST'
-  if (occurrence === 2) return 'SECOND'
-  if (occurrence === 3) return 'THIRD'
-  return 'FOURTH'
-}
-
-function isLastOccurrence(date: Date) {
-  const nextWeek = new Date(date)
-  nextWeek.setDate(date.getDate() + 7)
-  return nextWeek.getMonth() !== date.getMonth()
-}
-
-function buildMonthPreview(referenceDate = new Date()): MonthPreviewCell[] {
-  const firstDay = new Date(referenceDate.getFullYear(), referenceDate.getMonth(), 1)
-  const startOffset = toMondayIndex(firstDay.getDay())
-  const startDate = new Date(firstDay)
-  startDate.setDate(firstDay.getDate() - startOffset)
-
-  return Array.from({ length: 42 }, (_, index) => {
-    const current = new Date(startDate)
-    current.setDate(startDate.getDate() + index)
-
-    return {
-      isoDate: current.toISOString().slice(0, 10),
-      dayIndex: toMondayIndex(current.getDay()),
-      isCurrentMonth: current.getMonth() === referenceDate.getMonth(),
-      occurrencePattern: getOccurrencePattern(current),
-      isLastOccurrence: isLastOccurrence(current),
-      dayNumber: current.getDate(),
-    }
-  })
-}
-
-function isCellScheduled(
-  isActiveDay: boolean,
-  selectedPattern: WeekPattern,
-  cell: MonthPreviewCell,
-) {
-  if (!isActiveDay) return false
-  if (selectedPattern === 'EVERY') return true
-  if (selectedPattern === 'LAST') return cell.isLastOccurrence
-  return selectedPattern === cell.occurrencePattern
-}
 
 interface SetWorkDaysPersonalProps {
   onSaved?: () => void | Promise<void>
@@ -103,12 +43,7 @@ export function SetWorkDaysPersonal({ onSaved, hideHeader = false }: SetWorkDays
     }
   }
 
-  const monthPreview = useMemo(() => buildMonthPreview(), [])
   const selectedDayName = DAY_NAMES[selectedDayIndex]
-  const monthLabel = useMemo(() => {
-    const today = new Date()
-    return `${today.getFullYear()}년 ${today.getMonth() + 1}월 반복 미리보기`
-  }, [])
 
   return (
     <div className="set-work-days-personal">
@@ -127,53 +62,13 @@ export function SetWorkDaysPersonal({ onSaved, hideHeader = false }: SetWorkDays
 
       <div className="schedule-summary">
         <span className="summary-chip">활성 요일 {workDays.filter(Boolean).length}일</span>
-        <p>이번 달 캘린더에서 반복 근무 패턴을 미리 확인하면서 요일별 근무 시간을 저장할 수 있습니다.</p>
+        <p>반복 근무는 여기서 요일별로 정리하고, 특정 날짜 예외 일정은 우측 캘린더에서 바로 추가할 수 있습니다.</p>
       </div>
 
       {isLoading ? (
         <div className="schedule-loading">로딩 중...</div>
       ) : (
         <div className="schedule-calendar-layout">
-          <div className="schedule-calendar-board">
-            <div className="schedule-calendar-head">
-              <strong>{monthLabel}</strong>
-              <span>반복 패턴이 실제 달력에서 어떻게 보이는지 미리 확인할 수 있습니다.</span>
-            </div>
-            <div className="schedule-calendar-grid schedule-calendar-weekdays">
-              {DAY_NAMES.map((day) => (
-                <span key={day} className="schedule-calendar-weekday">{day}</span>
-              ))}
-            </div>
-            <div className="schedule-calendar-grid schedule-calendar-days">
-              {monthPreview.map((cell) => {
-                const isActiveCell = isCellScheduled(workDays[cell.dayIndex], weekPatterns[cell.dayIndex], cell)
-                const isSelectedDay = selectedDayIndex === cell.dayIndex
-
-                return (
-                  <button
-                    key={cell.isoDate}
-                    type="button"
-                    className={[
-                      'schedule-calendar-cell',
-                      cell.isCurrentMonth ? 'current' : 'outside',
-                      isActiveCell ? 'active' : 'inactive',
-                      isSelectedDay ? 'selected' : '',
-                    ].filter(Boolean).join(' ')}
-                    onClick={() => setSelectedDayIndex(cell.dayIndex)}
-                    aria-label={`${cell.dayNumber}일 ${DAY_NAMES[cell.dayIndex]} ${isActiveCell ? '근무 예정' : '휴무'}`}
-                  >
-                    <span className="schedule-calendar-date">{cell.dayNumber}</span>
-                    <span className="schedule-calendar-state">
-                      {isActiveCell
-                        ? `${daySchedules[cell.dayIndex].checkInTime} - ${daySchedules[cell.dayIndex].checkOutTime}`
-                        : '휴무'}
-                    </span>
-                  </button>
-                )
-              })}
-            </div>
-          </div>
-
           <div className={`schedule-day-editor ${workDays[selectedDayIndex] ? 'active' : 'inactive'}`}>
             <div className="schedule-day-tabs" role="tablist" aria-label="근무 일정 요일 선택">
               {DAY_NAMES.map((day, index) => (

--- a/src/features/attendance/ui/__tests__/SetWorkDaysPersonal.test.tsx
+++ b/src/features/attendance/ui/__tests__/SetWorkDaysPersonal.test.tsx
@@ -62,7 +62,7 @@ describe('SetWorkDaysPersonal', () => {
   it('활성화된 요일(월-금)에 출근/퇴근 라벨이 표시된다', async () => {
     render(<SetWorkDaysPersonal />, { wrapper })
     await waitFor(() => {
-      expect(screen.getByText(/반복 미리보기/)).toBeInTheDocument()
+      expect(screen.getByText(/특정 날짜 예외 일정은 우측 캘린더/)).toBeInTheDocument()
       expect(screen.getByText('출근')).toBeInTheDocument()
       expect(screen.getByText('퇴근')).toBeInTheDocument()
     })

--- a/src/pages/work-schedules/__tests__/WorkSchedules.test.tsx
+++ b/src/pages/work-schedules/__tests__/WorkSchedules.test.tsx
@@ -1,21 +1,156 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import { WorkSchedules } from '../index'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
-vi.mock('../../../features/attendance/ui', () => ({
-  SetWorkDaysPersonal: () => <div data-testid="work-schedule-editor">mock-editor</div>,
+const mockGetAllWorkSchedules = vi.fn()
+const mockGetTeamWorkSchedules = vi.fn()
+const mockGetWorkScheduleEvents = vi.fn()
+const mockCreateWorkScheduleEvent = vi.fn()
+
+let mockState = {
+  currentUser: { id: '1', name: '관리자', role: 'ADMIN', team: '1팀' },
+  users: [
+    { id: '1', name: '관리자', role: 'ADMIN', team: '1팀', email: 'admin@yanus.kr', status: 'ACTIVE' },
+    { id: '2', name: '팀원', role: 'MEMBER', team: '1팀', email: 'member@yanus.kr', status: 'ACTIVE' },
+  ],
+  teams: [
+    { id: 1, name: '1팀' },
+    { id: 2, name: '2팀' },
+  ],
+}
+
+vi.mock('@fullcalendar/react', () => ({
+  default: (props: { events?: unknown[]; dateClick?: (arg: { dateStr: string }) => void }) => (
+    <div data-testid="mock-calendar">
+      <button type="button" onClick={() => props.dateClick?.({ dateStr: '2026-03-30' })}>
+        날짜 클릭
+      </button>
+      <span>events:{props.events?.length ?? 0}</span>
+    </div>
+  ),
 }))
 
+vi.mock('../../../features/auth/model', () => ({
+  useApp: () => ({
+    state: mockState,
+    refreshMembers: vi.fn(async () => []),
+    refreshTeams: vi.fn(async () => []),
+  }),
+}))
+
+vi.mock('../../../features/attendance/ui', () => ({
+  SetWorkDaysPersonal: () => <div data-testid="recurring-editor">반복 근무 편집기</div>,
+}))
+
+vi.mock('../../../shared/api/attendanceApi', () => ({
+  getAllWorkSchedules: (...args: unknown[]) => mockGetAllWorkSchedules(...args),
+  getTeamWorkSchedules: (...args: unknown[]) => mockGetTeamWorkSchedules(...args),
+  getWorkScheduleEvents: (...args: unknown[]) => mockGetWorkScheduleEvents(...args),
+  createWorkScheduleEvent: (...args: unknown[]) => mockCreateWorkScheduleEvent(...args),
+  updateWorkScheduleEvent: vi.fn(),
+  deleteWorkScheduleEvent: vi.fn(),
+}))
+
+import { WorkSchedules } from '../index'
+
 describe('WorkSchedules 페이지', () => {
-  it('근무 일정 페이지는 캘린더 편집 카드만 렌더링한다', () => {
+  beforeEach(() => {
+    mockState = {
+      currentUser: { id: '1', name: '관리자', role: 'ADMIN', team: '1팀' },
+      users: [
+        { id: '1', name: '관리자', role: 'ADMIN', team: '1팀', email: 'admin@yanus.kr', status: 'ACTIVE' },
+        { id: '2', name: '팀원', role: 'MEMBER', team: '1팀', email: 'member@yanus.kr', status: 'ACTIVE' },
+      ],
+      teams: [
+        { id: 1, name: '1팀' },
+        { id: 2, name: '2팀' },
+      ],
+    }
+    mockGetAllWorkSchedules.mockResolvedValue([
+      {
+        memberId: 1,
+        memberName: '관리자',
+        teamName: '1팀',
+        workSchedules: [{ id: 1, dayOfWeek: 'MONDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'EVERY' }],
+      },
+    ])
+    mockGetTeamWorkSchedules.mockResolvedValue([
+      {
+        memberId: 2,
+        memberName: '팀원',
+        teamName: '1팀',
+        workSchedules: [{ id: 2, dayOfWeek: 'TUESDAY', startTime: '10:00:00', endTime: '19:00:00', weekPattern: 'EVERY' }],
+      },
+    ])
+    mockGetWorkScheduleEvents.mockResolvedValue([
+      {
+        id: 101,
+        date: '2026-03-30',
+        startTime: '13:00:00',
+        endTime: '18:00:00',
+        memberId: 2,
+        memberName: '팀원',
+        teamName: '1팀',
+      },
+    ])
+    mockCreateWorkScheduleEvent.mockResolvedValue({
+      id: 999,
+      date: '2026-03-30',
+      startTime: '09:00:00',
+      endTime: '18:00:00',
+      memberId: 1,
+      memberName: '관리자',
+      teamName: '1팀',
+    })
+  })
+
+  it('관리자는 전체, 팀별, 개인 필터와 캘린더를 본다', async () => {
     render(<WorkSchedules />)
 
-    expect(screen.getByText('내 근무 일정')).toBeInTheDocument()
-    expect(screen.getByText('캘린더에서 반복 근무 일정을 바로 확인하고 수정할 수 있습니다.')).toBeInTheDocument()
-    expect(
-      screen.getByText('근무 일정 조회와 편집을 한 화면의 캘린더로 단순화했습니다.'),
-    ).toBeInTheDocument()
-    expect(screen.getByTestId('work-schedule-editor')).toBeInTheDocument()
-    expect(screen.queryByText('근무 일정 조회')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '전체' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '팀별' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '개인' })).toBeInTheDocument()
+    expect(screen.getByTestId('recurring-editor')).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(mockGetAllWorkSchedules).toHaveBeenCalled()
+      expect(mockGetWorkScheduleEvents).toHaveBeenCalled()
+      expect(screen.getByTestId('mock-calendar')).toBeInTheDocument()
+    })
+  })
+
+  it('일반 멤버는 우리 팀과 개인 필터만 본다', async () => {
+    mockState = {
+      currentUser: { id: '2', name: '팀원', role: 'MEMBER', team: '1팀' },
+      users: [
+        { id: '1', name: '관리자', role: 'ADMIN', team: '1팀', email: 'admin@yanus.kr', status: 'ACTIVE' },
+        { id: '2', name: '팀원', role: 'MEMBER', team: '1팀', email: 'member@yanus.kr', status: 'ACTIVE' },
+      ],
+      teams: [{ id: 1, name: '1팀' }],
+    }
+
+    render(<WorkSchedules />)
+
+    expect(screen.queryByRole('button', { name: '전체' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '우리 팀' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '개인' })).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(mockGetTeamWorkSchedules).toHaveBeenCalled()
+    })
+  })
+
+  it('빠른 추가 버튼을 누르면 날짜별 근무 일정 추가 모달이 열린다', async () => {
+    render(<WorkSchedules />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '날짜별 일정 추가' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: '날짜별 일정 추가' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('날짜별 근무 일정 추가')).toBeInTheDocument()
+      expect(document.querySelector('input[type="date"]')).not.toBeNull()
+    })
   })
 })

--- a/src/pages/work-schedules/index.tsx
+++ b/src/pages/work-schedules/index.tsx
@@ -1,28 +1,747 @@
-import { CalendarDays } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { CalendarDays, Pencil, Plus, Trash2, UserRound, Users } from 'lucide-react'
+import FullCalendar from '@fullcalendar/react'
+import dayGridPlugin from '@fullcalendar/daygrid'
+import interactionPlugin from '@fullcalendar/interaction'
+import listPlugin from '@fullcalendar/list'
+import koLocale from '@fullcalendar/core/locales/ko'
+import type { EventInput } from '@fullcalendar/core'
+import type { DateClickArg } from '@fullcalendar/interaction'
+import type { EventClickArg } from '@fullcalendar/core'
+import { useApp } from '../../features/auth/model'
 import { SetWorkDaysPersonal } from '../../features/attendance/ui'
+import {
+  createWorkScheduleEvent,
+  deleteWorkScheduleEvent,
+  getAllWorkSchedules,
+  getTeamWorkSchedules,
+  getWorkScheduleEvents,
+  updateWorkScheduleEvent,
+  type MemberWorkScheduleItem,
+  type WeekPattern,
+  type WorkScheduleEventItem,
+} from '../../shared/api/attendanceApi'
+import { formatTeamName, getTeamOptions, sortUsersByTeamAndName } from '../../shared/lib/team'
+import { canViewAllWorkSchedules, canViewTeamWorkSchedules } from '../../shared/lib/permissions'
 import { DataTableSection } from '../../shared/ui/DataTableSection'
+import { EmptyState } from '../../shared/ui/EmptyState'
+import { Toast } from '../../shared/ui/Toast'
+import { TimeInput } from '../../components/TimeInput'
 import './work-schedules.css'
 
+type CalendarScope = 'all' | 'team' | 'person'
+
+interface CalendarRange {
+  start: string
+  end: string
+}
+
+interface CalendarRecurringEventMeta {
+  kind: 'recurring'
+  memberId: number
+  memberName: string
+  teamName: string
+  date: string
+  startTime: string
+  endTime: string
+  weekPattern: WeekPattern
+}
+
+interface CalendarDateEventMeta {
+  kind: 'date-event'
+  item: WorkScheduleEventItem
+  isEditable: boolean
+}
+
+type WorkScheduleCalendarMeta = CalendarRecurringEventMeta | CalendarDateEventMeta
+
+interface ScheduleModalState {
+  mode: 'create' | 'edit' | 'detail'
+  date: string
+  startTime: string
+  endTime: string
+  item: WorkScheduleCalendarMeta | null
+}
+
+const DEFAULT_START_TIME = '09:00'
+const DEFAULT_END_TIME = '18:00'
+const WEEK_PATTERN_LABELS: Record<WeekPattern, string> = {
+  EVERY: '매주',
+  FIRST: '1주차',
+  SECOND: '2주차',
+  THIRD: '3주차',
+  FOURTH: '4주차',
+  LAST: '마지막 주',
+}
+
+const DAY_OF_WEEK_TO_INDEX = {
+  MONDAY: 0,
+  TUESDAY: 1,
+  WEDNESDAY: 2,
+  THURSDAY: 3,
+  FRIDAY: 4,
+  SATURDAY: 5,
+  SUNDAY: 6,
+} as const
+
+function toIsoDate(date: Date) {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function toMondayIndex(jsDay: number) {
+  return (jsDay + 6) % 7
+}
+
+function getOccurrencePattern(date: Date): Exclude<WeekPattern, 'EVERY' | 'LAST'> {
+  const occurrence = Math.floor((date.getDate() - 1) / 7) + 1
+  if (occurrence === 1) return 'FIRST'
+  if (occurrence === 2) return 'SECOND'
+  if (occurrence === 3) return 'THIRD'
+  return 'FOURTH'
+}
+
+function isLastOccurrence(date: Date) {
+  const nextWeek = new Date(date)
+  nextWeek.setDate(date.getDate() + 7)
+  return nextWeek.getMonth() !== date.getMonth()
+}
+
+function matchesWeekPattern(date: Date, pattern: WeekPattern | undefined) {
+  const normalized = pattern ?? 'EVERY'
+  if (normalized === 'EVERY') return true
+  if (normalized === 'LAST') return isLastOccurrence(date)
+  return getOccurrencePattern(date) === normalized
+}
+
+function addDays(date: Date, days: number) {
+  const next = new Date(date)
+  next.setDate(next.getDate() + days)
+  return next
+}
+
+function formatTimeLabel(time: string) {
+  return time.slice(0, 5)
+}
+
+function getEventColors(kind: 'recurring' | 'date-event', isMine: boolean) {
+  if (kind === 'date-event') {
+    return isMine
+      ? {
+          backgroundColor: 'rgba(249, 115, 22, 0.16)',
+          borderColor: 'rgba(249, 115, 22, 0.42)',
+          textColor: 'var(--text-primary)',
+        }
+      : {
+          backgroundColor: 'rgba(14, 165, 233, 0.16)',
+          borderColor: 'rgba(14, 165, 233, 0.36)',
+          textColor: 'var(--text-primary)',
+        }
+  }
+
+  return isMine
+    ? {
+        backgroundColor: 'rgba(138, 114, 216, 0.18)',
+        borderColor: 'rgba(138, 114, 216, 0.38)',
+        textColor: 'var(--text-primary)',
+      }
+    : {
+        backgroundColor: 'rgba(99, 102, 241, 0.12)',
+        borderColor: 'rgba(99, 102, 241, 0.28)',
+        textColor: 'var(--text-primary)',
+      }
+}
+
+function expandRecurringSchedules(
+  schedules: MemberWorkScheduleItem[],
+  range: CalendarRange | null,
+  currentUserId: string,
+): EventInput[] {
+  if (!range) return []
+
+  const start = new Date(`${range.start}T00:00:00`)
+  const endExclusive = new Date(`${range.end}T00:00:00`)
+  const events: EventInput[] = []
+
+  for (const member of schedules) {
+    for (let cursor = new Date(start); cursor < endExclusive; cursor = addDays(cursor, 1)) {
+      const mondayIndex = toMondayIndex(cursor.getDay())
+      const schedule = member.workSchedules.find(
+        (item) => DAY_OF_WEEK_TO_INDEX[item.dayOfWeek] === mondayIndex && matchesWeekPattern(cursor, item.weekPattern),
+      )
+
+      if (!schedule) continue
+
+      const isoDate = toIsoDate(cursor)
+      const isMine = String(member.memberId) === currentUserId
+      const colors = getEventColors('recurring', isMine)
+      const startTime = formatTimeLabel(schedule.startTime)
+      const endTime = formatTimeLabel(schedule.endTime)
+
+      events.push({
+        id: `recurring-${member.memberId}-${schedule.dayOfWeek}-${schedule.weekPattern ?? 'EVERY'}-${isoDate}`,
+        title: `${member.memberName} · ${startTime}`,
+        start: `${isoDate}T${schedule.startTime}`,
+        end: `${isoDate}T${schedule.endTime}`,
+        allDay: false,
+        editable: false,
+        ...colors,
+        extendedProps: {
+          kind: 'recurring',
+          memberId: member.memberId,
+          memberName: member.memberName,
+          teamName: member.teamName,
+          date: isoDate,
+          startTime,
+          endTime,
+          weekPattern: schedule.weekPattern ?? 'EVERY',
+        } satisfies CalendarRecurringEventMeta,
+      })
+    }
+  }
+
+  return events
+}
+
+function toDateEvents(items: WorkScheduleEventItem[], currentUserId: string): EventInput[] {
+  return items.map((item) => {
+    const isMine = String(item.memberId) === currentUserId
+    const colors = getEventColors('date-event', isMine)
+    return {
+      id: `date-event-${item.id}`,
+      title: `${item.memberName} · ${formatTimeLabel(item.startTime)}`,
+      start: `${item.date}T${item.startTime}`,
+      end: `${item.date}T${item.endTime}`,
+      allDay: false,
+      editable: false,
+      ...colors,
+      extendedProps: {
+        kind: 'date-event',
+        item,
+        isEditable: isMine,
+      } satisfies CalendarDateEventMeta,
+    }
+  })
+}
+
+function getDefaultRange(): CalendarRange {
+  const now = new Date()
+  const start = new Date(now.getFullYear(), now.getMonth(), 1)
+  const end = new Date(now.getFullYear(), now.getMonth() + 1, 1)
+  return { start: toIsoDate(start), end: toIsoDate(end) }
+}
+
 export function WorkSchedules() {
+  const { state, refreshMembers, refreshTeams } = useApp()
+  const [scope, setScope] = useState<CalendarScope>('team')
+  const [selectedTeamId, setSelectedTeamId] = useState<number | null>(null)
+  const [selectedMemberId, setSelectedMemberId] = useState<string>('')
+  const [calendarRange, setCalendarRange] = useState<CalendarRange>(getDefaultRange)
+  const [recurringSchedules, setRecurringSchedules] = useState<MemberWorkScheduleItem[]>([])
+  const [dateEvents, setDateEvents] = useState<WorkScheduleEventItem[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [modalState, setModalState] = useState<ScheduleModalState | null>(null)
+  const [isModalSaving, setIsModalSaving] = useState(false)
+
+  const currentUser = state.currentUser
+  const canViewAll = canViewAllWorkSchedules(currentUser)
+  const canViewTeam = canViewTeamWorkSchedules(currentUser)
+  const currentUserId = currentUser?.id ?? ''
+  const currentTeamName = currentUser?.team ?? ''
+
+  const activeUsers = useMemo(
+    () => sortUsersByTeamAndName(state.users.filter((member) => (member.status ?? 'ACTIVE') === 'ACTIVE')),
+    [state.users],
+  )
+  const allTeams = useMemo(() => getTeamOptions(state.users, state.teams), [state.users, state.teams])
+  const currentTeam = useMemo(
+    () => allTeams.find((team) => team.name === currentTeamName) ?? null,
+    [allTeams, currentTeamName],
+  )
+  const visibleTeams = useMemo(
+    () => (canViewAll ? allTeams : currentTeam ? [currentTeam] : []),
+    [allTeams, canViewAll, currentTeam],
+  )
+  const teamMembers = useMemo(
+    () => activeUsers.filter((member) => member.team === currentTeamName),
+    [activeUsers, currentTeamName],
+  )
+  const selectableMembers = useMemo(() => {
+    if (canViewAll) return activeUsers
+    if (canViewTeam) return teamMembers
+    return currentUser ? activeUsers.filter((member) => member.id === currentUser.id) : []
+  }, [activeUsers, canViewAll, canViewTeam, currentUser, teamMembers])
+
+  useEffect(() => {
+    if (state.teams.length === 0) {
+      refreshTeams().catch((err) => {
+        setErrorMessage(err instanceof Error ? err.message : '팀 목록을 불러오지 못했습니다')
+      })
+    }
+
+    if (state.users.length === 0) {
+      refreshMembers().catch((err) => {
+        setErrorMessage(err instanceof Error ? err.message : '멤버 목록을 불러오지 못했습니다')
+      })
+    }
+  }, [refreshMembers, refreshTeams, state.teams.length, state.users.length])
+
+  useEffect(() => {
+    setScope(canViewAll ? 'all' : 'team')
+  }, [canViewAll, currentUserId])
+
+  useEffect(() => {
+    if (visibleTeams.length === 0) {
+      setSelectedTeamId(null)
+      return
+    }
+
+    if (selectedTeamId && visibleTeams.some((team) => team.id === selectedTeamId)) return
+    setSelectedTeamId(currentTeam?.id ?? visibleTeams[0]?.id ?? null)
+  }, [currentTeam, selectedTeamId, visibleTeams])
+
+  useEffect(() => {
+    if (selectableMembers.length === 0) {
+      setSelectedMemberId('')
+      return
+    }
+
+    if (selectedMemberId && selectableMembers.some((member) => member.id === selectedMemberId)) return
+    setSelectedMemberId(currentUserId || selectableMembers[0]?.id || '')
+  }, [currentUserId, selectableMembers, selectedMemberId])
+
+  const selectedTeam = useMemo(
+    () => visibleTeams.find((team) => team.id === selectedTeamId) ?? currentTeam ?? null,
+    [currentTeam, selectedTeamId, visibleTeams],
+  )
+
+  const filteredDateEvents = useMemo(() => {
+    if (scope === 'all' && canViewAll) return dateEvents
+    if (scope === 'team') {
+      const teamName = selectedTeam?.name ?? currentTeamName
+      return dateEvents.filter((item) => item.teamName === teamName)
+    }
+    return dateEvents.filter((item) => String(item.memberId) === selectedMemberId)
+  }, [canViewAll, currentTeamName, dateEvents, scope, selectedMemberId, selectedTeam])
+
+  const loadCalendarData = useCallback(async () => {
+    if (!currentUser) {
+      setRecurringSchedules([])
+      setDateEvents([])
+      setIsLoading(false)
+      return
+    }
+
+    setIsLoading(true)
+    try {
+      const [events, schedules] = await Promise.all([
+        getWorkScheduleEvents(calendarRange.start, calendarRange.end),
+        (async () => {
+          if (scope === 'all' && canViewAll) {
+            return getAllWorkSchedules()
+          }
+
+          const teamId =
+            scope === 'team'
+              ? (selectedTeam?.id ?? currentTeam?.id ?? null)
+              : canViewAll
+                ? null
+                : (currentTeam?.id ?? null)
+
+          if (scope === 'person' && canViewAll) {
+            const all = await getAllWorkSchedules()
+            return all.filter((item) => String(item.memberId) === selectedMemberId)
+          }
+
+          if (teamId) {
+            const teamSchedules = await getTeamWorkSchedules(teamId)
+            return scope === 'person'
+              ? teamSchedules.filter((item) => String(item.memberId) === selectedMemberId)
+              : teamSchedules
+          }
+
+          return []
+        })(),
+      ])
+
+      setDateEvents(events)
+      setRecurringSchedules(schedules)
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '근무 일정 캘린더를 불러오지 못했습니다')
+      setDateEvents([])
+      setRecurringSchedules([])
+    } finally {
+      setIsLoading(false)
+    }
+  }, [calendarRange.end, calendarRange.start, canViewAll, currentTeam, currentUser, scope, selectedMemberId, selectedTeam])
+
+  useEffect(() => {
+    loadCalendarData()
+  }, [loadCalendarData])
+
+  const calendarEvents = useMemo(
+    () => [
+      ...expandRecurringSchedules(recurringSchedules, calendarRange, currentUserId),
+      ...toDateEvents(filteredDateEvents, currentUserId),
+    ],
+    [calendarRange, currentUserId, filteredDateEvents, recurringSchedules],
+  )
+
+  const openCreateModal = useCallback((date: string) => {
+    setModalState({
+      mode: 'create',
+      date,
+      startTime: DEFAULT_START_TIME,
+      endTime: DEFAULT_END_TIME,
+      item: null,
+    })
+  }, [])
+
+  const handleDateClick = useCallback((arg: DateClickArg) => {
+    openCreateModal(arg.dateStr.slice(0, 10))
+  }, [openCreateModal])
+
+  const handleEventClick = useCallback((arg: EventClickArg) => {
+    const meta = arg.event.extendedProps as WorkScheduleCalendarMeta | undefined
+    if (!meta) return
+
+    if (meta.kind === 'date-event') {
+      setModalState({
+        mode: meta.isEditable ? 'edit' : 'detail',
+        date: meta.item.date,
+        startTime: formatTimeLabel(meta.item.startTime),
+        endTime: formatTimeLabel(meta.item.endTime),
+        item: meta,
+      })
+      return
+    }
+
+    setModalState({
+      mode: 'detail',
+      date: meta.date,
+      startTime: meta.startTime,
+      endTime: meta.endTime,
+      item: meta,
+    })
+  }, [])
+
+  const handleModalSubmit = async () => {
+    if (!modalState || modalState.mode === 'detail') return
+
+    setIsModalSaving(true)
+    try {
+      const payload = {
+        date: modalState.date,
+        startTime: `${modalState.startTime}:00`,
+        endTime: `${modalState.endTime}:00`,
+      }
+
+      if (modalState.mode === 'create') {
+        await createWorkScheduleEvent(payload)
+      } else if (modalState.item?.kind === 'date-event') {
+        await updateWorkScheduleEvent(modalState.item.item.id, payload)
+      }
+
+      setModalState(null)
+      await loadCalendarData()
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '날짜별 근무 일정 저장에 실패했습니다')
+    } finally {
+      setIsModalSaving(false)
+    }
+  }
+
+  const handleDeleteEvent = async () => {
+    if (!modalState || modalState.mode !== 'edit' || modalState.item?.kind !== 'date-event') return
+
+    setIsModalSaving(true)
+    try {
+      await deleteWorkScheduleEvent(modalState.item.item.id)
+      setModalState(null)
+      await loadCalendarData()
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '날짜별 근무 일정 삭제에 실패했습니다')
+    } finally {
+      setIsModalSaving(false)
+    }
+  }
+
+  const modalTitle = useMemo(() => {
+    if (!modalState) return ''
+    if (modalState.mode === 'create') return '날짜별 근무 일정 추가'
+    if (modalState.item?.kind === 'date-event') return '날짜별 근무 일정'
+    return '근무 일정 상세'
+  }, [modalState])
+
   return (
     <div className="work-schedules-page">
+      {errorMessage && (
+        <Toast message={errorMessage} type="error" onClose={() => setErrorMessage(null)} />
+      )}
+
       <header className="work-schedules-header">
         <div className="work-schedules-copy">
-          <p>캘린더에서 반복 근무 일정을 바로 확인하고 수정할 수 있습니다.</p>
+          <p>반복 근무와 날짜별 근무 일정을 같은 캘린더에서 보고 바로 관리할 수 있습니다.</p>
         </div>
         <div className="work-schedules-summary glass">
           <CalendarDays size={16} />
-          <span>근무 일정 조회와 편집을 한 화면의 캘린더로 단순화했습니다.</span>
+          <span>날짜 클릭으로 개별 일정을 추가하고, 역할 범위에 따라 다른 사람 일정도 함께 확인합니다.</span>
         </div>
       </header>
 
-      <DataTableSection
-        className="work-schedules-editor-card"
-        title="내 근무 일정"
-        description="캘린더에서 반복 근무 패턴을 확인하며 개인 근무 루틴을 관리합니다."
-      >
-        <SetWorkDaysPersonal hideHeader />
-      </DataTableSection>
+      <div className="work-schedules-layout">
+        <DataTableSection
+          className="work-schedules-calendar-card"
+          title="근무 일정 캘린더"
+          description="날짜를 눌러 개인 근무 일정을 추가하고, 역할 범위에 따라 다른 사람 근무 일정도 함께 확인합니다."
+        >
+          <div className="work-schedules-toolbar">
+            <div className="work-schedules-scope-group" role="group" aria-label="근무 일정 조회 범위">
+              {canViewAll && (
+                <button
+                  type="button"
+                  className={`scope-chip ${scope === 'all' ? 'active' : ''}`}
+                  onClick={() => setScope('all')}
+                >
+                  <Users size={14} />
+                  전체
+                </button>
+              )}
+              {canViewTeam && (
+                <button
+                  type="button"
+                  className={`scope-chip ${scope === 'team' ? 'active' : ''}`}
+                  onClick={() => setScope('team')}
+                >
+                  <CalendarDays size={14} />
+                  {canViewAll ? '팀별' : '우리 팀'}
+                </button>
+              )}
+              <button
+                type="button"
+                className={`scope-chip ${scope === 'person' ? 'active' : ''}`}
+                onClick={() => setScope('person')}
+              >
+                <UserRound size={14} />
+                개인
+              </button>
+            </div>
+
+            <div className="work-schedules-selectors">
+              {scope === 'team' && canViewAll && visibleTeams.length > 0 && (
+                <label className="work-schedules-select">
+                  <span>조회 팀</span>
+                  <select
+                    value={selectedTeamId ?? ''}
+                    onChange={(event) => setSelectedTeamId(Number(event.target.value))}
+                  >
+                    {visibleTeams.map((team) => (
+                      <option key={team.id} value={team.id}>
+                        {formatTeamName(team.name)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
+
+              {scope === 'person' && selectableMembers.length > 0 && (
+                <label className="work-schedules-select">
+                  <span>조회 멤버</span>
+                  <select
+                    value={selectedMemberId}
+                    onChange={(event) => setSelectedMemberId(event.target.value)}
+                  >
+                    {selectableMembers.map((member) => (
+                      <option key={member.id} value={member.id}>
+                        {member.name} · {formatTeamName(member.team)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
+            </div>
+          </div>
+
+          <div className="work-schedules-calendar-meta">
+            <div className="work-schedules-legend">
+              <span className="legend-chip recurring-own">내 반복 일정</span>
+              <span className="legend-chip recurring-team">공유 반복 일정</span>
+              <span className="legend-chip date-own">날짜별 추가 일정</span>
+              <span className="legend-chip date-team">팀 공유 일정</span>
+            </div>
+            <button
+              type="button"
+              className="quick-add-btn"
+              onClick={() => openCreateModal(toIsoDate(new Date()))}
+            >
+              <Plus size={16} />
+              날짜별 일정 추가
+            </button>
+          </div>
+
+          {isLoading ? (
+            <div className="work-schedules-loading">근무 일정을 불러오는 중...</div>
+          ) : calendarEvents.length === 0 ? (
+            <EmptyState
+              title="표시할 근무 일정이 없습니다."
+              description="반복 근무를 저장하거나 날짜를 눌러 개별 근무 일정을 추가해 주세요."
+            />
+          ) : (
+            <div className="work-schedules-calendar-shell">
+              <FullCalendar
+                plugins={[dayGridPlugin, interactionPlugin, listPlugin]}
+                locale={koLocale}
+                initialView="dayGridMonth"
+                headerToolbar={{
+                  left: 'prev,next today',
+                  center: 'title',
+                  right: 'dayGridMonth,listWeek',
+                }}
+                buttonText={{
+                  today: '오늘',
+                  month: '월',
+                  list: '목록',
+                }}
+                height="auto"
+                events={calendarEvents}
+                dateClick={handleDateClick}
+                eventClick={handleEventClick}
+                datesSet={(arg) => {
+                  setCalendarRange({
+                    start: toIsoDate(arg.start),
+                    end: toIsoDate(arg.end),
+                  })
+                }}
+                dayMaxEventRows={3}
+                eventTimeFormat={{ hour: '2-digit', minute: '2-digit', hour12: false }}
+              />
+            </div>
+          )}
+        </DataTableSection>
+
+        <div className="work-schedules-side">
+          <DataTableSection
+            className="work-schedules-editor-card"
+            title="반복 근무 설정"
+            description="요일별 반복 근무만 빠르게 수정합니다. 날짜별 일정 조회와 예외 추가는 왼쪽 캘린더에서 처리합니다."
+          >
+            <SetWorkDaysPersonal hideHeader onSaved={loadCalendarData} />
+          </DataTableSection>
+        </div>
+      </div>
+
+      {modalState && (
+        <div className="work-schedules-modal-overlay" onClick={() => setModalState(null)}>
+          <div className="work-schedules-modal glass" onClick={(event) => event.stopPropagation()}>
+            <div className="work-schedules-modal-header">
+              <div>
+                <h3>{modalTitle}</h3>
+                <p>{modalState.date}</p>
+              </div>
+              <button type="button" className="work-schedules-modal-close" onClick={() => setModalState(null)}>
+                닫기
+              </button>
+            </div>
+
+            {modalState.mode === 'detail' && modalState.item?.kind === 'recurring' && (
+              <div className="work-schedules-detail-list">
+                <div className="work-schedules-detail-item">
+                  <strong>멤버</strong>
+                  <span>{modalState.item.memberName}</span>
+                </div>
+                <div className="work-schedules-detail-item">
+                  <strong>팀</strong>
+                  <span>{formatTeamName(modalState.item.teamName)}</span>
+                </div>
+                <div className="work-schedules-detail-item">
+                  <strong>시간</strong>
+                  <span>{modalState.startTime} - {modalState.endTime}</span>
+                </div>
+                <div className="work-schedules-detail-item">
+                  <strong>반복 주차</strong>
+                  <span>{WEEK_PATTERN_LABELS[modalState.item.weekPattern]}</span>
+                </div>
+              </div>
+            )}
+
+            {modalState.mode === 'detail' && modalState.item?.kind === 'date-event' && (
+              <div className="work-schedules-detail-list">
+                <div className="work-schedules-detail-item">
+                  <strong>멤버</strong>
+                  <span>{modalState.item.item.memberName}</span>
+                </div>
+                <div className="work-schedules-detail-item">
+                  <strong>팀</strong>
+                  <span>{formatTeamName(modalState.item.item.teamName)}</span>
+                </div>
+                <div className="work-schedules-detail-item">
+                  <strong>시간</strong>
+                  <span>{modalState.startTime} - {modalState.endTime}</span>
+                </div>
+              </div>
+            )}
+
+            {modalState.mode !== 'detail' && (
+              <>
+                <div className="work-schedules-modal-form">
+                  <label className="work-schedules-modal-field">
+                    <span>날짜</span>
+                    <input
+                      type="date"
+                      value={modalState.date}
+                      onChange={(event) =>
+                        setModalState((prev) => (prev ? { ...prev, date: event.target.value } : prev))
+                      }
+                    />
+                  </label>
+                  <label className="work-schedules-modal-field">
+                    <span>출근 시간</span>
+                    <TimeInput
+                      value={modalState.startTime}
+                      onChange={(value) =>
+                        setModalState((prev) => (prev ? { ...prev, startTime: value } : prev))
+                      }
+                    />
+                  </label>
+                  <label className="work-schedules-modal-field">
+                    <span>퇴근 시간</span>
+                    <TimeInput
+                      value={modalState.endTime}
+                      onChange={(value) =>
+                        setModalState((prev) => (prev ? { ...prev, endTime: value } : prev))
+                      }
+                    />
+                  </label>
+                </div>
+
+                <div className="work-schedules-modal-actions">
+                  {modalState.mode === 'edit' && (
+                    <button
+                      type="button"
+                      className="danger-btn"
+                      onClick={handleDeleteEvent}
+                      disabled={isModalSaving}
+                    >
+                      <Trash2 size={16} />
+                      삭제
+                    </button>
+                  )}
+                  <button type="button" className="secondary-btn" onClick={() => setModalState(null)}>
+                    취소
+                  </button>
+                  <button type="button" className="primary-btn" onClick={handleModalSubmit} disabled={isModalSaving}>
+                    <Pencil size={16} />
+                    {isModalSaving ? '저장 중...' : modalState.mode === 'create' ? '추가' : '수정'}
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/pages/work-schedules/work-schedules.css
+++ b/src/pages/work-schedules/work-schedules.css
@@ -25,13 +25,360 @@
   border-radius: 16px;
 }
 
+.work-schedules-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(320px, 0.9fr);
+  gap: 20px;
+  align-items: start;
+}
+
+.work-schedules-calendar-card,
 .work-schedules-editor-card {
   padding: 24px;
   border-radius: 24px;
 }
 
+.work-schedules-side {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.work-schedules-toolbar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.work-schedules-scope-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.scope-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 40px;
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: var(--surface-muted);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease, background 0.2s ease;
+}
+
+.scope-chip:hover {
+  transform: translateY(-1px);
+}
+
+.scope-chip.active {
+  border-color: var(--accent-purple);
+  background: color-mix(in srgb, var(--accent-purple) 16%, var(--surface));
+}
+
+.work-schedules-selectors {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.work-schedules-select {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 220px;
+}
+
+.work-schedules-select span {
+  font-size: 0.84rem;
+  color: var(--text-secondary);
+}
+
+.work-schedules-select select,
+.work-schedules-modal-field input[type='date'] {
+  min-height: 42px;
+  padding: 10px 14px;
+  border-radius: 14px;
+  border: 1px solid var(--border-color);
+  background: var(--surface-muted);
+  color: var(--text-primary);
+}
+
+.work-schedules-calendar-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.work-schedules-legend {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.legend-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 7px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.legend-chip.recurring-own {
+  background: rgba(138, 114, 216, 0.16);
+}
+
+.legend-chip.recurring-team {
+  background: rgba(99, 102, 241, 0.12);
+}
+
+.legend-chip.date-own {
+  background: rgba(249, 115, 22, 0.16);
+}
+
+.legend-chip.date-team {
+  background: rgba(14, 165, 233, 0.14);
+}
+
+.quick-add-btn,
+.primary-btn,
+.secondary-btn,
+.danger-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 42px;
+  padding: 10px 16px;
+  border-radius: 14px;
+  border: 1px solid var(--border-color);
+  background: var(--surface-muted);
+  color: var(--text-primary);
+  font-weight: 700;
+}
+
+.quick-add-btn {
+  background: color-mix(in srgb, var(--accent-purple) 18%, var(--surface));
+}
+
+.primary-btn {
+  background: var(--gradient-purple);
+  color: var(--text-on-accent);
+  border-color: transparent;
+}
+
+.danger-btn {
+  background: color-mix(in srgb, var(--error) 12%, var(--surface));
+  color: var(--error);
+}
+
+.work-schedules-loading {
+  padding: 48px 0;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.work-schedules-calendar-shell {
+  min-width: 0;
+}
+
+.work-schedules-calendar-shell .fc {
+  min-width: 0;
+  color: var(--text-primary);
+}
+
+.work-schedules-calendar-shell .fc-theme-standard td,
+.work-schedules-calendar-shell .fc-theme-standard th {
+  border-color: var(--border-color);
+}
+
+.work-schedules-calendar-shell .fc .fc-scrollgrid,
+.work-schedules-calendar-shell .fc .fc-view-harness,
+.work-schedules-calendar-shell .fc .fc-daygrid-body,
+.work-schedules-calendar-shell .fc .fc-list {
+  background: transparent;
+}
+
+.work-schedules-calendar-shell .fc .fc-toolbar.fc-header-toolbar {
+  margin-bottom: 1rem;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.work-schedules-calendar-shell .fc .fc-toolbar-title,
+.work-schedules-calendar-shell .fc .fc-col-header-cell-cushion,
+.work-schedules-calendar-shell .fc .fc-daygrid-day-number,
+.work-schedules-calendar-shell .fc .fc-list-day-cushion {
+  color: var(--text-primary);
+}
+
+.work-schedules-calendar-shell .fc .fc-col-header-cell {
+  background: color-mix(in srgb, var(--surface-muted) 72%, transparent);
+}
+
+.work-schedules-calendar-shell .fc .fc-button {
+  border-radius: 12px;
+  border-color: var(--border-color);
+  background: var(--surface-muted);
+  color: var(--text-primary);
+  box-shadow: none;
+}
+
+.work-schedules-calendar-shell .fc .fc-button:hover {
+  background: color-mix(in srgb, var(--surface-muted) 84%, transparent);
+}
+
+.work-schedules-calendar-shell .fc .fc-button-primary:not(:disabled).fc-button-active,
+.work-schedules-calendar-shell .fc .fc-button-primary:not(:disabled):active {
+  background: color-mix(in srgb, var(--accent-purple) 18%, var(--surface));
+  border-color: var(--accent-purple);
+}
+
+.work-schedules-calendar-shell .fc .fc-button:disabled {
+  opacity: 0.54;
+}
+
+.work-schedules-calendar-shell .fc .fc-daygrid-day-frame {
+  min-height: 118px;
+}
+
+.work-schedules-calendar-shell .fc .fc-daygrid-day.fc-day-today {
+  background: color-mix(in srgb, var(--surface-tint) 52%, transparent);
+}
+
+.work-schedules-calendar-shell .fc .fc-daygrid-day:hover {
+  background: color-mix(in srgb, var(--surface-muted) 60%, transparent);
+}
+
+.work-schedules-calendar-shell .fc .fc-daygrid-event,
+.work-schedules-calendar-shell .fc .fc-list-event {
+  border-radius: 10px;
+  padding: 2px 4px;
+}
+
+.work-schedules-calendar-shell .fc .fc-list-event:hover td {
+  background: color-mix(in srgb, var(--surface-muted) 72%, transparent);
+}
+
+.work-schedules-calendar-shell .fc .fc-event-title {
+  font-weight: 600;
+}
+
+.work-schedules-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 70;
+  background: rgba(15, 23, 42, 0.46);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.work-schedules-modal {
+  width: min(560px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 24px;
+  border-radius: 24px;
+}
+
+.work-schedules-modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.work-schedules-modal-header h3,
+.work-schedules-modal-header p {
+  margin: 0;
+}
+
+.work-schedules-modal-header p {
+  color: var(--text-secondary);
+  margin-top: 6px;
+}
+
+.work-schedules-modal-close {
+  color: var(--text-secondary);
+}
+
+.work-schedules-detail-list,
+.work-schedules-modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.work-schedules-detail-item,
+.work-schedules-modal-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.work-schedules-detail-item strong,
+.work-schedules-modal-field span {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+}
+
+.work-schedules-detail-item span {
+  font-size: 0.96rem;
+}
+
+.work-schedules-modal-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 1280px) {
+  .work-schedules-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 768px) {
-  .work-schedules-editor-card {
+  .work-schedules-calendar-card,
+  .work-schedules-editor-card,
+  .work-schedules-modal {
     padding: 18px;
+  }
+
+  .work-schedules-select {
+    min-width: 100%;
+  }
+
+  .work-schedules-calendar-shell .fc .fc-daygrid-day-frame {
+    min-height: 88px;
+  }
+
+  .work-schedules-calendar-meta {
+    align-items: stretch;
+  }
+
+  .quick-add-btn {
+    width: 100%;
+  }
+
+  .work-schedules-calendar-shell .fc .fc-toolbar-title {
+    font-size: 1rem;
   }
 }

--- a/src/shared/api/__tests__/attendanceApi.test.ts
+++ b/src/shared/api/__tests__/attendanceApi.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
 import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
 import {
+  createWorkScheduleEvent,
+  deleteWorkScheduleEvent,
   getMyAttendance,
   getAttendanceByDate,
   clockIn,
@@ -12,14 +14,28 @@ import {
   deleteWorkScheduleDay,
   getAllWorkSchedules,
   getTeamWorkSchedules,
+  getWorkScheduleEvents,
+  updateWorkScheduleEvent,
 } from '../attendanceApi'
 
 const WORK_SCHEDULES = [
-  { id: 1, dayOfWeek: 'MONDAY', startTime: '09:00:00', endTime: '18:00:00' },
-  { id: 2, dayOfWeek: 'TUESDAY', startTime: '09:00:00', endTime: '18:00:00' },
-  { id: 3, dayOfWeek: 'WEDNESDAY', startTime: '09:00:00', endTime: '18:00:00' },
-  { id: 4, dayOfWeek: 'THURSDAY', startTime: '09:00:00', endTime: '18:00:00' },
-  { id: 5, dayOfWeek: 'FRIDAY', startTime: '09:00:00', endTime: '18:00:00' },
+  { id: 1, dayOfWeek: 'MONDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'EVERY' },
+  { id: 2, dayOfWeek: 'TUESDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'EVERY' },
+  { id: 3, dayOfWeek: 'WEDNESDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'SECOND' },
+  { id: 4, dayOfWeek: 'THURSDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'EVERY' },
+  { id: 5, dayOfWeek: 'FRIDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'LAST' },
+]
+
+const WORK_SCHEDULE_EVENTS = [
+  {
+    id: 101,
+    date: '2026-03-31',
+    startTime: '13:00:00',
+    endTime: '18:00:00',
+    memberId: 1,
+    memberName: '김리더',
+    teamName: '1팀',
+  },
 ]
 
 const MEMBER_WORK_SCHEDULES = [
@@ -60,6 +76,26 @@ const server = setupServer(
       data: MEMBER_WORK_SCHEDULES.filter((item) => String(params.teamId) === (item.teamName === '1팀' ? '1' : '2')),
     }),
   ),
+  http.get('/api/v1/work-schedule-events', () =>
+    HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: WORK_SCHEDULE_EVENTS }),
+  ),
+  http.post('/api/v1/work-schedule-events', async ({ request }) => {
+    const body = await request.json() as Record<string, string>
+    return HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: { id: 999, memberId: 1, memberName: '김리더', teamName: '1팀', ...body },
+    })
+  }),
+  http.put('/api/v1/work-schedule-events/:eventId', async ({ request, params }) => {
+    const body = await request.json() as Record<string, string>
+    return HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: { id: Number(params.eventId), memberId: 1, memberName: '김리더', teamName: '1팀', ...body },
+    })
+  }),
+  http.delete('/api/v1/work-schedule-events/:eventId', () => new HttpResponse(null, { status: 200 })),
   http.get('/api/v1/attendances/me', ({ request }) => {
     const url = new URL(request.url)
     const date = url.searchParams.get('date')
@@ -147,10 +183,16 @@ describe('workScheduleApi', () => {
   })
 
   it('upsertWorkScheduleDay() 특정 요일 근무 일정을 저장하고 반환한다', async () => {
-    const result = await upsertWorkScheduleDay({ dayOfWeek: 'MONDAY', startTime: '08:00:00', endTime: '17:00:00' })
+    const result = await upsertWorkScheduleDay({
+      dayOfWeek: 'MONDAY',
+      startTime: '08:00:00',
+      endTime: '17:00:00',
+      weekPattern: 'FIRST',
+    })
     expect(result.dayOfWeek).toBe('MONDAY')
     expect(result.startTime).toBe('08:00:00')
     expect(result.endTime).toBe('17:00:00')
+    expect(result.weekPattern).toBe('FIRST')
   })
 
   it('deleteWorkScheduleDay() 특정 요일 근무 일정을 삭제한다', async () => {
@@ -168,5 +210,35 @@ describe('workScheduleApi', () => {
     const schedules = await getTeamWorkSchedules(1)
     expect(schedules).toHaveLength(1)
     expect(schedules[0]).toMatchObject({ memberName: '김리더', teamName: '1팀' })
+  })
+
+  it('getWorkScheduleEvents() 날짜 범위의 근무 일정 이벤트를 반환한다', async () => {
+    const events = await getWorkScheduleEvents('2026-03-01', '2026-03-31')
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({ memberName: '김리더', date: '2026-03-31' })
+  })
+
+  it('createWorkScheduleEvent() 날짜별 근무 일정을 생성한다', async () => {
+    const result = await createWorkScheduleEvent({
+      date: '2026-03-30',
+      startTime: '09:00:00',
+      endTime: '18:00:00',
+    })
+
+    expect(result).toMatchObject({ id: 999, date: '2026-03-30', memberName: '김리더' })
+  })
+
+  it('updateWorkScheduleEvent() 날짜별 근무 일정을 수정한다', async () => {
+    const result = await updateWorkScheduleEvent(101, {
+      date: '2026-03-31',
+      startTime: '10:00:00',
+      endTime: '19:00:00',
+    })
+
+    expect(result).toMatchObject({ id: 101, startTime: '10:00:00', endTime: '19:00:00' })
+  })
+
+  it('deleteWorkScheduleEvent() 날짜별 근무 일정을 삭제한다', async () => {
+    await expect(deleteWorkScheduleEvent(101)).resolves.toBeNull()
   })
 })

--- a/src/shared/api/attendanceApi.ts
+++ b/src/shared/api/attendanceApi.ts
@@ -32,18 +32,21 @@ export const resetMyAttendance = (date?: string) =>
   baseClient.delete<null>(`/api/v1/attendances/me${date ? `?date=${date}` : ''}`)
 
 export type DayOfWeek = 'MONDAY' | 'TUESDAY' | 'WEDNESDAY' | 'THURSDAY' | 'FRIDAY' | 'SATURDAY' | 'SUNDAY'
+export type WeekPattern = 'EVERY' | 'FIRST' | 'SECOND' | 'THIRD' | 'FOURTH' | 'LAST'
 
 export interface WorkScheduleItem {
   id: number
   dayOfWeek: DayOfWeek
   startTime: string  // HH:mm:ss
   endTime: string    // HH:mm:ss
+  weekPattern?: WeekPattern
 }
 
 export interface WorkSchedulePayload {
   dayOfWeek: DayOfWeek
   startTime: string  // HH:mm:ss
   endTime: string    // HH:mm:ss
+  weekPattern?: WeekPattern
 }
 
 export interface MemberWorkScheduleItem {
@@ -51,6 +54,22 @@ export interface MemberWorkScheduleItem {
   memberName: string
   teamName: string
   workSchedules: WorkScheduleItem[]
+}
+
+export interface WorkScheduleEventItem {
+  id: number
+  date: string
+  startTime: string
+  endTime: string
+  memberId: number
+  memberName: string
+  teamName: string
+}
+
+export interface WorkScheduleEventPayload {
+  date: string
+  startTime: string
+  endTime: string
 }
 
 interface RawMemberWorkScheduleItem {
@@ -88,3 +107,15 @@ export const getTeamWorkSchedules = (teamId: number) =>
   baseClient
     .get<RawMemberWorkScheduleItem[]>(`/api/v1/work-schedules/team/${teamId}`)
     .then((items) => items.map(normalizeMemberWorkSchedule))
+
+export const getWorkScheduleEvents = (startDate: string, endDate: string) =>
+  baseClient.get<WorkScheduleEventItem[]>(`/api/v1/work-schedule-events?startDate=${startDate}&endDate=${endDate}`)
+
+export const createWorkScheduleEvent = (body: WorkScheduleEventPayload) =>
+  baseClient.post<WorkScheduleEventItem>('/api/v1/work-schedule-events', body)
+
+export const updateWorkScheduleEvent = (eventId: number, body: WorkScheduleEventPayload) =>
+  baseClient.put<WorkScheduleEventItem>(`/api/v1/work-schedule-events/${eventId}`, body)
+
+export const deleteWorkScheduleEvent = (eventId: number) =>
+  baseClient.delete<null>(`/api/v1/work-schedule-events/${eventId}`)

--- a/src/shared/api/mock/handlers/attendance.ts
+++ b/src/shared/api/mock/handlers/attendance.ts
@@ -1,5 +1,11 @@
 import { http, HttpResponse } from 'msw'
-import type { DayOfWeek, MemberWorkScheduleItem, WorkScheduleItem } from '../../attendanceApi'
+import type {
+  DayOfWeek,
+  MemberWorkScheduleItem,
+  WeekPattern,
+  WorkScheduleEventItem,
+  WorkScheduleItem,
+} from '../../attendanceApi'
 
 function todayStr() {
   const d = new Date()
@@ -14,11 +20,11 @@ let myRecord: {
 
 // 근무 일정 mock 데이터
 let workSchedules: WorkScheduleItem[] = [
-  { id: 1, dayOfWeek: 'MONDAY', startTime: '09:00:00', endTime: '18:00:00' },
-  { id: 2, dayOfWeek: 'TUESDAY', startTime: '09:00:00', endTime: '18:00:00' },
-  { id: 3, dayOfWeek: 'WEDNESDAY', startTime: '09:00:00', endTime: '18:00:00' },
-  { id: 4, dayOfWeek: 'THURSDAY', startTime: '09:00:00', endTime: '18:00:00' },
-  { id: 5, dayOfWeek: 'FRIDAY', startTime: '09:00:00', endTime: '18:00:00' },
+  { id: 1, dayOfWeek: 'MONDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'EVERY' },
+  { id: 2, dayOfWeek: 'TUESDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'EVERY' },
+  { id: 3, dayOfWeek: 'WEDNESDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'SECOND' },
+  { id: 4, dayOfWeek: 'THURSDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'EVERY' },
+  { id: 5, dayOfWeek: 'FRIDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'LAST' },
 ]
 
 let memberWorkSchedules: MemberWorkScheduleItem[] = [
@@ -26,28 +32,60 @@ let memberWorkSchedules: MemberWorkScheduleItem[] = [
     memberId: 1,
     memberName: '김리더',
     teamName: '1팀',
-    workSchedules: [
-      { id: 1, dayOfWeek: 'MONDAY', startTime: '09:00:00', endTime: '18:00:00' },
-      { id: 2, dayOfWeek: 'TUESDAY', startTime: '09:00:00', endTime: '18:00:00' },
-      { id: 3, dayOfWeek: 'WEDNESDAY', startTime: '09:00:00', endTime: '18:00:00' },
+      workSchedules: [
+      { id: 1, dayOfWeek: 'MONDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'EVERY' },
+      { id: 2, dayOfWeek: 'TUESDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'EVERY' },
+      { id: 3, dayOfWeek: 'WEDNESDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'SECOND' },
     ],
   },
   {
     memberId: 2,
     memberName: '박팀장',
     teamName: '2팀',
-    workSchedules: [
-      { id: 4, dayOfWeek: 'MONDAY', startTime: '10:00:00', endTime: '19:00:00' },
-      { id: 5, dayOfWeek: 'THURSDAY', startTime: '10:00:00', endTime: '19:00:00' },
+      workSchedules: [
+      { id: 4, dayOfWeek: 'MONDAY', startTime: '10:00:00', endTime: '19:00:00', weekPattern: 'EVERY' },
+      { id: 5, dayOfWeek: 'THURSDAY', startTime: '10:00:00', endTime: '19:00:00', weekPattern: 'EVERY' },
     ],
   },
   {
     memberId: 4,
     memberName: '최개발',
     teamName: '1팀',
-    workSchedules: [
-      { id: 6, dayOfWeek: 'FRIDAY', startTime: '09:30:00', endTime: '18:30:00' },
+      workSchedules: [
+      { id: 6, dayOfWeek: 'FRIDAY', startTime: '09:30:00', endTime: '18:30:00', weekPattern: 'LAST' },
     ],
+  },
+]
+
+function syncMyMemberWorkSchedules() {
+  memberWorkSchedules = memberWorkSchedules.map((item) =>
+    item.memberId === 1
+      ? {
+          ...item,
+          workSchedules,
+        }
+      : item,
+  )
+}
+
+let workScheduleEvents: WorkScheduleEventItem[] = [
+  {
+    id: 101,
+    date: '2026-03-31',
+    startTime: '13:00:00',
+    endTime: '18:00:00',
+    memberId: 1,
+    memberName: '김리더',
+    teamName: '1팀',
+  },
+  {
+    id: 102,
+    date: '2026-04-02',
+    startTime: '11:00:00',
+    endTime: '16:00:00',
+    memberId: 4,
+    memberName: '최개발',
+    teamName: '1팀',
   },
 ]
 
@@ -144,23 +182,100 @@ export const attendanceHandlers = [
     })
   }),
 
+  http.get('/api/v1/work-schedule-events', ({ request }) => {
+    const url = new URL(request.url)
+    const startDate = url.searchParams.get('startDate')
+    const endDate = url.searchParams.get('endDate')
+
+    const filtered = workScheduleEvents.filter((item) => {
+      if (startDate && item.date < startDate) return false
+      if (endDate && item.date > endDate) return false
+      return true
+    })
+
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: filtered })
+  }),
+
+  http.post('/api/v1/work-schedule-events', async ({ request }) => {
+    const body = await request.json() as { date: string; startTime: string; endTime: string }
+    const created: WorkScheduleEventItem = {
+      id: Date.now(),
+      date: body.date,
+      startTime: body.startTime,
+      endTime: body.endTime,
+      memberId: 1,
+      memberName: '김리더',
+      teamName: '1팀',
+    }
+
+    workScheduleEvents = [...workScheduleEvents, created]
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: created })
+  }),
+
+  http.put('/api/v1/work-schedule-events/:eventId', async ({ params, request }) => {
+    const eventId = Number(params.eventId)
+    const body = await request.json() as { date: string; startTime: string; endTime: string }
+    const existing = workScheduleEvents.find((item) => item.id === eventId)
+
+    if (!existing) {
+      return HttpResponse.json(
+        { code: 'WORK_SCHEDULE_NOT_FOUND', message: '근무 일정이 없습니다.', data: null },
+        { status: 404 },
+      )
+    }
+
+    const updated: WorkScheduleEventItem = {
+      ...existing,
+      date: body.date,
+      startTime: body.startTime,
+      endTime: body.endTime,
+    }
+
+    workScheduleEvents = workScheduleEvents.map((item) => (item.id === eventId ? updated : item))
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: updated })
+  }),
+
+  http.delete('/api/v1/work-schedule-events/:eventId', ({ params }) => {
+    const eventId = Number(params.eventId)
+    workScheduleEvents = workScheduleEvents.filter((item) => item.id !== eventId)
+    return new HttpResponse(null, { status: 200 })
+  }),
+
   http.put('/api/v1/work-schedules', async ({ request }) => {
-    const body = await request.json() as { dayOfWeek: DayOfWeek; startTime: string; endTime: string }
+    const body = await request.json() as {
+      dayOfWeek: DayOfWeek
+      startTime: string
+      endTime: string
+      weekPattern?: WeekPattern
+    }
     const existing = workSchedules.find((s) => s.dayOfWeek === body.dayOfWeek)
     let updated: WorkScheduleItem
     if (existing) {
-      updated = { ...existing, startTime: body.startTime, endTime: body.endTime }
+      updated = {
+        ...existing,
+        startTime: body.startTime,
+        endTime: body.endTime,
+        weekPattern: body.weekPattern ?? existing.weekPattern ?? 'EVERY',
+      }
       workSchedules = workSchedules.map((s) => s.dayOfWeek === body.dayOfWeek ? updated : s)
     } else {
-      updated = { id: Date.now(), dayOfWeek: body.dayOfWeek, startTime: body.startTime, endTime: body.endTime }
+      updated = {
+        id: Date.now(),
+        dayOfWeek: body.dayOfWeek,
+        startTime: body.startTime,
+        endTime: body.endTime,
+        weekPattern: body.weekPattern ?? 'EVERY',
+      }
       workSchedules = [...workSchedules, updated]
     }
+    syncMyMemberWorkSchedules()
     return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: updated })
   }),
 
   http.delete('/api/v1/work-schedules/:dayOfWeek', ({ params }) => {
     const dayOfWeek = String(params.dayOfWeek) as DayOfWeek
     workSchedules = workSchedules.filter((schedule) => schedule.dayOfWeek !== dayOfWeek)
+    syncMyMemberWorkSchedules()
     return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: null })
   }),
 ]

--- a/src/shared/lib/permissions.ts
+++ b/src/shared/lib/permissions.ts
@@ -77,5 +77,5 @@ export function canViewAllWorkSchedules(user: MaybeUser) {
 }
 
 export function canViewTeamWorkSchedules(user: MaybeUser) {
-  return canAccessAdmin(user) || canAccessTeamManagement(user)
+  return Boolean(user)
 }


### PR DESCRIPTION
## 작업 내용
- 날짜별 근무 일정 CRUD API를 근무 일정 페이지에 연결했습니다.
- 반복 근무와 날짜별 일정을 한 캘린더에서 함께 조회할 수 있게 바꿨습니다.
- 반복 근무 설정 카드는 편집 중심으로 단순화하고 라이트 모드 스타일을 보강했습니다.

## 변경 이유
- 기존 근무 일정 화면은 반복 근무 설정과 조회가 분리돼 있어 사용 흐름이 불편했습니다.
- 새로운 백엔드 API를 활용해 날짜 클릭 기반의 근무 일정 추가와 역할별 일정 조회를 지원하기 위해서입니다.

## 상세 변경 사항
- 관리자: 전체 / 팀별 / 개인 범위로 근무 일정 캘린더 조회 가능
- 팀장/멤버: 우리 팀 / 개인 범위로 근무 일정 캘린더 조회 가능
- 날짜 클릭 또는 빠른 추가 버튼으로 날짜별 근무 일정 추가
- 본인 날짜별 일정 수정 및 삭제 가능
- 반복 근무 weekPattern 서버 저장 반영

## 테스트
- npm run test:run
- npm run build

## 리뷰 포인트
- 일반 멤버의 팀 일정 조회 권한이 최신 백엔드 정책과 일치하는지 확인 부탁드립니다.
- 날짜별 근무 일정은 본인 일정만 수정 가능하도록 처리했습니다.

## 관련 이슈
- Closes #284