### PR TITLE
[fix] #293 - 근무 일정 캘린더 목록 뷰와 월 이동 상태 유지

### DIFF
--- a/src/pages/work-schedules/index.tsx
+++ b/src/pages/work-schedules/index.tsx
@@ -242,6 +242,7 @@ export function WorkSchedules() {
   const [recurringSchedules, setRecurringSchedules] = useState<MemberWorkScheduleItem[]>([])
   const [dateEvents, setDateEvents] = useState<WorkScheduleEventItem[]>([])
   const [isLoading, setIsLoading] = useState(true)
+  const [hasLoadedCalendar, setHasLoadedCalendar] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [modalState, setModalState] = useState<ScheduleModalState | null>(null)
   const [isModalSaving, setIsModalSaving] = useState(false)
@@ -332,6 +333,7 @@ export function WorkSchedules() {
       setRecurringSchedules([])
       setDateEvents([])
       setIsLoading(false)
+      setHasLoadedCalendar(true)
       return
     }
 
@@ -375,6 +377,7 @@ export function WorkSchedules() {
       setRecurringSchedules([])
     } finally {
       setIsLoading(false)
+      setHasLoadedCalendar(true)
     }
   }, [calendarRange.end, calendarRange.start, canViewAll, currentTeam, currentUser, scope, selectedMemberId, selectedTeam])
 
@@ -582,15 +585,13 @@ export function WorkSchedules() {
             </button>
           </div>
 
-          {isLoading ? (
+          {isLoading && !hasLoadedCalendar ? (
             <div className="work-schedules-loading">근무 일정을 불러오는 중...</div>
-          ) : calendarEvents.length === 0 ? (
-            <EmptyState
-              title="표시할 근무 일정이 없습니다."
-              description="반복 근무를 저장하거나 날짜를 눌러 개별 근무 일정을 추가해 주세요."
-            />
           ) : (
             <div className="work-schedules-calendar-shell">
+              {isLoading && hasLoadedCalendar && (
+                <div className="work-schedules-calendar-overlay">근무 일정을 새로 불러오는 중...</div>
+              )}
               <FullCalendar
                 plugins={[dayGridPlugin, interactionPlugin, listPlugin]}
                 locale={koLocale}
@@ -618,6 +619,14 @@ export function WorkSchedules() {
                 dayMaxEventRows={3}
                 eventTimeFormat={{ hour: '2-digit', minute: '2-digit', hour12: false }}
               />
+              {!isLoading && calendarEvents.length === 0 && (
+                <div className="work-schedules-empty-state">
+                  <EmptyState
+                    title="표시할 근무 일정이 없습니다."
+                    description="반복 근무를 저장하거나 날짜를 눌러 개별 근무 일정을 추가해 주세요."
+                  />
+                </div>
+              )}
             </div>
           )}
         </DataTableSection>

--- a/src/pages/work-schedules/work-schedules.css
+++ b/src/pages/work-schedules/work-schedules.css
@@ -192,6 +192,7 @@
 
 .work-schedules-calendar-shell {
   min-width: 0;
+  position: relative;
 }
 
 .work-schedules-calendar-shell .fc {
@@ -321,6 +322,28 @@
 
 .work-schedules-calendar-shell .fc .fc-daygrid-event-dot {
   border-color: currentColor;
+}
+
+.work-schedules-calendar-overlay {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  z-index: 3;
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  font-weight: 700;
+  box-shadow: var(--shadow-soft);
+}
+
+.work-schedules-empty-state {
+  margin-top: 16px;
 }
 
 :root[data-theme='light'] .work-schedules-calendar-shell .fc {
@@ -459,5 +482,10 @@
 
   .work-schedules-calendar-shell .fc .fc-toolbar-title {
     font-size: 1rem;
+  }
+
+  .work-schedules-calendar-overlay {
+    top: 10px;
+    right: 10px;
   }
 }


### PR DESCRIPTION
## 작업 내용
- 근무 일정 캘린더 재조회 중에도 현재 뷰와 월 위치가 유지되도록 수정했습니다.
- 목록 보기와 월 이동 도중 캘린더가 다시 초기화되던 문제를 해결했습니다.

## 변경 이유
- 재조회 때 FullCalendar가 언마운트되면서 목록 보기와 다음달 이동 상태가 리셋됐습니다.
- 사용자는 목록 보기와 월 이동이 안 되는 것처럼 느낄 수 있었습니다.

## 상세 변경 사항
- 초기 로딩과 갱신 로딩 분리
- 캘린더는 유지하고 내부 로딩 배지만 표시
- 목록 보기와 월 이동 상태 유지

## 테스트
- npm run test:run -- src/pages/work-schedules/__tests__/WorkSchedules.test.tsx
- npm run build

## 리뷰 포인트
- 목록 보기 전환 후 다시 월로 돌아오거나 다음달로 이동했을 때 상태가 유지되는지 확인 부탁드립니다.

## 관련 이슈
- Closes #293