### PR TITLE
[fix] #329 - MEMBER_PENDING 에러코드로 이메일 인증 대기 처리

### DIFF
--- a/src/features/auth/api/__tests__/authClient.test.ts
+++ b/src/features/auth/api/__tests__/authClient.test.ts
@@ -27,7 +27,7 @@ const server = setupServer(
     }
     if (body.email === 'pending@yanus.kr' && body.password === 'password') {
       return HttpResponse.json(
-        { code: 'EMAIL_NOT_VERIFIED', message: '이메일 인증이 필요합니다', data: null },
+        { code: 'MEMBER_PENDING', message: '이메일 인증이 완료되지 않은 계정입니다.', data: null },
         { status: 403 },
       )
     }

--- a/src/features/auth/api/authClient.ts
+++ b/src/features/auth/api/authClient.ts
@@ -40,7 +40,7 @@ export async function login(email: string, password: string): Promise<string> {
     if (err instanceof ApiError && err.code === 'ACCOUNT_LOCKED') {
       throw new Error('로그인 5회 실패로 계정이 잠겼습니다. 30분 후 다시 시도해 주세요')
     }
-    if (err instanceof ApiError && err.code === 'EMAIL_NOT_VERIFIED') {
+    if (err instanceof ApiError && err.code === 'MEMBER_PENDING') {
       throw new Error('이메일 인증을 완료한 뒤 로그인해 주세요')
     }
     throw err

--- a/src/shared/api/mock/handlers/auth.ts
+++ b/src/shared/api/mock/handlers/auth.ts
@@ -59,7 +59,7 @@ export const authHandlers = [
 
     if (!verifiedEmails.has(body.email)) {
       return HttpResponse.json(
-        { code: 'EMAIL_NOT_VERIFIED', message: '이메일 인증이 필요합니다', data: null },
+        { code: 'MEMBER_PENDING', message: '이메일 인증이 완료되지 않은 계정입니다.', data: null },
         { status: 403 },
       )
     }


### PR DESCRIPTION
## 작업 내용
- 로그인 시 이메일 인증 대기 계정의 에러코드를 `MEMBER_PENDING` 기준으로 처리하도록 수정했습니다.
- authClient, auth 테스트, MSW mock 핸들러의 코드값을 백엔드와 맞췄습니다.

## 변경 이유
- 백엔드는 `MEMBER_PENDING`을 내려주는데 프론트는 `EMAIL_NOT_VERIFIED`를 체크하고 있어 이메일 인증 대기 흐름이 실제 응답과 어긋나 있었습니다.
- 프론트가 실제 백엔드 에러코드를 기준으로 동작하도록 맞출 필요가 있었습니다.

## 상세 변경 사항
### 주요 변경
- [x] authClient에서 `MEMBER_PENDING` 처리
- [x] authClient 테스트 코드값 정정
- [x] MSW 인증 mock 코드값 정정

### 추가 메모
- 로그인 후 인증 페이지 이동 흐름은 그대로 유지하고, 에러코드 기준만 백엔드와 일치시켰습니다.

## 테스트
- [x] `npm run test -- src/features/auth/api/__tests__/authClient.test.ts src/pages/login/__tests__/Login.test.tsx`
- [x] `npm run build`
- [x] 브라우저에서 주요 동작 확인

## 리뷰 포인트
- 백엔드가 `MEMBER_PENDING`을 내려도 프론트가 동일하게 이메일 인증 대기 상태로 처리하는지
- mock 환경과 실제 환경의 코드값이 일치하는지

## 관련 이슈
- closes #329