### PR TITLE
[chore] #335 - 버전 1.0.0 반영

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "new-yanus-fe",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "new-yanus-fe",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "@fullcalendar/core": "^6.1.20",
         "@fullcalendar/daygrid": "^6.1.20",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "new-yanus-fe",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## 작업 내용
- `package.json`과 `package-lock.json` 버전을 `1.0.0`으로 반영했습니다.
- 첫 정식 출시 기준에 맞춰 버전 표기를 정리했습니다.

## 변경 이유
- 현재 기능 범위와 운영 흐름이 안정화되어 첫 정식 출시 버전을 `v1.0.0`으로 가져가기로 결정했습니다.
- 배포 브랜치와 패키지 버전 표기가 다르면 릴리즈 관리가 헷갈릴 수 있어 먼저 맞췄습니다.

## 상세 변경 사항
### 주요 변경
- [x] 패키지 버전 `1.0.0` 반영
- [x] lock 파일 버전 동기화
- [x] 릴리즈 PR 기준 버전 정리 준비

### 추가 메모
- 태그 생성은 main 머지 시점에 맞춰 진행하면 됩니다.

## 테스트
- [ ] `npm run test:run`
- [x] `npm run build`
- [ ] 브라우저에서 주요 동작 확인

## 리뷰 포인트
- 이번 배포 버전을 `v1.0.0`으로 가져가는 데 무리가 없는지 확인 부탁드립니다.

## 관련 이슈
- closes #335