### PR TITLE
[fix] #313 - 출근 내역 초기화 전 확인 모달 추가

### DIFF
--- a/src/pages/dashboard/__tests__/Dashboard.test.tsx
+++ b/src/pages/dashboard/__tests__/Dashboard.test.tsx
@@ -9,18 +9,10 @@ const mockDeleteEvent = vi.fn()
 const mockToggleTaskDone = vi.fn()
 const mockHandleClockClick = vi.fn()
 const mockUseWorkSchedule = vi.fn()
+const mockUseWorkSession = vi.fn()
 
 vi.mock('../../../features/attendance/model/useWorkSession', () => ({
-  useWorkSession: () => ({
-    status: 'idle',
-    clockIn: null,
-    clockOut: null,
-    handleClockClick: mockHandleClockClick,
-    errorMessage: null,
-    toastType: 'info',
-    clearError: vi.fn(),
-    isLoading: false,
-  }),
+  useWorkSession: () => mockUseWorkSession(),
 }))
 
 vi.mock('../../../features/attendance/ui', () => ({
@@ -64,6 +56,16 @@ vi.mock('../../../shared/lib/date', () => ({
 describe('Dashboard 페이지', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUseWorkSession.mockReturnValue({
+      status: 'idle',
+      clockIn: null,
+      clockOut: null,
+      handleClockClick: mockHandleClockClick,
+      errorMessage: null,
+      toastType: 'info',
+      clearError: vi.fn(),
+      isLoading: false,
+    })
     mockUseWorkSchedule.mockReturnValue({
       workDays: [true, false, false, false, false, false, false],
       daySchedules: [
@@ -165,6 +167,56 @@ describe('Dashboard 페이지', () => {
     )
 
     await user.click(screen.getByRole('button', { name: '출근하기' }))
+    await user.click(screen.getByRole('button', { name: '계속하기' }))
+
+    expect(mockHandleClockClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('퇴근 완료 상태에서 출근 내역 초기화 버튼 클릭 시 확인 모달이 열린다', async () => {
+    const user = userEvent.setup()
+    mockUseWorkSession.mockReturnValue({
+      status: 'done',
+      clockIn: new Date('2026-03-23T09:00:00'),
+      clockOut: new Date('2026-03-23T18:00:00'),
+      handleClockClick: mockHandleClockClick,
+      errorMessage: null,
+      toastType: 'info',
+      clearError: vi.fn(),
+      isLoading: false,
+    })
+
+    render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>
+    )
+
+    await user.click(screen.getByRole('button', { name: '출근 내역 초기화' }))
+
+    expect(screen.getByText('출근 내역을 초기화할까요?')).toBeInTheDocument()
+    expect(mockHandleClockClick).not.toHaveBeenCalled()
+  })
+
+  it('출근 내역 초기화 확인 모달에서 계속하기를 누르면 초기화한다', async () => {
+    const user = userEvent.setup()
+    mockUseWorkSession.mockReturnValue({
+      status: 'done',
+      clockIn: new Date('2026-03-23T09:00:00'),
+      clockOut: new Date('2026-03-23T18:00:00'),
+      handleClockClick: mockHandleClockClick,
+      errorMessage: null,
+      toastType: 'info',
+      clearError: vi.fn(),
+      isLoading: false,
+    })
+
+    render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>
+    )
+
+    await user.click(screen.getByRole('button', { name: '출근 내역 초기화' }))
     await user.click(screen.getByRole('button', { name: '계속하기' }))
 
     expect(mockHandleClockClick).toHaveBeenCalledTimes(1)

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -58,6 +58,7 @@ export function Dashboard() {
   const [now, setNow] = useState(() => new Date())
   const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(null)
   const [showScheduleConfirmModal, setShowScheduleConfirmModal] = useState(false)
+  const [showResetConfirmModal, setShowResetConfirmModal] = useState(false)
   const [isEditingEvent, setIsEditingEvent] = useState(false)
   const [eventForm, setEventForm] = useState({
     title: '',
@@ -201,6 +202,16 @@ export function Dashboard() {
     handleClockClick()
   }
 
+  const handleResetClick = () => {
+    if (status !== 'done' || isLoading) return
+    setShowResetConfirmModal(true)
+  }
+
+  const handleContinueReset = () => {
+    setShowResetConfirmModal(false)
+    handleClockClick()
+  }
+
   let centerText = ''
   let centerClass = 'clock-time'
 
@@ -305,7 +316,7 @@ export function Dashboard() {
               <button
                 type="button"
                 className="clock-reset-btn"
-                onClick={handleClockClick}
+                onClick={handleResetClick}
                 disabled={isLoading}
               >
                 출근 내역 초기화
@@ -566,6 +577,44 @@ export function Dashboard() {
                 type="button"
                 className="dashboard-primary-btn"
                 onClick={handleContinueClockIn}
+              >
+                계속하기
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showResetConfirmModal && (
+        <div className="dashboard-modal-overlay" onClick={() => setShowResetConfirmModal(false)}>
+          <div className="dashboard-detail-modal glass" onClick={(event) => event.stopPropagation()}>
+            <div className="dashboard-detail-head">
+              <h3>출근 내역을 초기화할까요?</h3>
+              <button
+                type="button"
+                className="dashboard-detail-close"
+                aria-label="닫기"
+                onClick={() => setShowResetConfirmModal(false)}
+              >
+                <X size={18} />
+              </button>
+            </div>
+            <div className="dashboard-detail-body">
+              <p>오늘 기록된 출근과 퇴근 시간이 초기화됩니다.</p>
+              <span>다시 출근 기록을 남겨야 하는 경우에만 계속 진행해 주세요.</span>
+            </div>
+            <div className="dashboard-detail-actions">
+              <button
+                type="button"
+                className="dashboard-secondary-btn"
+                onClick={() => setShowResetConfirmModal(false)}
+              >
+                닫기
+              </button>
+              <button
+                type="button"
+                className="dashboard-primary-btn"
+                onClick={handleContinueReset}
               >
                 계속하기
               </button>


### PR DESCRIPTION
## 작업 내용
- 대시보드에서 출근 내역 초기화 버튼 클릭 시 바로 초기화되지 않고 확인 모달이 먼저 열리도록 변경했습니다.
- 확인 모달에서 `계속하기`를 눌렀을 때만 실제 초기화가 진행되도록 연결했습니다.
- 대시보드 테스트를 상태별로 주입할 수 있게 정리하고, 초기화 확인 모달 흐름 테스트를 추가했습니다.

## 변경 이유
- 출근 내역 초기화는 되돌리기 어려운 동작이라 실수로 누르는 경우를 한 번 더 막아줄 필요가 있었습니다.
- QA 이슈에서 사용자 입장에서 초기화 전에 다시 한번 묻는 흐름이 있으면 좋겠다는 피드백이 들어와 반영했습니다.

## 상세 변경 사항
### 주요 변경
- [x] 퇴근 완료 상태에서 초기화 버튼 클릭 시 확인 모달 표시
- [x] 확인 후에만 출근 내역 초기화 실행
- [x] 대시보드 테스트에 초기화 확인 시나리오 추가

### 추가 메모
- 기존 근무 일정 미등록 경고 모달과 같은 패턴으로 맞춰서 사용자 경험이 튀지 않도록 구성했습니다.

## 테스트
- [x] `npm run test -- src/pages/dashboard/__tests__/Dashboard.test.tsx`
- [x] `npm run build`
- [x] 브라우저에서 주요 동작 확인

## 리뷰 포인트
- 퇴근 완료 상태에서만 초기화 확인 모달이 노출되는지
- 모달에서 `닫기`와 `계속하기`가 각각 의도대로 동작하는지
- 기존 출근 전 근무 일정 확인 모달 흐름에 영향이 없는지

## 관련 이슈
- closes #313