### PR TITLE
release: v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "new-yanus-fe",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "new-yanus-fe",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "@fullcalendar/core": "^6.1.20",
         "@fullcalendar/daygrid": "^6.1.20",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "new-yanus-fe",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/pages/settings/__tests__/Settings.test.tsx
+++ b/src/pages/settings/__tests__/Settings.test.tsx
@@ -5,18 +5,21 @@ import { Settings } from '../index'
 const mockUpdateMyProfile = vi.fn()
 const mockDeactivateMember = vi.fn()
 const mockGetMonthlyAttendanceSettlement = vi.fn()
+const mockGetAutoCheckoutTime = vi.fn()
+const mockUpdateAutoCheckoutTime = vi.fn()
 const mockSetTheme = vi.fn()
 const mockLogout = vi.fn()
 const mockNavigate = vi.fn()
+let currentUserRole: 'MEMBER' | 'ADMIN' = 'MEMBER'
 
 vi.mock('../../../features/auth/model', () => ({
   useApp: () => ({
     state: {
-      currentUser: { id: '1', name: '홍길동', role: 'MEMBER', team: '1팀' },
+      currentUser: { id: '1', name: '홍길동', role: currentUserRole, team: '1팀' },
       users: [],
       teams: [{ id: 1, name: '1팀' }],
     },
-    isAdmin: false,
+    isAdmin: currentUserRole === 'ADMIN',
     isTeamLead: false,
     logout: mockLogout,
   }),
@@ -29,6 +32,11 @@ vi.mock('../../../shared/api/membersApi', () => ({
 
 vi.mock('../../../shared/api/attendanceSettlementApi', () => ({
   getMonthlyAttendanceSettlement: (...args: unknown[]) => mockGetMonthlyAttendanceSettlement(...args),
+}))
+
+vi.mock('../../../shared/api/settingsApi', () => ({
+  getAutoCheckoutTime: (...args: unknown[]) => mockGetAutoCheckoutTime(...args),
+  updateAutoCheckoutTime: (...args: unknown[]) => mockUpdateAutoCheckoutTime(...args),
 }))
 
 vi.mock('../../../shared/theme', () => ({
@@ -50,6 +58,7 @@ vi.mock('react-router-dom', async () => {
 describe('Settings 페이지', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    currentUserRole = 'MEMBER'
     mockGetMonthlyAttendanceSettlement.mockResolvedValue({
       yearMonth: '2026-03',
       memberId: 1,
@@ -73,17 +82,21 @@ describe('Settings 페이지', () => {
         },
       ],
     })
+    mockGetAutoCheckoutTime.mockResolvedValue({
+      autoCheckoutTime: '23:59:59',
+    })
   })
 
   it('설정 페이지 설명이 렌더링된다', () => {
     render(<Settings />)
-    expect(screen.getByText('프로필, 알림, 테마, 정산, 보안 정보를 한 곳에서 관리하세요.')).toBeInTheDocument()
+    expect(screen.getByText('프로필, 알림, 출퇴근, 테마, 정산, 보안 정보를 한 곳에서 관리하세요.')).toBeInTheDocument()
   })
 
   it('5개의 탭이 렌더링된다', () => {
     render(<Settings />)
     expect(screen.getByText('프로필')).toBeInTheDocument()
     expect(screen.getByText('알림')).toBeInTheDocument()
+    expect(screen.getByText('출퇴근')).toBeInTheDocument()
     expect(screen.getByText('테마')).toBeInTheDocument()
     expect(screen.getByText('정산')).toBeInTheDocument()
     expect(screen.getByText('보안')).toBeInTheDocument()
@@ -104,6 +117,45 @@ describe('Settings 페이지', () => {
     render(<Settings />)
     fireEvent.click(screen.getByText('보안'))
     expect(screen.getByText('비밀번호 변경')).toBeInTheDocument()
+  })
+
+  it('출퇴근 탭 클릭 시 자동 체크아웃 시간이 표시된다', async () => {
+    render(<Settings />)
+    fireEvent.click(screen.getByText('출퇴근'))
+
+    expect(await screen.findByText('자동 체크아웃 시간')).toBeInTheDocument()
+    expect(mockGetAutoCheckoutTime).toHaveBeenCalled()
+    expect(screen.getByDisplayValue('23:59:59')).toBeInTheDocument()
+  })
+
+  it('일반 멤버는 자동 체크아웃 시간을 읽기 전용으로 본다', async () => {
+    render(<Settings />)
+    fireEvent.click(screen.getByText('출퇴근'))
+
+    expect(await screen.findByText('관리자만 변경할 수 있습니다.')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '자동 체크아웃 시간 저장' })).not.toBeInTheDocument()
+  })
+
+  it('관리자는 자동 체크아웃 시간을 변경할 수 있다', async () => {
+    currentUserRole = 'ADMIN'
+    mockUpdateAutoCheckoutTime.mockResolvedValueOnce({
+      autoCheckoutTime: '22:00:00',
+    })
+
+    render(<Settings />)
+    fireEvent.click(screen.getByText('출퇴근'))
+
+    await screen.findByDisplayValue('23:59:59')
+
+    fireEvent.change(screen.getByLabelText('자동 체크아웃 시간 입력'), {
+      target: { value: '22:00:00' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '자동 체크아웃 시간 저장' }))
+
+    await waitFor(() => {
+      expect(mockUpdateAutoCheckoutTime).toHaveBeenCalledWith('22:00:00')
+    })
+    expect(screen.getByDisplayValue('22:00:00')).toBeInTheDocument()
   })
 
   it('정산 탭 클릭 시 개인 지각비 정산이 표시된다', async () => {

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -1,23 +1,29 @@
 import { useEffect, useState } from 'react'
-import { User, Bell, Palette, Shield, Save, Monitor, Moon, Sun, AlertTriangle, Wallet } from 'lucide-react'
+import { User, Bell, Palette, Shield, Save, Monitor, Moon, Sun, AlertTriangle, Wallet, Clock3 } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useApp } from '../../features/auth/model'
 import { useTheme, type ThemeMode } from '../../shared/theme'
 import { updateMyProfile, deactivateMember } from '../../shared/api/membersApi'
 import { getMonthlyAttendanceSettlement } from '../../shared/api/attendanceSettlementApi'
 import type { AttendanceSettlement } from '../../shared/api/attendanceSettlementApi'
+import { getAutoCheckoutTime, updateAutoCheckoutTime } from '../../shared/api/settingsApi'
 import { Toast } from '../../shared/ui/Toast'
 import './settings.css'
 
-type SettingsTab = 'profile' | 'notifications' | 'appearance' | 'security' | 'settlement'
+type SettingsTab = 'profile' | 'notifications' | 'attendance' | 'appearance' | 'security' | 'settlement'
 
 function formatCurrency(amount: number) {
   return `${amount.toLocaleString('ko-KR')}원`
 }
 
+function normalizeTimeValue(value: string) {
+  if (!value) return ''
+  return value.length === 5 ? `${value}:00` : value
+}
+
 export function Settings() {
   const navigate = useNavigate()
-  const { state, logout } = useApp()
+  const { state, logout, isAdmin } = useApp()
   const { theme, setTheme } = useTheme()
   const [activeTab, setActiveTab] = useState<SettingsTab>('profile')
   const [notifications, setNotifications] = useState({
@@ -39,6 +45,10 @@ export function Settings() {
   const [selectedSettlementMonth, setSelectedSettlementMonth] = useState(new Date().toISOString().slice(0, 7))
   const [settlementLoading, setSettlementLoading] = useState(false)
   const [settlement, setSettlement] = useState<AttendanceSettlement | null>(null)
+  const [autoCheckoutLoading, setAutoCheckoutLoading] = useState(false)
+  const [autoCheckoutSaving, setAutoCheckoutSaving] = useState(false)
+  const [autoCheckoutSaved, setAutoCheckoutSaved] = useState(false)
+  const [autoCheckoutTime, setAutoCheckoutTime] = useState('')
 
   useEffect(() => {
     if (activeTab !== 'settlement') return
@@ -55,6 +65,22 @@ export function Settings() {
         setSettlementLoading(false)
       })
   }, [activeTab, selectedSettlementMonth])
+
+  useEffect(() => {
+    if (activeTab !== 'attendance') return
+
+    setAutoCheckoutLoading(true)
+    getAutoCheckoutTime()
+      .then((data) => {
+        setAutoCheckoutTime(normalizeTimeValue(data.autoCheckoutTime))
+      })
+      .catch((err) => {
+        setErrorMessage(err instanceof Error ? err.message : '자동 체크아웃 시간을 불러오지 못했습니다')
+      })
+      .finally(() => {
+        setAutoCheckoutLoading(false)
+      })
+  }, [activeTab])
 
   const handleSave = async () => {
     try {
@@ -104,9 +130,26 @@ export function Settings() {
     }
   }
 
+  const handleAutoCheckoutSave = async () => {
+    if (!isAdmin || !autoCheckoutTime) return
+
+    setAutoCheckoutSaving(true)
+    try {
+      const result = await updateAutoCheckoutTime(normalizeTimeValue(autoCheckoutTime))
+      setAutoCheckoutTime(normalizeTimeValue(result.autoCheckoutTime))
+      setAutoCheckoutSaved(true)
+      setTimeout(() => setAutoCheckoutSaved(false), 2000)
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '자동 체크아웃 시간 저장에 실패했습니다')
+    } finally {
+      setAutoCheckoutSaving(false)
+    }
+  }
+
   const tabs: { id: SettingsTab; label: string; icon: React.ReactNode }[] = [
     { id: 'profile', label: '프로필', icon: <User size={18} /> },
     { id: 'notifications', label: '알림', icon: <Bell size={18} /> },
+    { id: 'attendance', label: '출퇴근', icon: <Clock3 size={18} /> },
     { id: 'appearance', label: '테마', icon: <Palette size={18} /> },
     { id: 'settlement', label: '정산', icon: <Wallet size={18} /> },
     { id: 'security', label: '보안', icon: <Shield size={18} /> },
@@ -124,7 +167,7 @@ export function Settings() {
       <header className="settings-header">
         <div className="settings-header-copy">
           <p className="settings-kicker">My Page</p>
-          <p className="settings-subtitle">프로필, 알림, 테마, 정산, 보안 정보를 한 곳에서 관리하세요.</p>
+          <p className="settings-subtitle">프로필, 알림, 출퇴근, 테마, 정산, 보안 정보를 한 곳에서 관리하세요.</p>
         </div>
         <div className="settings-summary-card glass">
           <div className="settings-summary-icon">
@@ -243,6 +286,59 @@ export function Settings() {
               <div className="appearance-note">
                 <h4>테마 전환 안내</h4>
                 <p>레이아웃, 카드, 입력창, 플로팅 UI까지 모두 선택한 테마에 맞춰 함께 전환됩니다.</p>
+              </div>
+            </section>
+          )}
+
+          {activeTab === 'attendance' && (
+            <section className="settings-section">
+              <h3>자동 체크아웃 시간</h3>
+              <div className="attendance-settings-card">
+                <div className="attendance-settings-copy">
+                  <strong>미퇴근자는 이 시간 기준으로 자동 체크아웃됩니다.</strong>
+                  <p>매일 자정 스케줄러가 설정된 시간을 기준으로 미퇴근자를 자동 체크아웃 처리합니다.</p>
+                </div>
+
+                {autoCheckoutLoading ? (
+                  <div className="settlement-empty-panel compact">
+                    <p className="settlement-empty-title">자동 체크아웃 시간을 불러오는 중입니다.</p>
+                    <p className="settlement-empty-description">현재 운영 중인 자동 체크아웃 시간을 확인하고 있습니다.</p>
+                  </div>
+                ) : (
+                  <>
+                    <div className="setting-field">
+                      <label htmlFor="auto-checkout-time">자동 체크아웃 시간</label>
+                      <input
+                        id="auto-checkout-time"
+                        aria-label="자동 체크아웃 시간 입력"
+                        type="time"
+                        step={1}
+                        value={autoCheckoutTime}
+                        onChange={(e) => setAutoCheckoutTime(normalizeTimeValue(e.target.value))}
+                        className="setting-input"
+                        disabled={!isAdmin}
+                      />
+                    </div>
+
+                    {isAdmin ? (
+                      <button
+                        className="save-btn"
+                        type="button"
+                        onClick={handleAutoCheckoutSave}
+                        disabled={autoCheckoutSaving || !autoCheckoutTime}
+                        aria-label="자동 체크아웃 시간 저장"
+                      >
+                        <Save size={16} />
+                        {autoCheckoutSaving ? '저장 중...' : autoCheckoutSaved ? '저장됨!' : '자동 체크아웃 시간 저장'}
+                      </button>
+                    ) : (
+                      <div className="attendance-settings-note">
+                        <span>관리자만 변경할 수 있습니다.</span>
+                        <p>현재 시간은 확인할 수 있지만 수정은 관리자 계정에서만 가능합니다.</p>
+                      </div>
+                    )}
+                  </>
+                )}
               </div>
             </section>
           )}

--- a/src/pages/settings/settings.css
+++ b/src/pages/settings/settings.css
@@ -123,6 +123,53 @@
   gap: 18px;
 }
 
+.attendance-settings-card {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 20px;
+  border-radius: 20px;
+  border: 1px solid var(--border-color);
+  background: color-mix(in srgb, var(--surface-muted) 72%, transparent);
+}
+
+.attendance-settings-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.attendance-settings-copy strong {
+  color: var(--text-primary);
+  font-size: 1rem;
+}
+
+.attendance-settings-copy p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.attendance-settings-note {
+  padding: 16px 18px;
+  border-radius: 18px;
+  border: 1px dashed var(--border-color);
+  background: color-mix(in srgb, var(--surface) 78%, transparent);
+}
+
+.attendance-settings-note span {
+  display: block;
+  margin-bottom: 6px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.attendance-settings-note p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
 .my-settlement-summary-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));

--- a/src/shared/api/__tests__/settingsApi.test.ts
+++ b/src/shared/api/__tests__/settingsApi.test.ts
@@ -1,0 +1,45 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { getAutoCheckoutTime, updateAutoCheckoutTime } from '../settingsApi'
+
+const server = setupServer(
+  http.get('/api/v1/settings/auto-checkout-time', () =>
+    HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: {
+        autoCheckoutTime: '23:59:59',
+      },
+    }),
+  ),
+  http.patch('/api/v1/settings/auto-checkout-time', async ({ request }) => {
+    const body = (await request.json()) as { autoCheckoutTime: string }
+
+    return HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: {
+        autoCheckoutTime: body.autoCheckoutTime,
+      },
+    })
+  }),
+)
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('settingsApi', () => {
+  it('getAutoCheckoutTime() 자동 체크아웃 시간을 반환한다', async () => {
+    await expect(getAutoCheckoutTime()).resolves.toEqual({
+      autoCheckoutTime: '23:59:59',
+    })
+  })
+
+  it('updateAutoCheckoutTime() 자동 체크아웃 시간을 저장하고 반환한다', async () => {
+    await expect(updateAutoCheckoutTime('22:00:00')).resolves.toEqual({
+      autoCheckoutTime: '22:00:00',
+    })
+  })
+})

--- a/src/shared/api/settingsApi.ts
+++ b/src/shared/api/settingsApi.ts
@@ -1,0 +1,13 @@
+import { baseClient } from './baseClient'
+
+export interface AutoCheckoutTimeResponse {
+  autoCheckoutTime: string
+}
+
+export const getAutoCheckoutTime = () =>
+  baseClient.get<AutoCheckoutTimeResponse>('/api/v1/settings/auto-checkout-time')
+
+export const updateAutoCheckoutTime = (autoCheckoutTime: string) =>
+  baseClient.patch<AutoCheckoutTimeResponse>('/api/v1/settings/auto-checkout-time', {
+    autoCheckoutTime,
+  })


### PR DESCRIPTION
## 작업 내용
- develop 브랜치의 최신 변경 사항을 main에 반영하는 `v1.0.0` 배포 PR입니다.
- 이번 배포에는 설정 페이지 자동 체크아웃 시간 설정 기능과 최근 운영 안정화 작업이 포함됩니다.
- 패키지 버전도 `1.0.0`으로 정리되었습니다.

## 변경 이유
- 기능 범위와 운영 흐름이 정식 출시 기준에 도달해 첫 정식 버전을 `v1.0.0`으로 배포합니다.

## 상세 변경 사항
### 주요 변경
- [x] 설정 페이지 출퇴근 탭 및 자동 체크아웃 시간 관리 기능 반영
- [x] 최근 이메일 인증, 관리자 기능, 정산/출퇴근 흐름 안정화 포함
- [x] 패키지 버전 `1.0.0` 반영

### 추가 메모
- main 머지 후 `v1.0.0` 태그를 기준으로 배포하면 됩니다.

## 테스트
- [x] `npm run test -- src/shared/api/__tests__/settingsApi.test.ts src/pages/settings/__tests__/Settings.test.tsx`
- [x] `npm run build`
- [ ] 브라우저에서 주요 동작 최종 확인

## 리뷰 포인트
- `v1.0.0` 정식 출시 기준으로 기능 범위와 운영 흐름이 충분한지 확인 부탁드립니다.

## 관련 이슈
- closes #332
- closes #335