### PR TITLE
release: v1.0.0

### DIFF
--- a/src/pages/admin/__tests__/Admin.test.tsx
+++ b/src/pages/admin/__tests__/Admin.test.tsx
@@ -91,6 +91,7 @@ const mockSettlement = {
 }
 
 const mockTemporaryPassword = 'A1b2C3d4'
+const mockAutoCheckoutTime = '23:59:59'
 
 const server = setupServer(
   http.get('/api/v1/auth/me', () =>
@@ -171,6 +172,21 @@ const server = setupServer(
       data: { temporaryPassword: mockTemporaryPassword },
     }),
   ),
+  http.get('/api/v1/settings/auto-checkout-time', () =>
+    HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: { autoCheckoutTime: mockAutoCheckoutTime },
+    }),
+  ),
+  http.patch('/api/v1/settings/auto-checkout-time', async ({ request }) => {
+    const body = await request.json() as { autoCheckoutTime: string }
+    return HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: { autoCheckoutTime: body.autoCheckoutTime },
+    })
+  }),
 )
 
 beforeAll(() => server.listen())
@@ -225,6 +241,34 @@ describe('Admin 페이지', () => {
     expect(screen.getByRole('button', { name: '팀 관리' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '감사 로그' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '지각비 정산' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '운영 설정' })).toBeInTheDocument()
+  })
+
+  it('운영 설정 탭에서 자동 체크아웃 시간을 확인할 수 있다', async () => {
+    const user = userEvent.setup()
+    renderAdmin()
+
+    await user.click(screen.getByRole('button', { name: '운영 설정' }))
+
+    expect(await screen.findByLabelText('자동 체크아웃 시간 입력')).toBeInTheDocument()
+    expect(screen.getByDisplayValue(mockAutoCheckoutTime)).toBeInTheDocument()
+  })
+
+  it('운영 설정 탭에서 자동 체크아웃 시간을 저장할 수 있다', async () => {
+    const user = userEvent.setup()
+    renderAdmin()
+
+    await user.click(screen.getByRole('button', { name: '운영 설정' }))
+    await screen.findByDisplayValue(mockAutoCheckoutTime)
+
+    await user.clear(screen.getByLabelText('자동 체크아웃 시간 입력'))
+    await user.type(screen.getByLabelText('자동 체크아웃 시간 입력'), '220000')
+    await user.click(screen.getByRole('button', { name: '자동 체크아웃 시간 저장' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('자동 체크아웃 시간을 저장했습니다')).toBeInTheDocument()
+    })
+    expect(screen.getByDisplayValue('22:00:00')).toBeInTheDocument()
   })
 
   it('멤버 관리 탭 클릭 시 멤버 테이블이 표시된다', async () => {

--- a/src/pages/admin/admin.css
+++ b/src/pages/admin/admin.css
@@ -102,6 +102,58 @@
   border: 1px solid rgba(255, 255, 255, 0.06);
 }
 
+.admin-ops-card {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 20px;
+  border-radius: 20px;
+  border: 1px solid var(--border-color);
+  background: color-mix(in srgb, var(--surface-muted) 72%, transparent);
+}
+
+.admin-ops-card-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.admin-ops-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--accent-purple) 16%, transparent);
+  color: var(--text-primary);
+  flex-shrink: 0;
+}
+
+.admin-ops-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.admin-ops-copy strong {
+  color: var(--text-primary);
+  font-size: 1rem;
+}
+
+.admin-ops-copy p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.admin-ops-form {
+  display: flex;
+  align-items: end;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
 .admin-settlement-actions {
   display: flex;
   align-items: center;

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react'
-import { Crown, Download, FolderPlus, History, Trash2, Users } from 'lucide-react'
+import { Clock3, Crown, Download, FolderPlus, History, Save, Trash2, Users } from 'lucide-react'
 import { useApp } from '../../features/auth/model'
 import { TeamAttendanceStatus } from '../../features/attendance/ui'
 import { getAttendanceByDate, getAttendanceByDates } from '../../shared/api/attendanceApi'
@@ -26,6 +26,7 @@ import {
 import type { AttendanceSettlementRollup } from '../../shared/lib/attendanceSettlement'
 import { createTeam, deleteTeam } from '../../shared/api/teamsApi'
 import type { TeamResponse } from '../../shared/api/teamsApi'
+import { getAutoCheckoutTime, updateAutoCheckoutTime } from '../../shared/api/settingsApi'
 import { DEFAULT_SIGNUP_TEAM_NAME, formatTeamName, getTeamOptions, sortUsersByTeamAndName } from '../../shared/lib/team'
 import {
   canChangeMemberTeamFor,
@@ -39,7 +40,7 @@ import { EmptyState } from '../../shared/ui/EmptyState'
 import { SectionHeader } from '../../shared/ui/SectionHeader'
 import './admin.css'
 
-type Tab = 'attendance' | 'members' | 'teams' | 'audit' | 'settlement'
+type Tab = 'attendance' | 'members' | 'teams' | 'audit' | 'settlement' | 'settings'
 type SettlementView = 'overall' | 'team' | 'member'
 
 const ALL_ROLES: UserRole[] = ['MEMBER', 'TEAM_LEAD', 'ADMIN']
@@ -80,6 +81,11 @@ function formatTime(value: string | null) {
   return value ? value.slice(11, 16) : '-'
 }
 
+function normalizeTimeValue(value: string) {
+  if (!value) return ''
+  return value.length === 5 ? `${value}:00` : value
+}
+
 interface TeamSettlementGroup {
   teamName: string
   settlements: AttendanceSettlement[]
@@ -109,6 +115,10 @@ export function Admin() {
   const [selectedSettlementMonth, setSelectedSettlementMonth] = useState(getTodayStr().slice(0, 7))
   const [settlements, setSettlements] = useState<AttendanceSettlement[]>([])
   const [settlementAttendanceRecords, setSettlementAttendanceRecords] = useState<AttendanceRecord[]>([])
+  const [autoCheckoutLoading, setAutoCheckoutLoading] = useState(false)
+  const [autoCheckoutSaving, setAutoCheckoutSaving] = useState(false)
+  const [autoCheckoutSaved, setAutoCheckoutSaved] = useState(false)
+  const [autoCheckoutTime, setAutoCheckoutTime] = useState('')
 
   const todayStr = getTodayStr()
   const members = useMemo(() => sortUsersByTeamAndName(state.users), [state.users])
@@ -213,6 +223,22 @@ export function Admin() {
         setSettlementLoading(false)
       })
   }, [tab, selectedSettlementMonth, settlementMemberOptions])
+
+  useEffect(() => {
+    if (tab !== 'settings') return
+
+    setAutoCheckoutLoading(true)
+    getAutoCheckoutTime()
+      .then((data) => {
+        setAutoCheckoutTime(normalizeTimeValue(data.autoCheckoutTime))
+      })
+      .catch((err) => {
+        setErrorMessage(err instanceof Error ? err.message : '자동 체크아웃 시간을 불러오지 못했습니다')
+      })
+      .finally(() => {
+        setAutoCheckoutLoading(false)
+      })
+  }, [tab])
 
   const reloadMembersAndTeams = async () => {
     const [memberList] = await Promise.all([
@@ -446,6 +472,23 @@ export function Admin() {
     }
   }
 
+  const handleAutoCheckoutSave = async () => {
+    if (!autoCheckoutTime) return
+
+    setAutoCheckoutSaving(true)
+    try {
+      const result = await updateAutoCheckoutTime(normalizeTimeValue(autoCheckoutTime))
+      setAutoCheckoutTime(normalizeTimeValue(result.autoCheckoutTime))
+      setAutoCheckoutSaved(true)
+      setSuccessMessage('자동 체크아웃 시간을 저장했습니다')
+      setTimeout(() => setAutoCheckoutSaved(false), 2000)
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '자동 체크아웃 시간 저장에 실패했습니다')
+    } finally {
+      setAutoCheckoutSaving(false)
+    }
+  }
+
   return (
     <div className="admin-page">
       {errorMessage && (
@@ -505,6 +548,13 @@ export function Admin() {
           onClick={() => setTab('settlement')}
         >
           지각비 정산
+        </button>
+        <button
+          type="button"
+          className={`admin-tab-btn ${tab === 'settings' ? 'active' : ''}`}
+          onClick={() => setTab('settings')}
+        >
+          운영 설정
         </button>
       </div>
 
@@ -995,6 +1045,59 @@ export function Admin() {
               )}
             </div>
           )}
+        </div>
+      )}
+
+      {tab === 'settings' && (
+        <div className="admin-tab-content glass">
+          <SectionHeader
+            title="운영 설정"
+            description="출근 운영 정책처럼 관리자만 다뤄야 하는 공통 설정을 관리합니다."
+          />
+
+          <section className="admin-ops-card">
+            <div className="admin-ops-card-head">
+              <div className="admin-ops-icon">
+                <Clock3 size={18} />
+              </div>
+              <div className="admin-ops-copy">
+                <strong>자동 체크아웃 시간</strong>
+                <p>매일 자정 스케줄러가 이 시간을 기준으로 미퇴근자를 자동 체크아웃 처리합니다.</p>
+              </div>
+            </div>
+
+            {autoCheckoutLoading ? (
+              <EmptyState
+                compact
+                title="자동 체크아웃 시간을 불러오는 중입니다."
+                description="현재 운영 중인 기준 시간을 확인하고 있습니다."
+              />
+            ) : (
+              <div className="admin-ops-form">
+                <label className="admin-settlement-field">
+                  <span>자동 체크아웃 시간</span>
+                  <input
+                    aria-label="자동 체크아웃 시간 입력"
+                    type="time"
+                    step={1}
+                    value={autoCheckoutTime}
+                    onChange={(event) => setAutoCheckoutTime(normalizeTimeValue(event.target.value))}
+                  />
+                </label>
+
+                <button
+                  type="button"
+                  className="admin-create-team-btn"
+                  onClick={handleAutoCheckoutSave}
+                  disabled={autoCheckoutSaving || !autoCheckoutTime}
+                  aria-label="자동 체크아웃 시간 저장"
+                >
+                  <Save size={16} />
+                  {autoCheckoutSaving ? '저장 중...' : autoCheckoutSaved ? '저장됨!' : '자동 체크아웃 시간 저장'}
+                </button>
+              </div>
+            )}
+          </section>
         </div>
       )}
 

--- a/src/pages/settings/__tests__/Settings.test.tsx
+++ b/src/pages/settings/__tests__/Settings.test.tsx
@@ -5,21 +5,18 @@ import { Settings } from '../index'
 const mockUpdateMyProfile = vi.fn()
 const mockDeactivateMember = vi.fn()
 const mockGetMonthlyAttendanceSettlement = vi.fn()
-const mockGetAutoCheckoutTime = vi.fn()
-const mockUpdateAutoCheckoutTime = vi.fn()
 const mockSetTheme = vi.fn()
 const mockLogout = vi.fn()
 const mockNavigate = vi.fn()
-let currentUserRole: 'MEMBER' | 'ADMIN' = 'MEMBER'
 
 vi.mock('../../../features/auth/model', () => ({
   useApp: () => ({
     state: {
-      currentUser: { id: '1', name: '홍길동', role: currentUserRole, team: '1팀' },
+      currentUser: { id: '1', name: '홍길동', role: 'MEMBER', team: '1팀' },
       users: [],
       teams: [{ id: 1, name: '1팀' }],
     },
-    isAdmin: currentUserRole === 'ADMIN',
+    isAdmin: false,
     isTeamLead: false,
     logout: mockLogout,
   }),
@@ -32,11 +29,6 @@ vi.mock('../../../shared/api/membersApi', () => ({
 
 vi.mock('../../../shared/api/attendanceSettlementApi', () => ({
   getMonthlyAttendanceSettlement: (...args: unknown[]) => mockGetMonthlyAttendanceSettlement(...args),
-}))
-
-vi.mock('../../../shared/api/settingsApi', () => ({
-  getAutoCheckoutTime: (...args: unknown[]) => mockGetAutoCheckoutTime(...args),
-  updateAutoCheckoutTime: (...args: unknown[]) => mockUpdateAutoCheckoutTime(...args),
 }))
 
 vi.mock('../../../shared/theme', () => ({
@@ -58,7 +50,6 @@ vi.mock('react-router-dom', async () => {
 describe('Settings 페이지', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    currentUserRole = 'MEMBER'
     mockGetMonthlyAttendanceSettlement.mockResolvedValue({
       yearMonth: '2026-03',
       memberId: 1,
@@ -82,21 +73,17 @@ describe('Settings 페이지', () => {
         },
       ],
     })
-    mockGetAutoCheckoutTime.mockResolvedValue({
-      autoCheckoutTime: '23:59:59',
-    })
   })
 
   it('설정 페이지 설명이 렌더링된다', () => {
     render(<Settings />)
-    expect(screen.getByText('프로필, 알림, 출퇴근, 테마, 정산, 보안 정보를 한 곳에서 관리하세요.')).toBeInTheDocument()
+    expect(screen.getByText('프로필, 알림, 테마, 정산, 보안 정보를 한 곳에서 관리하세요.')).toBeInTheDocument()
   })
 
   it('5개의 탭이 렌더링된다', () => {
     render(<Settings />)
     expect(screen.getByText('프로필')).toBeInTheDocument()
     expect(screen.getByText('알림')).toBeInTheDocument()
-    expect(screen.getByText('출퇴근')).toBeInTheDocument()
     expect(screen.getByText('테마')).toBeInTheDocument()
     expect(screen.getByText('정산')).toBeInTheDocument()
     expect(screen.getByText('보안')).toBeInTheDocument()
@@ -117,45 +104,6 @@ describe('Settings 페이지', () => {
     render(<Settings />)
     fireEvent.click(screen.getByText('보안'))
     expect(screen.getByText('비밀번호 변경')).toBeInTheDocument()
-  })
-
-  it('출퇴근 탭 클릭 시 자동 체크아웃 시간이 표시된다', async () => {
-    render(<Settings />)
-    fireEvent.click(screen.getByText('출퇴근'))
-
-    expect(await screen.findByText('자동 체크아웃 시간')).toBeInTheDocument()
-    expect(mockGetAutoCheckoutTime).toHaveBeenCalled()
-    expect(screen.getByDisplayValue('23:59:59')).toBeInTheDocument()
-  })
-
-  it('일반 멤버는 자동 체크아웃 시간을 읽기 전용으로 본다', async () => {
-    render(<Settings />)
-    fireEvent.click(screen.getByText('출퇴근'))
-
-    expect(await screen.findByText('관리자만 변경할 수 있습니다.')).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: '자동 체크아웃 시간 저장' })).not.toBeInTheDocument()
-  })
-
-  it('관리자는 자동 체크아웃 시간을 변경할 수 있다', async () => {
-    currentUserRole = 'ADMIN'
-    mockUpdateAutoCheckoutTime.mockResolvedValueOnce({
-      autoCheckoutTime: '22:00:00',
-    })
-
-    render(<Settings />)
-    fireEvent.click(screen.getByText('출퇴근'))
-
-    await screen.findByDisplayValue('23:59:59')
-
-    fireEvent.change(screen.getByLabelText('자동 체크아웃 시간 입력'), {
-      target: { value: '22:00:00' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: '자동 체크아웃 시간 저장' }))
-
-    await waitFor(() => {
-      expect(mockUpdateAutoCheckoutTime).toHaveBeenCalledWith('22:00:00')
-    })
-    expect(screen.getByDisplayValue('22:00:00')).toBeInTheDocument()
   })
 
   it('정산 탭 클릭 시 개인 지각비 정산이 표시된다', async () => {

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -1,29 +1,23 @@
 import { useEffect, useState } from 'react'
-import { User, Bell, Palette, Shield, Save, Monitor, Moon, Sun, AlertTriangle, Wallet, Clock3 } from 'lucide-react'
+import { User, Bell, Palette, Shield, Save, Monitor, Moon, Sun, AlertTriangle, Wallet } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useApp } from '../../features/auth/model'
 import { useTheme, type ThemeMode } from '../../shared/theme'
 import { updateMyProfile, deactivateMember } from '../../shared/api/membersApi'
 import { getMonthlyAttendanceSettlement } from '../../shared/api/attendanceSettlementApi'
 import type { AttendanceSettlement } from '../../shared/api/attendanceSettlementApi'
-import { getAutoCheckoutTime, updateAutoCheckoutTime } from '../../shared/api/settingsApi'
 import { Toast } from '../../shared/ui/Toast'
 import './settings.css'
 
-type SettingsTab = 'profile' | 'notifications' | 'attendance' | 'appearance' | 'security' | 'settlement'
+type SettingsTab = 'profile' | 'notifications' | 'appearance' | 'security' | 'settlement'
 
 function formatCurrency(amount: number) {
   return `${amount.toLocaleString('ko-KR')}원`
 }
 
-function normalizeTimeValue(value: string) {
-  if (!value) return ''
-  return value.length === 5 ? `${value}:00` : value
-}
-
 export function Settings() {
   const navigate = useNavigate()
-  const { state, logout, isAdmin } = useApp()
+  const { state, logout } = useApp()
   const { theme, setTheme } = useTheme()
   const [activeTab, setActiveTab] = useState<SettingsTab>('profile')
   const [notifications, setNotifications] = useState({
@@ -45,10 +39,6 @@ export function Settings() {
   const [selectedSettlementMonth, setSelectedSettlementMonth] = useState(new Date().toISOString().slice(0, 7))
   const [settlementLoading, setSettlementLoading] = useState(false)
   const [settlement, setSettlement] = useState<AttendanceSettlement | null>(null)
-  const [autoCheckoutLoading, setAutoCheckoutLoading] = useState(false)
-  const [autoCheckoutSaving, setAutoCheckoutSaving] = useState(false)
-  const [autoCheckoutSaved, setAutoCheckoutSaved] = useState(false)
-  const [autoCheckoutTime, setAutoCheckoutTime] = useState('')
 
   useEffect(() => {
     if (activeTab !== 'settlement') return
@@ -65,22 +55,6 @@ export function Settings() {
         setSettlementLoading(false)
       })
   }, [activeTab, selectedSettlementMonth])
-
-  useEffect(() => {
-    if (activeTab !== 'attendance') return
-
-    setAutoCheckoutLoading(true)
-    getAutoCheckoutTime()
-      .then((data) => {
-        setAutoCheckoutTime(normalizeTimeValue(data.autoCheckoutTime))
-      })
-      .catch((err) => {
-        setErrorMessage(err instanceof Error ? err.message : '자동 체크아웃 시간을 불러오지 못했습니다')
-      })
-      .finally(() => {
-        setAutoCheckoutLoading(false)
-      })
-  }, [activeTab])
 
   const handleSave = async () => {
     try {
@@ -130,26 +104,9 @@ export function Settings() {
     }
   }
 
-  const handleAutoCheckoutSave = async () => {
-    if (!isAdmin || !autoCheckoutTime) return
-
-    setAutoCheckoutSaving(true)
-    try {
-      const result = await updateAutoCheckoutTime(normalizeTimeValue(autoCheckoutTime))
-      setAutoCheckoutTime(normalizeTimeValue(result.autoCheckoutTime))
-      setAutoCheckoutSaved(true)
-      setTimeout(() => setAutoCheckoutSaved(false), 2000)
-    } catch (err) {
-      setErrorMessage(err instanceof Error ? err.message : '자동 체크아웃 시간 저장에 실패했습니다')
-    } finally {
-      setAutoCheckoutSaving(false)
-    }
-  }
-
   const tabs: { id: SettingsTab; label: string; icon: React.ReactNode }[] = [
     { id: 'profile', label: '프로필', icon: <User size={18} /> },
     { id: 'notifications', label: '알림', icon: <Bell size={18} /> },
-    { id: 'attendance', label: '출퇴근', icon: <Clock3 size={18} /> },
     { id: 'appearance', label: '테마', icon: <Palette size={18} /> },
     { id: 'settlement', label: '정산', icon: <Wallet size={18} /> },
     { id: 'security', label: '보안', icon: <Shield size={18} /> },
@@ -167,7 +124,7 @@ export function Settings() {
       <header className="settings-header">
         <div className="settings-header-copy">
           <p className="settings-kicker">My Page</p>
-          <p className="settings-subtitle">프로필, 알림, 출퇴근, 테마, 정산, 보안 정보를 한 곳에서 관리하세요.</p>
+          <p className="settings-subtitle">프로필, 알림, 테마, 정산, 보안 정보를 한 곳에서 관리하세요.</p>
         </div>
         <div className="settings-summary-card glass">
           <div className="settings-summary-icon">
@@ -286,59 +243,6 @@ export function Settings() {
               <div className="appearance-note">
                 <h4>테마 전환 안내</h4>
                 <p>레이아웃, 카드, 입력창, 플로팅 UI까지 모두 선택한 테마에 맞춰 함께 전환됩니다.</p>
-              </div>
-            </section>
-          )}
-
-          {activeTab === 'attendance' && (
-            <section className="settings-section">
-              <h3>자동 체크아웃 시간</h3>
-              <div className="attendance-settings-card">
-                <div className="attendance-settings-copy">
-                  <strong>미퇴근자는 이 시간 기준으로 자동 체크아웃됩니다.</strong>
-                  <p>매일 자정 스케줄러가 설정된 시간을 기준으로 미퇴근자를 자동 체크아웃 처리합니다.</p>
-                </div>
-
-                {autoCheckoutLoading ? (
-                  <div className="settlement-empty-panel compact">
-                    <p className="settlement-empty-title">자동 체크아웃 시간을 불러오는 중입니다.</p>
-                    <p className="settlement-empty-description">현재 운영 중인 자동 체크아웃 시간을 확인하고 있습니다.</p>
-                  </div>
-                ) : (
-                  <>
-                    <div className="setting-field">
-                      <label htmlFor="auto-checkout-time">자동 체크아웃 시간</label>
-                      <input
-                        id="auto-checkout-time"
-                        aria-label="자동 체크아웃 시간 입력"
-                        type="time"
-                        step={1}
-                        value={autoCheckoutTime}
-                        onChange={(e) => setAutoCheckoutTime(normalizeTimeValue(e.target.value))}
-                        className="setting-input"
-                        disabled={!isAdmin}
-                      />
-                    </div>
-
-                    {isAdmin ? (
-                      <button
-                        className="save-btn"
-                        type="button"
-                        onClick={handleAutoCheckoutSave}
-                        disabled={autoCheckoutSaving || !autoCheckoutTime}
-                        aria-label="자동 체크아웃 시간 저장"
-                      >
-                        <Save size={16} />
-                        {autoCheckoutSaving ? '저장 중...' : autoCheckoutSaved ? '저장됨!' : '자동 체크아웃 시간 저장'}
-                      </button>
-                    ) : (
-                      <div className="attendance-settings-note">
-                        <span>관리자만 변경할 수 있습니다.</span>
-                        <p>현재 시간은 확인할 수 있지만 수정은 관리자 계정에서만 가능합니다.</p>
-                      </div>
-                    )}
-                  </>
-                )}
               </div>
             </section>
           )}

--- a/src/pages/settings/settings.css
+++ b/src/pages/settings/settings.css
@@ -123,52 +123,6 @@
   gap: 18px;
 }
 
-.attendance-settings-card {
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-  padding: 20px;
-  border-radius: 20px;
-  border: 1px solid var(--border-color);
-  background: color-mix(in srgb, var(--surface-muted) 72%, transparent);
-}
-
-.attendance-settings-copy {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.attendance-settings-copy strong {
-  color: var(--text-primary);
-  font-size: 1rem;
-}
-
-.attendance-settings-copy p {
-  margin: 0;
-  color: var(--text-secondary);
-  line-height: 1.6;
-}
-
-.attendance-settings-note {
-  padding: 16px 18px;
-  border-radius: 18px;
-  border: 1px dashed var(--border-color);
-  background: color-mix(in srgb, var(--surface) 78%, transparent);
-}
-
-.attendance-settings-note span {
-  display: block;
-  margin-bottom: 6px;
-  font-weight: 700;
-  color: var(--text-primary);
-}
-
-.attendance-settings-note p {
-  margin: 0;
-  color: var(--text-secondary);
-  line-height: 1.6;
-}
 
 .my-settlement-summary-grid {
   display: grid;


### PR DESCRIPTION
## 작업 내용
- develop 브랜치의 최신 변경 사항을 main에 반영하는 `v1.0.0` 배포 PR입니다.
- 이번 배포에는 자동 체크아웃 시간 설정의 관리자 페이지 이동이 포함됩니다.
- 최근 정식 출시 준비까지 반영된 최신 develop 상태를 배포합니다.

## 변경 이유
- 운영 정책 성격의 설정을 관리자 페이지로 정리한 최신 상태를 main 배포 브랜치에 반영해야 합니다.

## 상세 변경 사항
### 주요 변경
- [x] 자동 체크아웃 시간 설정을 관리자 페이지 `운영 설정` 탭으로 이동
- [x] 마이페이지에서 운영 정책 설정 제거
- [x] `v1.0.0` 버전 반영 상태로 배포 준비

### 추가 메모
- main 머지 후 `v1.0.0` 기준 배포 및 태그 생성 진행하면 됩니다.

## 테스트
- [x] `npm run test -- src/pages/settings/__tests__/Settings.test.tsx src/pages/admin/__tests__/Admin.test.tsx src/shared/api/__tests__/settingsApi.test.ts`
- [x] `npm run build`
- [ ] 브라우저에서 주요 동작 최종 확인

## 리뷰 포인트
- 관리자 페이지로 위치를 옮긴 것이 운영 흐름상 더 자연스러운지 확인 부탁드립니다.

## 관련 이슈
- closes #337