### PR TITLE
release: v0.2.20

### DIFF
--- a/src/pages/admin/__tests__/Admin.test.tsx
+++ b/src/pages/admin/__tests__/Admin.test.tsx
@@ -90,6 +90,8 @@ const mockSettlement = {
   ],
 }
 
+const mockTemporaryPassword = 'A1b2C3d4'
+
 const server = setupServer(
   http.get('/api/v1/auth/me', () =>
     HttpResponse.json({
@@ -162,6 +164,13 @@ const server = setupServer(
       },
     })
   }),
+  http.post('/api/v1/members/:memberId/reset-password', () =>
+    HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: { temporaryPassword: mockTemporaryPassword },
+    }),
+  ),
 )
 
 beforeAll(() => server.listen())
@@ -225,6 +234,22 @@ describe('Admin 페이지', () => {
     expect(screen.getByText('멤버 목록')).toBeInTheDocument()
     expect(screen.getAllByRole('button', { name: '활성화' }).length).toBeGreaterThan(0)
     expect(screen.getAllByLabelText('관리 메뉴 열기').length).toBeGreaterThan(0)
+  })
+
+  it('관리자는 멤버 관리 메뉴에서 임시 비밀번호를 발급할 수 있다', async () => {
+    const user = userEvent.setup()
+    renderAdmin()
+    await user.click(screen.getByRole('button', { name: '멤버 관리' }))
+
+    const targetRow = screen.getByText('강민준').closest('tr')
+    expect(targetRow).not.toBeNull()
+
+    const scoped = within(targetRow as HTMLTableRowElement)
+    await user.click(scoped.getByLabelText('관리 메뉴 열기'))
+    await user.click(screen.getByRole('menuitem', { name: '임시 비밀번호 발급' }))
+
+    expect(await screen.findByText('임시 비밀번호가 발급되었습니다')).toBeInTheDocument()
+    expect(screen.getByText(mockTemporaryPassword)).toBeInTheDocument()
   })
 
   it('관리자는 본인 계정에 대해 역할, 상태, 퇴출 액션을 볼 수 없다', async () => {

--- a/src/pages/admin/admin.css
+++ b/src/pages/admin/admin.css
@@ -685,6 +685,36 @@
   font-weight: 600;
 }
 
+.admin-reset-password-result {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.admin-reset-password-result p,
+.admin-reset-password-result span {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.admin-reset-password-result strong {
+  color: var(--text-primary);
+}
+
+.admin-reset-password-result code {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--accent-purple) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-purple) 18%, transparent);
+  color: var(--text-primary);
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
 .admin-role-options {
   display: flex;
   flex-direction: column;

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -8,7 +8,13 @@ import { getMonthlyAttendanceSettlement } from '../../shared/api/attendanceSettl
 import type { AttendanceSettlement } from '../../shared/api/attendanceSettlementApi'
 import { getAuditLogs } from '../../shared/api/auditLogsApi'
 import type { AuditLog } from '../../shared/api/auditLogsApi'
-import { updateMemberRole, deactivateMember, activateMember, updateMemberTeam } from '../../shared/api/membersApi'
+import {
+  updateMemberRole,
+  deactivateMember,
+  activateMember,
+  updateMemberTeam,
+  resetMemberPassword,
+} from '../../shared/api/membersApi'
 import type { User, UserRole } from '../../entities/user/model/types'
 import { exportAttendanceToCsv } from '../../shared/lib/exportCsv'
 import { Toast } from '../../shared/ui/Toast'
@@ -96,6 +102,7 @@ export function Admin() {
   const [selectedRole, setSelectedRole] = useState<UserRole>('MEMBER')
   const [selectedTeamId, setSelectedTeamId] = useState<number | null>(null)
   const [newTeamName, setNewTeamName] = useState('')
+  const [resetPasswordResult, setResetPasswordResult] = useState<{ name: string; temporaryPassword: string } | null>(null)
   const [settlementView, setSettlementView] = useState<SettlementView>('overall')
   const [selectedSettlementTeamName, setSelectedSettlementTeamName] = useState('')
   const [selectedSettlementMemberId, setSelectedSettlementMemberId] = useState<string>('')
@@ -254,6 +261,26 @@ export function Admin() {
       await reloadMembersAndTeams()
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : '비활성화에 실패했습니다')
+    }
+    setSaving(false)
+  }
+
+  const handleResetPassword = async (member: User) => {
+    if (!canManageMemberStatusFor(state.currentUser, member)) {
+      setErrorMessage('본인 계정의 비밀번호는 이 화면에서 초기화할 수 없습니다')
+      return
+    }
+
+    setSaving(true)
+    try {
+      const result = await resetMemberPassword(member.id)
+      setResetPasswordResult({
+        name: member.name,
+        temporaryPassword: result.temporaryPassword,
+      })
+      setSuccessMessage(`${member.name}의 임시 비밀번호를 발급했습니다`)
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '임시 비밀번호 발급에 실패했습니다')
     }
     setSaving(false)
   }
@@ -498,6 +525,7 @@ export function Admin() {
             saving={saving}
             showStatus
             showActions
+            onResetPassword={handleResetPassword}
             onOpenRoleChange={(member) => handleOpenRoleChange(member.id, member.name, member.role)}
             onOpenTeamChange={handleOpenTeamChange}
             onDeactivate={handleDeactivate}
@@ -1033,6 +1061,26 @@ export function Admin() {
                 onClick={handleConfirmRoleChange}
               >
                 {saving ? '저장 중...' : '변경 확인'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {resetPasswordResult && (
+        <div className="admin-modal-overlay" onClick={() => setResetPasswordResult(null)}>
+          <div className="admin-modal glass" onClick={(event) => event.stopPropagation()}>
+            <h3>임시 비밀번호가 발급되었습니다</h3>
+            <div className="admin-reset-password-result">
+              <p>
+                <strong>{resetPasswordResult.name}</strong> 계정의 임시 비밀번호입니다.
+              </p>
+              <code>{resetPasswordResult.temporaryPassword}</code>
+              <span>로그인 후 반드시 비밀번호를 변경하도록 안내해 주세요.</span>
+            </div>
+            <div className="admin-modal-actions">
+              <button type="button" className="confirm-btn" onClick={() => setResetPasswordResult(null)}>
+                확인
               </button>
             </div>
           </div>

--- a/src/shared/api/__tests__/membersApi.test.ts
+++ b/src/shared/api/__tests__/membersApi.test.ts
@@ -1,7 +1,17 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
 import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
-import { getMembers, getMember, updateMemberRole, deactivateMember, activateMember, getMyProfile, updateMyProfile, updateMemberTeam } from '../membersApi'
+import {
+  getMembers,
+  getMember,
+  updateMemberRole,
+  deactivateMember,
+  activateMember,
+  getMyProfile,
+  updateMyProfile,
+  updateMemberTeam,
+  resetMemberPassword,
+} from '../membersApi'
 
 const server = setupServer(
   http.get('/api/v1/members', () =>
@@ -42,6 +52,13 @@ const server = setupServer(
   ),
   http.put('/api/v1/members/me', async () =>
     HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: null }),
+  ),
+  http.post('/api/v1/members/:id/reset-password', ({ params }) =>
+    HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: { temporaryPassword: `temp-${params.id}` },
+    }),
   ),
 )
 
@@ -84,5 +101,9 @@ describe('membersApi', () => {
 
   it('updateMyProfile() 내 프로필을 업데이트한다', async () => {
     await expect(updateMyProfile({ name: '새이름' })).resolves.not.toThrow()
+  })
+
+  it('resetMemberPassword() 임시 비밀번호를 발급한다', async () => {
+    await expect(resetMemberPassword('2')).resolves.toEqual({ temporaryPassword: 'temp-2' })
   })
 })

--- a/src/shared/api/membersApi.ts
+++ b/src/shared/api/membersApi.ts
@@ -10,6 +10,10 @@ export interface UpdateMemberTeamPayload {
   teamId: number
 }
 
+export interface TemporaryPasswordResponse {
+  temporaryPassword: string
+}
+
 // OpenAPI MemberResponse: id는 integer(int64) — User.id(string)로 변환 필요
 interface MemberResponse {
   id: number
@@ -64,3 +68,6 @@ export const activateMember = (id: string) =>
 
 export const updateMyProfile = (payload: ProfileUpdatePayload) =>
   baseClient.put<null>('/api/v1/members/me', payload)
+
+export const resetMemberPassword = (id: string) =>
+  baseClient.post<TemporaryPasswordResponse>(`/api/v1/members/${id}/reset-password`, {})

--- a/src/shared/api/mock/handlers/members.ts
+++ b/src/shared/api/mock/handlers/members.ts
@@ -86,6 +86,13 @@ export const membersHandlers = [
     return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: null })
   }),
 
+  http.post('/api/v1/members/:id/reset-password', ({ params }) =>
+    HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: { temporaryPassword: `temp-${params.id}-pw` },
+    })),
+
   http.put('/api/v1/members/me', async ({ request }) => {
     const body = await request.json() as { name?: string; password?: string }
     const auth = request.headers.get('Authorization') ?? ''

--- a/src/shared/ui/MemberManagementTable/MemberManagementTable.tsx
+++ b/src/shared/ui/MemberManagementTable/MemberManagementTable.tsx
@@ -26,6 +26,7 @@ interface MemberManagementTableProps {
   emptyMessage?: string
   showStatus?: boolean
   showActions?: boolean
+  onResetPassword?: (member: User) => void
   onOpenRoleChange?: (member: User) => void
   onOpenTeamChange?: (member: User) => void
   onDeactivate?: (memberId: string) => void
@@ -43,6 +44,7 @@ export function MemberManagementTable({
   emptyMessage = '표시할 멤버가 없습니다.',
   showStatus = false,
   showActions = false,
+  onResetPassword,
   onOpenRoleChange,
   onOpenTeamChange,
   onDeactivate,
@@ -54,6 +56,7 @@ export function MemberManagementTable({
   canExpelFor,
 }: MemberManagementTableProps) {
   const showRoleChange = typeof onOpenRoleChange === 'function'
+  const showResetPassword = typeof onResetPassword === 'function'
   const showTeamChange = typeof onOpenTeamChange === 'function'
   const showStatusAction = typeof onDeactivate === 'function' || typeof onActivate === 'function'
   const showExpel = typeof onExpel === 'function'
@@ -100,6 +103,14 @@ export function MemberManagementTable({
                   ? [{
                       label: '역할 변경',
                       onSelect: () => onOpenRoleChange?.(member),
+                    }]
+                  : []),
+                ...(canManageRole && showResetPassword
+                  ? [{
+                      label: '임시 비밀번호 발급',
+                      tone: 'warning' as const,
+                      disabled: saving,
+                      onSelect: () => onResetPassword?.(member),
                     }]
                   : []),
                 ...(canExpel


### PR DESCRIPTION
## 작업 내용
- 관리자 멤버 관리 액션 메뉴에 `임시 비밀번호 발급` 항목을 추가했습니다.
- 발급 성공 시 백엔드가 내려준 임시 비밀번호를 바로 확인할 수 있는 결과 모달을 연결했습니다.
- 멤버 API 래퍼와 개발용 MSW 핸들러를 추가하고, 관련 테스트를 보강했습니다.

## 변경 이유
- 백엔드에 관리자 임시 비밀번호 발급 API가 추가되어 프론트엔드에서도 바로 사용할 수 있어야 했습니다.
- 단순 요청만 보내는 것보다, 발급된 임시 비밀번호를 관리자가 즉시 확인하고 전달할 수 있는 UI가 필요했습니다.

## 상세 변경 사항
- 관리자 멤버 관리 액션 메뉴에 임시 비밀번호 발급 연결
- 발급 결과 모달 추가
- 멤버 API 및 MSW 핸들러 보강
- 관리자/멤버 API 테스트 추가

## 테스트
- `npm run test -- src/shared/api/__tests__/membersApi.test.ts src/pages/admin/__tests__/Admin.test.tsx`
- `npm run build`

## 리뷰 포인트
- 관리자 멤버 관리 메뉴에서 임시 비밀번호 발급 액션이 자연스럽게 노출되는지
- 발급 후 결과 모달에 비밀번호가 바로 표시되는지
- 기존 역할 변경, 팀 변경, 상태 변경 액션과 충돌하지 않는지

## 관련 이슈
- closes #141