### PR TITLE
release: v0.2.25

### DIFF
--- a/src/pages/login/__tests__/Login.test.tsx
+++ b/src/pages/login/__tests__/Login.test.tsx
@@ -125,6 +125,21 @@ describe('Login 페이지', () => {
     })
   })
 
+  it('이메일 인증 관련 다른 문구여도 인증 페이지로 이동한다', async () => {
+    mockLogin.mockRejectedValue(new Error('이메일 인증되지 않은 계정입니다.'))
+    renderLogin()
+    await userEvent.type(screen.getByLabelText('이메일'), 'pending2@yanus.kr')
+    await userEvent.type(screen.getByLabelText('비밀번호'), 'password123')
+    await userEvent.click(screen.getByRole('button', { name: '로그인' }))
+
+    await waitFor(() => {
+      expect(sessionStorage.getItem('yanus-pending-verification-email')).toBe('pending2@yanus.kr')
+      expect(mockNavigate).toHaveBeenCalledWith('/verify-email', {
+        state: { email: 'pending2@yanus.kr' },
+      })
+    })
+  })
+
   it('로딩 중에는 버튼이 비활성화된다', async () => {
     mockLogin.mockImplementation(() => new Promise(() => {})) // 무한 대기
     renderLogin()

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -8,7 +8,9 @@ import { setPendingVerificationEmail } from '../../shared/lib/emailVerification'
 import logoSrc from '../../assets/logo.png'
 import './login.css'
 
-const EMAIL_NOT_VERIFIED_MESSAGE = '이메일 인증을 완료한 뒤 로그인해 주세요'
+function isEmailVerificationPendingMessage(message: string) {
+  return message.includes('이메일 인증')
+}
 
 interface FormErrors {
   email?: string
@@ -64,7 +66,7 @@ export function Login() {
       navigate('/')
     } catch (err) {
       const message = err instanceof Error ? err.message : '로그인에 실패했습니다'
-      if (message === EMAIL_NOT_VERIFIED_MESSAGE) {
+      if (isEmailVerificationPendingMessage(message)) {
         setPendingVerificationEmail(email)
         navigate('/verify-email', {
           state: { email },


### PR DESCRIPTION
## 작업 내용
- 이메일 인증 관련 문구 변형도 인증 페이지로 이동하도록 수정
- 로그인 테스트 보강

## 변경 이유
- 실제 서버 문구가 조금 달라도 이메일 인증 미완료 계정은 바로 인증을 이어갈 수 있어야 합니다.

## 상세 변경 사항
### 주요 변경
- [x] 이메일 인증 관련 문구 분기 보강
- [x] 로그인 테스트 추가

### 추가 메모
- 일반 로그인 실패 문구는 그대로 유지했습니다.

## 테스트
- [x] `npm run test -- src/pages/login/__tests__/Login.test.tsx`
- [x] `npm run build`
- [x] 브라우저에서 주요 동작 확인

## 리뷰 포인트
- 이메일 인증 관련 문구 변형에서도 인증 페이지로 이동하는지
- 다른 로그인 실패 흐름과 충돌이 없는지

## 관련 이슈
- #326