### PR TITLE
release: v0.2.24

### DIFF
--- a/src/pages/login/__tests__/Login.test.tsx
+++ b/src/pages/login/__tests__/Login.test.tsx
@@ -110,6 +110,21 @@ describe('Login 페이지', () => {
     expect(await screen.findByText('로그인 5회 실패로 계정이 잠겼습니다. 30분 후 다시 시도해 주세요')).toBeInTheDocument()
   })
 
+  it('이메일 인증이 안 된 계정이면 인증 페이지로 이동한다', async () => {
+    mockLogin.mockRejectedValue(new Error('이메일 인증을 완료한 뒤 로그인해 주세요'))
+    renderLogin()
+    await userEvent.type(screen.getByLabelText('이메일'), 'pending@yanus.kr')
+    await userEvent.type(screen.getByLabelText('비밀번호'), 'password123')
+    await userEvent.click(screen.getByRole('button', { name: '로그인' }))
+
+    await waitFor(() => {
+      expect(sessionStorage.getItem('yanus-pending-verification-email')).toBe('pending@yanus.kr')
+      expect(mockNavigate).toHaveBeenCalledWith('/verify-email', {
+        state: { email: 'pending@yanus.kr' },
+      })
+    })
+  })
+
   it('로딩 중에는 버튼이 비활성화된다', async () => {
     mockLogin.mockImplementation(() => new Promise(() => {})) // 무한 대기
     renderLogin()

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -4,8 +4,11 @@ import { Mail, Lock, Eye, EyeOff, AlertCircle } from 'lucide-react'
 import { login, getMe } from '../../features/auth/api/authClient'
 import { useApp } from '../../features/auth/model'
 import { consumeSessionExpiredMessage } from '../../shared/lib/authStorage'
+import { setPendingVerificationEmail } from '../../shared/lib/emailVerification'
 import logoSrc from '../../assets/logo.png'
 import './login.css'
+
+const EMAIL_NOT_VERIFIED_MESSAGE = '이메일 인증을 완료한 뒤 로그인해 주세요'
 
 interface FormErrors {
   email?: string
@@ -60,7 +63,16 @@ export function Login() {
       loadUser(user)
       navigate('/')
     } catch (err) {
-      setServerError(err instanceof Error ? err.message : '로그인에 실패했습니다')
+      const message = err instanceof Error ? err.message : '로그인에 실패했습니다'
+      if (message === EMAIL_NOT_VERIFIED_MESSAGE) {
+        setPendingVerificationEmail(email)
+        navigate('/verify-email', {
+          state: { email },
+        })
+        return
+      }
+
+      setServerError(message)
     } finally {
       setLoading(false)
     }


### PR DESCRIPTION
## 작업 내용
- 이메일 인증 미완료 로그인 시 인증 페이지로 이동하도록 수정
- 인증 페이지에 로그인 이메일 전달
- 로그인 테스트 보강

## 변경 이유
- 이메일 인증이 되지 않은 계정이 로그인 화면에서 멈추지 않고 바로 인증을 이어갈 수 있어야 합니다.

## 상세 변경 사항
### 주요 변경
- [x] 인증 미완료 로그인 분기 추가
- [x] 인증 페이지 이메일 전달
- [x] 로그인 테스트 추가

### 추가 메모
- 인증 미완료 외 다른 로그인 실패 흐름은 그대로 유지했습니다.

## 테스트
- [x] `npm run test -- src/pages/login/__tests__/Login.test.tsx`
- [x] `npm run build`
- [x] 브라우저에서 주요 동작 확인

## 리뷰 포인트
- 인증 미완료 로그인 시 인증 페이지로 바로 이동하는지
- 일반 로그인 실패 케이스와 충돌이 없는지

## 관련 이슈
- #323