### PR TITLE
[feat] #317 - 이메일 인증 화면 및 API 연동 추가

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -5,6 +5,7 @@ import { AdminRoute } from '../shared/ui/AdminRoute'
 import { TeamLeadRoute } from '../shared/ui/TeamLeadRoute'
 import { Login } from '../pages/login'
 import { Register } from '../pages/register'
+import { VerifyEmail } from '../pages/verify-email'
 import { Dashboard } from '../pages/dashboard'
 import { Chat } from '../pages/chat'
 import { Calendar } from '../pages/calendar'
@@ -23,6 +24,7 @@ export function AppRouter() {
       <Routes>
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
+        <Route path="/verify-email" element={<VerifyEmail />} />
         <Route element={<PrivateRoute />}>
           <Route path="/" element={<Layout />}>
             <Route index element={<Dashboard />} />

--- a/src/features/auth/api/__tests__/authClient.test.ts
+++ b/src/features/auth/api/__tests__/authClient.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
 import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
-import { login, register, getMe, logout } from '../authClient'
+import { login, register, getMe, logout, verifyEmail, resendVerificationEmail } from '../authClient'
 
 const server = setupServer(
   http.post('/api/v1/auth/login', async ({ request }) => {
@@ -22,6 +22,12 @@ const server = setupServer(
     if (body.email === 'locked@yanus.kr' && body.password === 'password') {
       return HttpResponse.json(
         { code: 'ACCOUNT_LOCKED', message: '로그인 5회 실패로 계정이 잠겼습니다', data: null },
+        { status: 403 },
+      )
+    }
+    if (body.email === 'pending@yanus.kr' && body.password === 'password') {
+      return HttpResponse.json(
+        { code: 'EMAIL_NOT_VERIFIED', message: '이메일 인증이 필요합니다', data: null },
         { status: 403 },
       )
     }
@@ -50,6 +56,28 @@ const server = setupServer(
   http.post('/api/v1/auth/logout', () =>
     HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: null }),
   ),
+  http.post('/api/v1/auth/verify-email', async ({ request }) => {
+    const body = await request.json() as { token: string }
+    if (body.token === 'valid-token') {
+      return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: {} })
+    }
+
+    return HttpResponse.json(
+      { code: 'INVALID_TOKEN', message: '유효하지 않거나 만료된 인증 링크입니다', data: null },
+      { status: 400 },
+    )
+  }),
+  http.post('/api/v1/auth/verify-email/resend', async ({ request }) => {
+    const body = await request.json() as { email: string }
+    if (body.email === 'unknown@yanus.kr') {
+      return HttpResponse.json(
+        { code: 'NOT_FOUND', message: '가입된 이메일을 찾을 수 없습니다', data: null },
+        { status: 404 },
+      )
+    }
+
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: {} })
+  }),
 )
 
 beforeAll(() => server.listen())
@@ -81,6 +109,12 @@ describe('authClient', () => {
     it('계정 잠금 상태면 전용 안내 문구를 반환한다', async () => {
       await expect(login('locked@yanus.kr', 'password')).rejects.toThrow(
         '로그인 5회 실패로 계정이 잠겼습니다. 30분 후 다시 시도해 주세요',
+      )
+    })
+
+    it('이메일 인증 전 계정이면 전용 안내 문구를 반환한다', async () => {
+      await expect(login('pending@yanus.kr', 'password')).rejects.toThrow(
+        '이메일 인증을 완료한 뒤 로그인해 주세요',
       )
     })
   })
@@ -119,6 +153,26 @@ describe('authClient', () => {
       await expect(logout()).resolves.not.toThrow()
       expect(localStorage.getItem('accessToken')).toBeNull()
       expect(localStorage.getItem('refreshToken')).toBeNull()
+    })
+  })
+
+  describe('verifyEmail()', () => {
+    it('유효한 토큰이면 완료된다', async () => {
+      await expect(verifyEmail('valid-token')).resolves.not.toThrow()
+    })
+
+    it('유효하지 않은 토큰이면 에러를 던진다', async () => {
+      await expect(verifyEmail('invalid-token')).rejects.toThrow('유효하지 않거나 만료된 인증 링크입니다')
+    })
+  })
+
+  describe('resendVerificationEmail()', () => {
+    it('재전송 요청이 성공한다', async () => {
+      await expect(resendVerificationEmail('new@yanus.kr')).resolves.not.toThrow()
+    })
+
+    it('존재하지 않는 이메일이면 에러를 던진다', async () => {
+      await expect(resendVerificationEmail('unknown@yanus.kr')).rejects.toThrow('가입된 이메일을 찾을 수 없습니다')
     })
   })
 })

--- a/src/features/auth/api/authClient.ts
+++ b/src/features/auth/api/authClient.ts
@@ -40,6 +40,9 @@ export async function login(email: string, password: string): Promise<string> {
     if (err instanceof ApiError && err.code === 'ACCOUNT_LOCKED') {
       throw new Error('로그인 5회 실패로 계정이 잠겼습니다. 30분 후 다시 시도해 주세요')
     }
+    if (err instanceof ApiError && err.code === 'EMAIL_NOT_VERIFIED') {
+      throw new Error('이메일 인증을 완료한 뒤 로그인해 주세요')
+    }
     throw err
   }
 }
@@ -65,4 +68,12 @@ export async function logout(): Promise<void> {
   } finally {
     clearAuthTokens()
   }
+}
+
+export async function verifyEmail(token: string): Promise<void> {
+  await baseClient.post<Record<string, never>>('/api/v1/auth/verify-email', { token })
+}
+
+export async function resendVerificationEmail(email: string): Promise<void> {
+  await baseClient.post<Record<string, never>>('/api/v1/auth/verify-email/resend', { email })
 }

--- a/src/pages/register/__tests__/Register.test.tsx
+++ b/src/pages/register/__tests__/Register.test.tsx
@@ -36,6 +36,7 @@ describe('Register 페이지', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
+    sessionStorage.clear()
     mockGetMe.mockResolvedValue({ id: '4', name: '새사용자', email: 'new@yanus.kr', team: '신입', role: 'MEMBER', online: true })
     mockLogin.mockImplementation(async () => {
       localStorage.setItem('accessToken', 'mock-login-token')
@@ -74,7 +75,7 @@ describe('Register 페이지', () => {
     expect(await screen.findByText('비밀번호가 일치하지 않습니다')).toBeInTheDocument()
   })
 
-  it('회원가입 성공 시 accessToken을 저장하고 홈으로 이동한다', async () => {
+  it('회원가입 성공 시 이메일 인증 안내 화면으로 이동한다', async () => {
     mockRegister.mockResolvedValue(undefined)
     renderRegister()
     await userEvent.type(screen.getByLabelText('이름'), '홍길동')
@@ -89,9 +90,12 @@ describe('Register 페이지', () => {
         password: 'password123',
         teamId: 5,
       })
-      expect(localStorage.getItem('accessToken')).toBe('mock-login-token')
-      expect(localStorage.getItem('refreshToken')).toBe('mock-refresh-token')
-      expect(mockNavigate).toHaveBeenCalledWith('/')
+      expect(mockLogin).not.toHaveBeenCalled()
+      expect(mockGetMe).not.toHaveBeenCalled()
+      expect(sessionStorage.getItem('yanus-pending-verification-email')).toBe('user@test.com')
+      expect(mockNavigate).toHaveBeenCalledWith('/verify-email', {
+        state: { email: 'user@test.com' },
+      })
     })
   })
 

--- a/src/pages/register/index.tsx
+++ b/src/pages/register/index.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { User as UserIcon, Mail, Lock, Eye, EyeOff, AlertCircle } from 'lucide-react'
-import { getMe, login, register } from '../../features/auth/api/authClient'
-import { useApp } from '../../features/auth/model'
+import { register } from '../../features/auth/api/authClient'
 import { getTeams } from '../../shared/api/teamsApi'
 import type { TeamResponse } from '../../shared/api/teamsApi'
 import {
@@ -13,6 +12,7 @@ import {
   getDefaultSignupTeam,
   sortTeams,
 } from '../../shared/lib/team'
+import { setPendingVerificationEmail } from '../../shared/lib/emailVerification'
 import logoSrc from '../../assets/logo.png'
 import './register.css'
 
@@ -48,7 +48,6 @@ function validate(name: string, email: string, password: string, confirmPassword
 
 export function Register() {
   const navigate = useNavigate()
-  const { loadUser } = useApp()
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -102,10 +101,10 @@ export function Register() {
     setLoading(true)
     try {
       await register({ name, email, password, teamId: defaultTeam.id })
-      await login(email, password)
-      const user = await getMe()
-      loadUser(user)
-      navigate('/')
+      setPendingVerificationEmail(email)
+      navigate('/verify-email', {
+        state: { email },
+      })
     } catch (err) {
       setServerError(err instanceof Error ? err.message : '회원가입에 실패했습니다')
     } finally {

--- a/src/pages/verify-email/__tests__/VerifyEmail.test.tsx
+++ b/src/pages/verify-email/__tests__/VerifyEmail.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { VerifyEmail } from '../index'
+
+vi.mock('../../../features/auth/api/authClient', () => ({
+  verifyEmail: vi.fn(),
+  resendVerificationEmail: vi.fn(),
+}))
+
+import { verifyEmail, resendVerificationEmail } from '../../../features/auth/api/authClient'
+
+const mockVerifyEmail = vi.mocked(verifyEmail)
+const mockResendVerificationEmail = vi.mocked(resendVerificationEmail)
+
+function renderVerifyEmail(initialEntries: Array<string | { pathname: string; search?: string; state?: unknown }>) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <Routes>
+        <Route path="/verify-email" element={<VerifyEmail />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('VerifyEmail 페이지', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    sessionStorage.clear()
+  })
+
+  it('회원가입 직후 진입하면 이메일 인증 안내와 재전송 버튼을 표시한다', () => {
+    renderVerifyEmail([{ pathname: '/verify-email', state: { email: 'user@test.com' } }])
+
+    expect(screen.getByText('이메일을 확인해 주세요')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('user@test.com')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '인증 메일 다시 보내기' })).toBeInTheDocument()
+  })
+
+  it('토큰이 있으면 자동으로 이메일 인증을 시도하고 성공 메시지를 표시한다', async () => {
+    mockVerifyEmail.mockResolvedValue(undefined)
+
+    renderVerifyEmail(['/verify-email?token=valid-token'])
+
+    await waitFor(() => {
+      expect(mockVerifyEmail).toHaveBeenCalledWith('valid-token')
+    })
+
+    expect(await screen.findByText('이메일 인증이 완료되었습니다')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '로그인하러 가기' })).toBeInTheDocument()
+  })
+
+  it('이메일 인증 메일 재전송 요청이 가능하다', async () => {
+    const user = userEvent.setup()
+    mockResendVerificationEmail.mockResolvedValue(undefined)
+
+    renderVerifyEmail([{ pathname: '/verify-email', state: { email: 'user@test.com' } }])
+
+    await user.click(screen.getByRole('button', { name: '인증 메일 다시 보내기' }))
+
+    await waitFor(() => {
+      expect(mockResendVerificationEmail).toHaveBeenCalledWith('user@test.com')
+    })
+
+    expect(await screen.findByText('인증 메일을 다시 보냈습니다. 메일함을 확인해 주세요')).toBeInTheDocument()
+  })
+})

--- a/src/pages/verify-email/index.tsx
+++ b/src/pages/verify-email/index.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useLocation, useSearchParams } from 'react-router-dom'
+import { AlertCircle, CheckCircle2, Mail, RotateCw } from 'lucide-react'
+import { resendVerificationEmail, verifyEmail } from '../../features/auth/api/authClient'
+import {
+  clearPendingVerificationEmail,
+  getPendingVerificationEmail,
+  setPendingVerificationEmail,
+} from '../../shared/lib/emailVerification'
+import logoSrc from '../../assets/logo.png'
+import './verify-email.css'
+
+type VerifyStatus = 'idle' | 'loading' | 'success' | 'error'
+
+interface VerifyEmailLocationState {
+  email?: string
+}
+
+export function VerifyEmail() {
+  const location = useLocation()
+  const [searchParams] = useSearchParams()
+  const state = location.state as VerifyEmailLocationState | null
+  const token = searchParams.get('token')?.trim() ?? ''
+  const initialEmail = useMemo(
+    () => state?.email ?? getPendingVerificationEmail(),
+    [state?.email],
+  )
+
+  const [email, setEmail] = useState(initialEmail)
+  const [verifyStatus, setVerifyStatus] = useState<VerifyStatus>(token ? 'loading' : 'idle')
+  const [verifyMessage, setVerifyMessage] = useState('')
+  const [resendMessage, setResendMessage] = useState('')
+  const [resendError, setResendError] = useState('')
+  const [resending, setResending] = useState(false)
+
+  useEffect(() => {
+    if (!token) return
+
+    let cancelled = false
+
+    ;(async () => {
+      setVerifyStatus('loading')
+      setVerifyMessage('')
+      try {
+        await verifyEmail(token)
+        if (cancelled) return
+        clearPendingVerificationEmail()
+        setVerifyStatus('success')
+        setVerifyMessage('이메일 인증이 완료되었습니다')
+      } catch (error) {
+        if (cancelled) return
+        setVerifyStatus('error')
+        setVerifyMessage(error instanceof Error ? error.message : '이메일 인증에 실패했습니다')
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [token])
+
+  const handleResend = async () => {
+    const trimmedEmail = email.trim()
+    setResendMessage('')
+
+    if (!trimmedEmail) {
+      setResendError('이메일을 입력해 주세요')
+      return
+    }
+
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) {
+      setResendError('올바른 이메일 형식을 입력해 주세요')
+      return
+    }
+
+    setResendError('')
+    setResending(true)
+
+    try {
+      await resendVerificationEmail(trimmedEmail)
+      setPendingVerificationEmail(trimmedEmail)
+      setResendMessage('인증 메일을 다시 보냈습니다. 메일함을 확인해 주세요')
+    } catch (error) {
+      setResendError(error instanceof Error ? error.message : '인증 메일 재전송에 실패했습니다')
+    } finally {
+      setResending(false)
+    }
+  }
+
+  return (
+    <div className="verify-email-page">
+      <div className="verify-email-card glass">
+        <div className="verify-email-logo">
+          <img src={logoSrc} alt="yANUs" className="verify-email-logo-img" />
+          <span className="verify-email-logo-title">yANUs</span>
+          <span className="verify-email-logo-sub">이메일 인증</span>
+        </div>
+
+        <div className="verify-email-status-card">
+          <div className={`verify-email-status-icon ${verifyStatus}`}>
+            {verifyStatus === 'success' ? <CheckCircle2 size={22} /> : <Mail size={22} />}
+          </div>
+
+          {!token && (
+            <>
+              <h1>이메일을 확인해 주세요</h1>
+              <p>
+                회원가입이 거의 끝났습니다.
+                <br />
+                메일함에서 인증 링크를 눌러야 로그인할 수 있습니다.
+              </p>
+            </>
+          )}
+
+          {verifyStatus === 'loading' && (
+            <>
+              <h1>이메일 인증을 확인하고 있어요</h1>
+              <p>잠시만 기다려 주세요. 인증 결과를 바로 안내해 드릴게요.</p>
+            </>
+          )}
+
+          {token && verifyStatus === 'success' && (
+            <>
+              <h1>이메일 인증이 완료되었습니다</h1>
+              <p>이제 로그인해서 서비스를 이용할 수 있습니다.</p>
+            </>
+          )}
+
+          {token && verifyStatus === 'error' && (
+            <>
+              <h1>인증 링크를 확인할 수 없어요</h1>
+              <p>{verifyMessage}</p>
+            </>
+          )}
+
+          {!token && email && (
+            <div className="verify-email-target">
+              <span>인증 메일을 보낸 주소</span>
+              <strong>{email}</strong>
+            </div>
+          )}
+
+          {token && verifyStatus === 'success' && (
+            <Link to="/login" className="verify-email-primary-link">
+              로그인하러 가기
+            </Link>
+          )}
+        </div>
+
+        {verifyStatus !== 'success' && (
+          <div className="verify-email-resend">
+            <div className="verify-email-resend-head">
+              <RotateCw size={16} />
+              <span>메일을 받지 못하셨나요?</span>
+            </div>
+            <p className="verify-email-resend-copy">
+              아래 이메일로 인증 메일을 다시 보낼 수 있습니다.
+            </p>
+
+            <div className="verify-email-input-group">
+              <label htmlFor="resend-email">이메일</label>
+              <input
+                id="resend-email"
+                type="email"
+                className={`verify-email-input ${resendError ? 'error' : ''}`}
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                placeholder="name@example.com"
+                autoComplete="email"
+              />
+              {resendError && (
+                <div className="verify-email-feedback error" role="alert">
+                  <AlertCircle size={16} />
+                  {resendError}
+                </div>
+              )}
+              {resendMessage && (
+                <div className="verify-email-feedback success">
+                  <CheckCircle2 size={16} />
+                  {resendMessage}
+                </div>
+              )}
+            </div>
+
+            <button
+              type="button"
+              className="verify-email-resend-btn"
+              onClick={handleResend}
+              disabled={resending}
+            >
+              {resending ? '전송 중...' : '인증 메일 다시 보내기'}
+            </button>
+          </div>
+        )}
+
+        <div className="verify-email-footer">
+          이미 인증을 마치셨나요? <Link to="/login">로그인</Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/verify-email/verify-email.css
+++ b/src/pages/verify-email/verify-email.css
@@ -1,0 +1,247 @@
+.verify-email-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  position: relative;
+}
+
+.verify-email-page::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 78% 60% at 14% 16%, rgba(59, 130, 246, 0.2), transparent),
+    radial-gradient(ellipse 52% 52% at 84% 82%, rgba(124, 58, 237, 0.18), transparent),
+    radial-gradient(ellipse 36% 36% at 56% 10%, rgba(16, 185, 129, 0.1), transparent);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.verify-email-card {
+  width: 100%;
+  max-width: 500px;
+  padding: 42px 38px 38px;
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--accent-purple) 16%, transparent),
+    var(--shadow-strong),
+    0 4px 18px color-mix(in srgb, var(--accent-blue) 12%, transparent);
+}
+
+.verify-email-logo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.verify-email-logo-img {
+  height: 52px;
+  width: auto;
+  object-fit: contain;
+  filter: drop-shadow(0 0 12px rgba(59, 130, 246, 0.35));
+}
+
+.verify-email-logo-title {
+  font-size: 1.6rem;
+  font-weight: 800;
+  background: var(--gradient-purple-blue);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  letter-spacing: -0.5px;
+  line-height: 1;
+}
+
+.verify-email-logo-sub {
+  font-size: 0.83rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3px;
+}
+
+.verify-email-status-card,
+.verify-email-resend {
+  border-radius: 18px;
+  padding: 20px;
+  background: color-mix(in srgb, var(--bg-card-solid) 90%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
+}
+
+.verify-email-status-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.verify-email-status-card h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  line-height: 1.25;
+  color: var(--text-primary);
+}
+
+.verify-email-status-card p,
+.verify-email-resend-copy {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.verify-email-status-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent-blue);
+  background: color-mix(in srgb, var(--accent-blue) 14%, transparent);
+}
+
+.verify-email-status-icon.success {
+  color: var(--success);
+  background: color-mix(in srgb, var(--success) 14%, transparent);
+}
+
+.verify-email-target {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--accent-blue) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-blue) 18%, transparent);
+}
+
+.verify-email-target span {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.verify-email-target strong {
+  font-size: 1rem;
+  color: var(--text-primary);
+  word-break: break-all;
+}
+
+.verify-email-primary-link,
+.verify-email-resend-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 46px;
+  border-radius: 12px;
+  font-weight: 700;
+  text-decoration: none;
+  border: none;
+}
+
+.verify-email-primary-link,
+.verify-email-resend-btn {
+  background: var(--gradient-purple-blue);
+  color: #fff;
+  box-shadow: 0 8px 24px rgba(59, 130, 246, 0.22);
+}
+
+.verify-email-resend-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.verify-email-resend {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.verify-email-resend-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.verify-email-input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.verify-email-input-group label {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.verify-email-input {
+  width: 100%;
+  padding: 12px 14px;
+  background: var(--bg-input);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  color: var(--text-primary);
+  font-size: 0.93rem;
+  font-family: inherit;
+  transition: border-color 0.2s, box-shadow 0.2s, background 0.2s;
+  outline: none;
+}
+
+.verify-email-input:focus {
+  border-color: var(--accent-purple);
+  background: var(--bg-card-solid);
+  box-shadow: 0 0 0 3px var(--ring-color);
+}
+
+.verify-email-input.error {
+  border-color: var(--error);
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.12);
+}
+
+.verify-email-feedback {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.84rem;
+  line-height: 1.5;
+}
+
+.verify-email-feedback.error {
+  color: var(--error);
+}
+
+.verify-email-feedback.success {
+  color: var(--success);
+}
+
+.verify-email-footer {
+  text-align: center;
+  font-size: 0.83rem;
+  color: var(--text-muted);
+}
+
+.verify-email-footer a {
+  color: var(--accent-purple-light);
+  font-weight: 600;
+}
+
+@media (max-width: 480px) {
+  .verify-email-card {
+    padding: 34px 22px 28px;
+  }
+
+  .verify-email-status-card,
+  .verify-email-resend {
+    padding: 18px;
+  }
+}

--- a/src/shared/api/mock/handlers/auth.ts
+++ b/src/shared/api/mock/handlers/auth.ts
@@ -19,10 +19,12 @@ const INITIAL_CREDENTIALS: Record<string, { userId: string; password: string }> 
 }
 
 let validCredentials: Record<string, { userId: string; password: string }> = { ...INITIAL_CREDENTIALS }
+let verifiedEmails = new Set(Object.keys(INITIAL_CREDENTIALS))
 
 export function resetAuthMockData() {
   mockUsers = [...INITIAL_USERS]
   validCredentials = { ...INITIAL_CREDENTIALS }
+  verifiedEmails = new Set(Object.keys(INITIAL_CREDENTIALS))
 }
 
 export function getAuthMockUserByAuthorization(authorization: string | null): User {
@@ -51,6 +53,13 @@ export const authHandlers = [
     if (member?.status === 'INACTIVE') {
       return HttpResponse.json(
         { code: 'MEMBER_INACTIVE', message: '비활성화된 계정입니다', data: null },
+        { status: 403 },
+      )
+    }
+
+    if (!verifiedEmails.has(body.email)) {
+      return HttpResponse.json(
+        { code: 'EMAIL_NOT_VERIFIED', message: '이메일 인증이 필요합니다', data: null },
         { status: 403 },
       )
     }
@@ -89,6 +98,32 @@ export const authHandlers = [
     }
 
     return HttpResponse.json({ code: 'SUCCESS', message: 'created', data: null }, { status: 201 })
+  }),
+
+  http.post('/api/v1/auth/verify-email', async ({ request }) => {
+    const body = await request.json() as { token: string }
+
+    if (body.token === 'valid-token') {
+      verifiedEmails.add('new@yanus.kr')
+      return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: {} })
+    }
+
+    return HttpResponse.json(
+      { code: 'INVALID_TOKEN', message: '유효하지 않거나 만료된 인증 링크입니다', data: null },
+      { status: 400 },
+    )
+  }),
+
+  http.post('/api/v1/auth/verify-email/resend', async ({ request }) => {
+    const body = await request.json() as { email: string }
+    if (!validCredentials[body.email]) {
+      return HttpResponse.json(
+        { code: 'NOT_FOUND', message: '가입된 이메일을 찾을 수 없습니다', data: null },
+        { status: 404 },
+      )
+    }
+
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: {} })
   }),
 
   http.post('/api/v1/auth/refresh', async ({ request }) => {

--- a/src/shared/lib/emailVerification.ts
+++ b/src/shared/lib/emailVerification.ts
@@ -1,0 +1,13 @@
+const PENDING_EMAIL_KEY = 'yanus-pending-verification-email'
+
+export function setPendingVerificationEmail(email: string) {
+  sessionStorage.setItem(PENDING_EMAIL_KEY, email)
+}
+
+export function getPendingVerificationEmail() {
+  return sessionStorage.getItem(PENDING_EMAIL_KEY) ?? ''
+}
+
+export function clearPendingVerificationEmail() {
+  sessionStorage.removeItem(PENDING_EMAIL_KEY)
+}


### PR DESCRIPTION
## 작업 내용
- 회원가입 후 바로 로그인하지 않고 이메일 인증 안내 화면으로 이동하도록 변경했습니다.
- 공개 라우트 `/verify-email`을 추가해 인증 토큰 검증 결과를 화면에서 확인할 수 있게 했습니다.
- 인증 메일 재전송 API를 연결하고, 이메일 인증 전 로그인 안내 문구도 함께 보강했습니다.

## 변경 이유
- 백엔드에 이메일 인증 기능이 추가되면서 회원가입 이후 흐름도 메일 인증 기준으로 바뀌어야 했습니다.
- 사용자가 메일을 받지 못했을 때 다시 요청할 수 있는 화면이 없으면 가입이 중간에 끊길 수 있어 재전송 흐름도 함께 필요했습니다.

## 상세 변경 사항
### 주요 변경
- [x] 회원가입 성공 시 이메일 인증 안내 화면으로 이동
- [x] 이메일 인증 토큰 검증 공개 페이지 추가
- [x] 인증 메일 재전송 UI 및 API 연동 추가

### 추가 메모
- 회원가입 직후 이메일 주소는 세션 스토리지에 보관해 새로고침 후에도 재전송에 사용할 수 있도록 했습니다.
- MSW 인증 핸들러도 이메일 인증 흐름에 맞게 함께 보강했습니다.

## 테스트
- [x] `npm run test -- src/features/auth/api/__tests__/authClient.test.ts src/pages/register/__tests__/Register.test.tsx src/pages/verify-email/__tests__/VerifyEmail.test.tsx`
- [x] `npm run build`
- [x] 브라우저에서 주요 동작 확인

## 리뷰 포인트
- 회원가입 후 더 이상 자동 로그인되지 않고 `/verify-email`로 이동하는지
- 인증 링크 성공/실패 상태가 공개 페이지에서 자연스럽게 보이는지
- 재전송 버튼이 이메일 유무에 따라 정상 동작하는지

## 관련 이슈
- closes #317