### PR TITLE
release: v0.2.19

### DIFF
--- a/src/pages/dashboard/__tests__/Dashboard.test.tsx
+++ b/src/pages/dashboard/__tests__/Dashboard.test.tsx
@@ -1,18 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { Dashboard } from '../index'
 
 const mockUpdateEvent = vi.fn()
 const mockDeleteEvent = vi.fn()
 const mockToggleTaskDone = vi.fn()
+const mockHandleClockClick = vi.fn()
+const mockUseWorkSchedule = vi.fn()
 
 vi.mock('../../../features/attendance/model/useWorkSession', () => ({
   useWorkSession: () => ({
     status: 'idle',
     clockIn: null,
     clockOut: null,
-    handleClockClick: vi.fn(),
+    handleClockClick: mockHandleClockClick,
     errorMessage: null,
     toastType: 'info',
     clearError: vi.fn(),
@@ -25,18 +28,7 @@ vi.mock('../../../features/attendance/ui', () => ({
 }))
 
 vi.mock('../../../features/attendance/model/useWorkSchedule', () => ({
-  useWorkSchedule: () => ({
-    workDays: [true, false, false, false, false, false, false],
-    daySchedules: [
-      { checkInTime: '09:00', checkOutTime: '18:00' },
-      { checkInTime: '09:00', checkOutTime: '18:00' },
-      { checkInTime: '09:00', checkOutTime: '18:00' },
-      { checkInTime: '09:00', checkOutTime: '18:00' },
-      { checkInTime: '09:00', checkOutTime: '18:00' },
-      { checkInTime: '09:00', checkOutTime: '18:00' },
-      { checkInTime: '09:00', checkOutTime: '18:00' },
-    ],
-  }),
+  useWorkSchedule: () => mockUseWorkSchedule(),
 }))
 
 vi.mock('../../../features/calendar/model/EventsProvider', () => ({
@@ -72,6 +64,18 @@ vi.mock('../../../shared/lib/date', () => ({
 describe('Dashboard 페이지', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUseWorkSchedule.mockReturnValue({
+      workDays: [true, false, false, false, false, false, false],
+      daySchedules: [
+        { checkInTime: '09:00', checkOutTime: '18:00' },
+        { checkInTime: '09:00', checkOutTime: '18:00' },
+        { checkInTime: '09:00', checkOutTime: '18:00' },
+        { checkInTime: '09:00', checkOutTime: '18:00' },
+        { checkInTime: '09:00', checkOutTime: '18:00' },
+        { checkInTime: '09:00', checkOutTime: '18:00' },
+        { checkInTime: '09:00', checkOutTime: '18:00' },
+      ],
+    })
   })
 
   it('대시보드 페이지가 렌더링된다', () => {
@@ -108,6 +112,62 @@ describe('Dashboard 페이지', () => {
       </MemoryRouter>
     )
     expect(screen.getByText('출근은 220.69 대역 IP에서만 가능합니다.')).toBeInTheDocument()
+  })
+
+  it('근무 일정이 없는 날에는 출근 버튼 클릭 시 경고 모달이 열린다', async () => {
+    const user = userEvent.setup()
+    mockUseWorkSchedule.mockReturnValue({
+      workDays: [false, false, false, false, false, false, false],
+      daySchedules: [
+        { checkInTime: '09:00', checkOutTime: '18:00' },
+        { checkInTime: '09:00', checkOutTime: '18:00' },
+        { checkInTime: '09:00', checkOutTime: '18:00' },
+        { checkInTime: '09:00', checkOutTime: '18:00' },
+        { checkInTime: '09:00', checkOutTime: '18:00' },
+        { checkInTime: '09:00', checkOutTime: '18:00' },
+        { checkInTime: '09:00', checkOutTime: '18:00' },
+      ],
+    })
+
+    render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>
+    )
+
+    await user.click(screen.getByRole('button', { name: '출근하기' }))
+
+    expect(screen.getByText('근무 일정을 등록하셨나요?')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '계속하기' })).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: '닫기' }).length).toBeGreaterThan(0)
+    expect(mockHandleClockClick).not.toHaveBeenCalled()
+  })
+
+  it('근무 일정 경고 모달에서 계속하기를 누르면 출근 처리한다', async () => {
+    const user = userEvent.setup()
+    mockUseWorkSchedule.mockReturnValue({
+      workDays: [false, false, false, false, false, false, false],
+      daySchedules: [
+        { checkInTime: '09:00', checkOutTime: '18:00' },
+        { checkInTime: '09:00', checkOutTime: '18:00' },
+        { checkInTime: '09:00', checkOutTime: '18:00' },
+        { checkInTime: '09:00', checkOutTime: '18:00' },
+        { checkInTime: '09:00', checkOutTime: '18:00' },
+        { checkInTime: '09:00', checkOutTime: '18:00' },
+        { checkInTime: '09:00', checkOutTime: '18:00' },
+      ],
+    })
+
+    render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>
+    )
+
+    await user.click(screen.getByRole('button', { name: '출근하기' }))
+    await user.click(screen.getByRole('button', { name: '계속하기' }))
+
+    expect(mockHandleClockClick).toHaveBeenCalledTimes(1)
   })
 
   it('일정이 없을 때 빈 상태 메시지를 표시한다', () => {

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -57,6 +57,7 @@ export function Dashboard() {
   const navigate = useNavigate()
   const [now, setNow] = useState(() => new Date())
   const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(null)
+  const [showScheduleConfirmModal, setShowScheduleConfirmModal] = useState(false)
   const [isEditingEvent, setIsEditingEvent] = useState(false)
   const [eventForm, setEventForm] = useState({
     title: '',
@@ -184,6 +185,22 @@ export function Dashboard() {
     closeEventDetail()
   }
 
+  const handleClockButtonClick = () => {
+    if (status !== 'idle' || isLoading) return
+
+    if (!todayWorkEnabled) {
+      setShowScheduleConfirmModal(true)
+      return
+    }
+
+    handleClockClick()
+  }
+
+  const handleContinueClockIn = () => {
+    setShowScheduleConfirmModal(false)
+    handleClockClick()
+  }
+
   let centerText = ''
   let centerClass = 'clock-time'
 
@@ -223,7 +240,7 @@ export function Dashboard() {
           <button
             type="button"
             className={`clock-ring-btn ${status === 'idle' && !isLoading ? 'clickable' : ''}`}
-            onClick={status === 'idle' && !isLoading ? handleClockClick : undefined}
+            onClick={status === 'idle' && !isLoading ? handleClockButtonClick : undefined}
             disabled={isLoading || status !== 'idle'}
             aria-label="출근하기"
           >
@@ -514,6 +531,44 @@ export function Dashboard() {
                   </button>
                 </>
               )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showScheduleConfirmModal && (
+        <div className="dashboard-modal-overlay" onClick={() => setShowScheduleConfirmModal(false)}>
+          <div className="dashboard-detail-modal glass" onClick={(event) => event.stopPropagation()}>
+            <div className="dashboard-detail-head">
+              <h3>근무 일정을 등록하셨나요?</h3>
+              <button
+                type="button"
+                className="dashboard-detail-close"
+                aria-label="닫기"
+                onClick={() => setShowScheduleConfirmModal(false)}
+              >
+                <X size={18} />
+              </button>
+            </div>
+            <div className="dashboard-detail-body">
+              <p>오늘 등록된 근무 일정이 없어도 출근을 계속 진행할 수 있습니다.</p>
+              <span>근무 일정이 있다면 먼저 확인한 뒤 진행해 주세요.</span>
+            </div>
+            <div className="dashboard-detail-actions">
+              <button
+                type="button"
+                className="dashboard-secondary-btn"
+                onClick={() => setShowScheduleConfirmModal(false)}
+              >
+                닫기
+              </button>
+              <button
+                type="button"
+                className="dashboard-primary-btn"
+                onClick={handleContinueClockIn}
+              >
+                계속하기
+              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 작업 내용
- 근무 일정이 등록되지 않은 상태에서 대시보드 출근 버튼을 누르면 확인 모달이 먼저 뜨도록 변경했습니다.
- 모달에서 `계속하기`를 눌렀을 때만 실제 출근 처리가 진행되도록 정리했습니다.
- 관련 대시보드 테스트를 추가해 근무 일정 미등록 상태의 출근 흐름을 고정했습니다.

## 변경 이유
- 근무 일정을 등록하지 않은 상태에서 바로 출근 처리되면 사용자가 실수로 기록을 남길 수 있었습니다.
- 출근 전 한 번 더 확인하는 경고 UX가 필요했습니다.

## 상세 변경 사항
- 대시보드 출근 버튼 클릭 시 근무 일정 미등록 여부 확인
- `계속하기` / `닫기` 액션 분리
- 대시보드 출근 흐름 테스트 추가

## 테스트
- `npm run test -- src/pages/dashboard/__tests__/Dashboard.test.tsx`
- `npm run build`

## 리뷰 포인트
- 오늘 근무 일정이 없는 경우에만 모달이 뜨는지
- `계속하기` 이후 실제 출근 처리로 자연스럽게 이어지는지
- 기존 퇴근하기 / 초기화 흐름에는 영향이 없는지

## 관련 이슈
- refs #309