### PR TITLE
release: v1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ test-results
 .playwright-cli/
 output/
 docs/architecture/*.svg
+.gstack/

--- a/src/app/__tests__/MainBootstrap.test.tsx
+++ b/src/app/__tests__/MainBootstrap.test.tsx
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { startMockWorker, renderApp, createRootSpy } = vi.hoisted(() => {
+  const startMockWorker = vi.fn().mockResolvedValue(undefined)
+  const renderApp = vi.fn()
+  const createRootSpy = vi.fn(() => ({ render: renderApp }))
+
+  return { startMockWorker, renderApp, createRootSpy }
+})
+
+vi.mock('../../shared/api/mock/browser', () => ({
+  worker: {
+    start: startMockWorker,
+  },
+}))
+
+vi.mock('react-dom/client', () => ({
+  createRoot: createRootSpy,
+}))
+
+vi.mock('../../App.tsx', () => ({
+  default: () => null,
+}))
+
+describe('main bootstrap', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    startMockWorker.mockClear()
+    renderApp.mockClear()
+    createRootSpy.mockClear()
+    document.body.innerHTML = '<div id="root"></div>'
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('mock 모드에서 msw worker를 quiet 옵션과 함께 시작한 뒤 렌더링한다', async () => {
+    const { bootstrapApp } = await import('../../main')
+    await bootstrapApp({ useMock: true })
+
+    expect(startMockWorker).toHaveBeenCalledWith({
+      onUnhandledRequest: 'bypass',
+      quiet: true,
+    })
+    expect(createRootSpy).toHaveBeenCalledWith(document.getElementById('root'))
+    expect(renderApp).toHaveBeenCalled()
+  })
+})

--- a/src/features/attendance/ui/TeamAttendanceStatus.css
+++ b/src/features/attendance/ui/TeamAttendanceStatus.css
@@ -70,6 +70,7 @@
   flex-direction: column;
   gap: 8px;
   max-height: 420px;
+  min-height: 220px;
   overflow-y: auto;
 }
 
@@ -157,11 +158,30 @@
   font-variant-numeric: tabular-nums;
 }
 
-.attend-empty {
+.attend-empty-state {
+  display: grid;
+  place-items: center;
+  gap: 8px;
+  min-height: 180px;
+  padding: 24px;
+  border-radius: 18px;
+  border: 1px dashed rgba(148, 163, 184, 0.22);
+  background:
+    linear-gradient(135deg, rgba(124, 58, 237, 0.1), transparent 65%),
+    rgba(255, 255, 255, 0.02);
   text-align: center;
+}
+
+.attend-empty-state strong {
+  color: var(--text-primary);
+  font-size: 0.98rem;
+}
+
+.attend-empty {
+  margin: 0;
   color: var(--text-secondary);
   font-size: 0.85rem;
-  padding: 32px 0;
+  line-height: 1.6;
 }
 
 :root[data-theme='light'] .summary-item.left {
@@ -170,4 +190,11 @@
 
 :root[data-theme='light'] .attend-member-card {
   background: rgba(84, 102, 146, 0.04);
+}
+
+:root[data-theme='light'] .attend-empty-state {
+  border-color: rgba(84, 102, 146, 0.16);
+  background:
+    linear-gradient(135deg, rgba(107, 79, 196, 0.08), transparent 65%),
+    rgba(255, 255, 255, 0.72);
 }

--- a/src/features/attendance/ui/TeamAttendanceStatus.tsx
+++ b/src/features/attendance/ui/TeamAttendanceStatus.tsx
@@ -72,7 +72,12 @@ export function TeamAttendanceStatus({ members, records, date }: Props) {
 
       <div className="attend-member-grid">
         {filteredMembers.length === 0 ? (
-          <p className="attend-empty">해당 상태의 팀원이 없습니다</p>
+          <div className="attend-empty-state">
+            <strong>{STATUS_LABEL[activeFilter]} 상태인 팀원이 없습니다</strong>
+            <p className="attend-empty">
+              다른 상태 탭을 누르면 오늘 기록이 있는 팀원을 바로 확인할 수 있습니다.
+            </p>
+          </div>
         ) : (
           filteredMembers.map((member) => {
             const rec = records.find((r) => String(r.memberId) === String(member.id))

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,10 +3,12 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
-async function bootstrap() {
-  if (import.meta.env.VITE_USE_MOCK === 'true') {
+export async function bootstrapApp(options?: { useMock?: boolean }) {
+  const useMock = options?.useMock ?? (import.meta.env.VITE_USE_MOCK === 'true')
+
+  if (useMock) {
     const { worker } = await import('./shared/api/mock/browser')
-    await worker.start({ onUnhandledRequest: 'bypass' })
+    await worker.start({ onUnhandledRequest: 'bypass', quiet: true })
   }
 
   createRoot(document.getElementById('root')!).render(
@@ -16,4 +18,4 @@ async function bootstrap() {
   )
 }
 
-bootstrap()
+void bootstrapApp()

--- a/src/pages/admin/__tests__/Admin.test.tsx
+++ b/src/pages/admin/__tests__/Admin.test.tsx
@@ -251,7 +251,7 @@ describe('Admin 페이지', () => {
     await user.click(screen.getByRole('button', { name: '운영 설정' }))
 
     expect(await screen.findByLabelText('자동 체크아웃 시간 입력')).toBeInTheDocument()
-    expect(screen.getByDisplayValue(mockAutoCheckoutTime)).toBeInTheDocument()
+    expect(screen.getByDisplayValue('23:59')).toBeInTheDocument()
   })
 
   it('운영 설정 탭에서 자동 체크아웃 시간을 저장할 수 있다', async () => {
@@ -259,16 +259,16 @@ describe('Admin 페이지', () => {
     renderAdmin()
 
     await user.click(screen.getByRole('button', { name: '운영 설정' }))
-    await screen.findByDisplayValue(mockAutoCheckoutTime)
+    await screen.findByDisplayValue('23:59')
 
     await user.clear(screen.getByLabelText('자동 체크아웃 시간 입력'))
-    await user.type(screen.getByLabelText('자동 체크아웃 시간 입력'), '220000')
+    await user.type(screen.getByLabelText('자동 체크아웃 시간 입력'), '2200')
     await user.click(screen.getByRole('button', { name: '자동 체크아웃 시간 저장' }))
 
     await waitFor(() => {
       expect(screen.getByText('자동 체크아웃 시간을 저장했습니다')).toBeInTheDocument()
     })
-    expect(screen.getByDisplayValue('22:00:00')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('22:00')).toBeInTheDocument()
   })
 
   it('멤버 관리 탭 클릭 시 멤버 테이블이 표시된다', async () => {

--- a/src/pages/admin/admin.css
+++ b/src/pages/admin/admin.css
@@ -1,6 +1,6 @@
 .admin-page {
   width: 100%;
-  max-width: var(--page-max-wide);
+  max-width: var(--page-max-ultra);
   margin: 0 auto;
   display: flex;
   flex-direction: column;
@@ -70,6 +70,7 @@
   border-radius: 12px;
   padding: 4px;
   width: fit-content;
+  min-width: min(100%, 680px);
 }
 
 .admin-tab-btn {
@@ -152,6 +153,47 @@
   align-items: end;
   gap: 14px;
   flex-wrap: wrap;
+}
+
+.admin-overview-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 18px;
+}
+
+.admin-overview-card {
+  display: grid;
+  gap: 8px;
+  padding: 18px;
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--surface-muted) 78%, transparent);
+  border: 1px solid var(--border-color);
+}
+
+.admin-overview-card.emphasis {
+  background: color-mix(in srgb, var(--accent-purple) 14%, transparent);
+  border-color: color-mix(in srgb, var(--accent-purple) 24%, transparent);
+}
+
+.admin-overview-label {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.admin-overview-card strong {
+  font-size: clamp(1.8rem, 3vw, 2.25rem);
+  line-height: 1;
+  color: var(--text-primary);
+}
+
+.admin-overview-card p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.55;
 }
 
 .admin-settlement-actions {
@@ -885,6 +927,10 @@
     padding: 18px;
   }
 
+  .admin-overview-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .admin-team-create,
   .admin-team-create input,
   .admin-create-team-btn {
@@ -920,6 +966,10 @@
   .admin-tab-content {
     padding: 16px;
     border-radius: 20px;
+  }
+
+  .admin-overview-grid {
+    grid-template-columns: 1fr;
   }
 
   .admin-modal {

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -81,7 +81,12 @@ function formatTime(value: string | null) {
   return value ? value.slice(11, 16) : '-'
 }
 
-function normalizeTimeValue(value: string) {
+function toTimeInputValue(value: string) {
+  if (!value) return ''
+  return value.slice(0, 5)
+}
+
+function toApiTimeValue(value: string) {
   if (!value) return ''
   return value.length === 5 ? `${value}:00` : value
 }
@@ -135,6 +140,19 @@ export function Admin() {
   }, [settlementMemberOptions, teamOptions])
   const settlement = settlements.find((item) => String(item.memberId) === selectedSettlementMemberId) ?? null
   const settlementSummary = useMemo(() => rollupAttendanceSettlements(settlements), [settlements])
+  const activeMembers = useMemo(
+    () => members.filter((member) => member.status !== 'INACTIVE'),
+    [members],
+  )
+  const activeTeamCount = useMemo(
+    () => new Set(activeMembers.map((member) => member.team)).size,
+    [activeMembers],
+  )
+  const checkedOutCount = useMemo(
+    () => records.filter((record) => record.status === 'LEFT').length,
+    [records],
+  )
+  const missingAttendanceCount = Math.max(activeMembers.length - records.length, 0)
   const teamSettlementGroups = useMemo<TeamSettlementGroup[]>(
     () => settlementTeamOptions.map((teamName) => {
       const teamMemberSettlements = settlements.filter((item) => item.teamName === teamName)
@@ -230,7 +248,7 @@ export function Admin() {
     setAutoCheckoutLoading(true)
     getAutoCheckoutTime()
       .then((data) => {
-        setAutoCheckoutTime(normalizeTimeValue(data.autoCheckoutTime))
+        setAutoCheckoutTime(toTimeInputValue(data.autoCheckoutTime))
       })
       .catch((err) => {
         setErrorMessage(err instanceof Error ? err.message : '자동 체크아웃 시간을 불러오지 못했습니다')
@@ -477,8 +495,8 @@ export function Admin() {
 
     setAutoCheckoutSaving(true)
     try {
-      const result = await updateAutoCheckoutTime(normalizeTimeValue(autoCheckoutTime))
-      setAutoCheckoutTime(normalizeTimeValue(result.autoCheckoutTime))
+      const result = await updateAutoCheckoutTime(toApiTimeValue(autoCheckoutTime))
+      setAutoCheckoutTime(toTimeInputValue(result.autoCheckoutTime))
       setAutoCheckoutSaved(true)
       setSuccessMessage('자동 체크아웃 시간을 저장했습니다')
       setTimeout(() => setAutoCheckoutSaved(false), 2000)
@@ -560,6 +578,28 @@ export function Admin() {
 
       {tab === 'attendance' && (
         <div className="admin-tab-content glass">
+          <div className="admin-overview-grid">
+            <article className="admin-overview-card">
+              <span className="admin-overview-label">활성 멤버</span>
+              <strong>{activeMembers.length}명</strong>
+              <p>현재 운영 중인 전체 인원</p>
+            </article>
+            <article className="admin-overview-card">
+              <span className="admin-overview-label">활성 팀</span>
+              <strong>{activeTeamCount}개</strong>
+              <p>근무 일정을 관리 중인 팀 수</p>
+            </article>
+            <article className="admin-overview-card">
+              <span className="admin-overview-label">오늘 기록</span>
+              <strong>{records.length}건</strong>
+              <p>출근 또는 퇴근 기록이 남은 인원</p>
+            </article>
+            <article className="admin-overview-card emphasis">
+              <span className="admin-overview-label">오늘 미기록</span>
+              <strong>{missingAttendanceCount}명</strong>
+              <p>확인 필요한 인원, 퇴근 {checkedOutCount}명 완료</p>
+            </article>
+          </div>
           <TeamAttendanceStatus members={members} records={records} date={todayStr} />
         </div>
       )}
@@ -1081,7 +1121,7 @@ export function Admin() {
                     type="time"
                     step={1}
                     value={autoCheckoutTime}
-                    onChange={(event) => setAutoCheckoutTime(normalizeTimeValue(event.target.value))}
+                    onChange={(event) => setAutoCheckoutTime(event.target.value)}
                   />
                 </label>
 

--- a/src/pages/attendance/attendance.css
+++ b/src/pages/attendance/attendance.css
@@ -402,12 +402,15 @@
 
 @media (max-width: 720px) {
   .attendance-header {
+    flex-direction: column;
+    align-items: stretch;
     margin-bottom: 20px;
   }
 
   .header-actions {
     width: 100%;
     align-items: stretch;
+    gap: 10px;
   }
 
   .export-btn,
@@ -420,6 +423,8 @@
   .export-btn,
   .date-range {
     justify-content: center;
+    min-height: 44px;
+    border-radius: 14px;
   }
 
   .filter-tabs {
@@ -450,6 +455,7 @@
   .my-history-section,
   .leave-section-wrap {
     padding: 18px;
+    border-radius: 20px;
   }
 
   .pagination {
@@ -461,6 +467,11 @@
 @media (max-width: 560px) {
   .attendance-header-copy p {
     font-size: 0.92rem;
+  }
+
+  .filter-tabs button {
+    min-height: 42px;
+    font-size: 0.82rem;
   }
 
   .team-status-section,
@@ -489,6 +500,17 @@
     font-size: 0.72rem;
   }
 
+  .summary-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+  }
+
+  .stat-card .value {
+    font-size: 1.5rem;
+  }
+}
+
+@media (max-width: 420px) {
   .summary-stats {
     grid-template-columns: 1fr;
   }

--- a/src/pages/dashboard/dashboard.css
+++ b/src/pages/dashboard/dashboard.css
@@ -237,6 +237,8 @@
   grid-column: 2 / 4;
   grid-row: 1;
   min-height: 140px;
+  display: flex;
+  flex-direction: column;
 }
 
 .chat-preview {
@@ -275,6 +277,21 @@
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.schedule-card .empty-state-panel,
+.chat-preview .empty-state-panel,
+.tasks-card .empty-state-panel {
+  flex: 1;
+  min-height: 132px;
+  justify-items: center;
+  align-content: center;
+  text-align: center;
+}
+
+.schedule-card .empty-state-action,
+.tasks-card .empty-state-action {
+  justify-content: center;
 }
 
 .schedule-card ul,

--- a/src/pages/login/login.css
+++ b/src/pages/login/login.css
@@ -3,7 +3,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 24px;
+  padding: clamp(24px, 4vw, 56px);
   position: relative;
 }
 
@@ -21,33 +21,45 @@
 
 .login-card {
   width: 100%;
-  max-width: 420px;
-  padding: 48px 40px 44px;
+  max-width: 480px;
+  padding: 56px 44px 48px;
   position: relative;
   z-index: 1;
+  overflow: hidden;
+  border-radius: 28px;
   box-shadow:
     0 0 0 1px color-mix(in srgb, var(--accent-purple) 18%, transparent),
     var(--shadow-strong),
     0 4px 16px color-mix(in srgb, var(--accent-purple) 12%, transparent);
 }
 
+.login-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at top center, rgba(138, 114, 216, 0.16), transparent 42%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 32%);
+  pointer-events: none;
+}
+
 .login-logo {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 36px;
+  gap: 12px;
+  margin-bottom: 40px;
 }
 
 .login-logo-img {
-  height: 52px;
+  height: 58px;
   width: auto;
   object-fit: contain;
   filter: drop-shadow(0 0 12px rgba(124, 58, 237, 0.5));
 }
 
 .login-logo-title {
-  font-size: 1.6rem;
+  font-size: clamp(2rem, 3vw, 2.35rem);
   font-weight: 800;
   background: var(--gradient-purple);
   -webkit-background-clip: text;
@@ -58,10 +70,10 @@
 }
 
 .login-logo-sub {
-  font-size: 0.83rem;
-  color: var(--text-muted);
+  font-size: 0.94rem;
+  color: color-mix(in srgb, var(--text-secondary) 88%, white 12%);
   margin-top: 2px;
-  letter-spacing: 0.3px;
+  letter-spacing: 0.02em;
 }
 
 .login-form {
@@ -77,10 +89,10 @@
 }
 
 .form-group label {
-  font-size: 0.82rem;
+  font-size: 0.88rem;
   font-weight: 600;
-  color: var(--text-secondary);
-  letter-spacing: 0.3px;
+  color: color-mix(in srgb, var(--text-secondary) 85%, white 15%);
+  letter-spacing: 0.02em;
 }
 
 .input-wrap {
@@ -92,7 +104,7 @@
 .input-icon {
   position: absolute;
   left: 13px;
-  color: var(--text-muted);
+  color: color-mix(in srgb, var(--text-muted) 82%, white 18%);
   pointer-events: none;
   flex-shrink: 0;
   z-index: 2;
@@ -100,28 +112,32 @@
 
 .form-input {
   width: 100%;
-  padding: 11px 44px 11px 40px;
-  background: var(--bg-input);
-  border: 1px solid var(--border-color);
-  border-radius: 10px;
+  min-height: 52px;
+  padding: 13px 44px 13px 40px;
+  background: color-mix(in srgb, var(--bg-input) 84%, var(--bg-card-solid) 16%);
+  border: 1px solid color-mix(in srgb, var(--border-color) 92%, white 8%);
+  border-radius: 14px;
   color: var(--text-primary);
-  font-size: 0.93rem;
+  font-size: 0.96rem;
   font-family: inherit;
   transition: border-color 0.2s, box-shadow 0.2s, background 0.2s;
   outline: none;
   position: relative;
   z-index: 1;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
 }
 
 .form-input::placeholder {
-  color: var(--text-muted);
-  font-size: 0.88rem;
+  color: color-mix(in srgb, var(--text-muted) 76%, white 24%);
+  font-size: 0.91rem;
 }
 
 .form-input:focus {
   border-color: var(--accent-purple);
   background: var(--bg-card-solid);
-  box-shadow: 0 0 0 3px var(--ring-color);
+  box-shadow:
+    0 0 0 3px var(--ring-color),
+    0 12px 28px rgba(15, 18, 32, 0.18);
 }
 
 .form-input.error {
@@ -161,12 +177,13 @@
 
 .login-btn {
   width: 100%;
-  padding: 12px;
+  min-height: 54px;
+  padding: 12px 16px;
   background: var(--gradient-purple-blue);
   color: #fff;
-  font-size: 0.97rem;
+  font-size: 1rem;
   font-weight: 700;
-  border-radius: 10px;
+  border-radius: 14px;
   border: none;
   cursor: pointer;
   transition: opacity 0.2s, transform 0.15s, box-shadow 0.2s;
@@ -227,10 +244,10 @@
 }
 
 .login-footer {
-  margin-top: 20px;
+  margin-top: 24px;
   text-align: center;
-  font-size: 0.83rem;
-  color: var(--text-muted);
+  font-size: 0.9rem;
+  color: color-mix(in srgb, var(--text-muted) 70%, white 30%);
 }
 
 .login-footer a {
@@ -267,6 +284,24 @@
 
 @media (max-width: 480px) {
   .login-card {
-    padding: 36px 22px 32px;
+    max-width: 100%;
+    padding: 40px 22px 34px;
+    border-radius: 24px;
+  }
+
+  .login-logo {
+    margin-bottom: 32px;
+  }
+
+  .login-logo-img {
+    height: 54px;
+  }
+
+  .login-logo-title {
+    font-size: 1.95rem;
+  }
+
+  .login-logo-sub {
+    font-size: 0.92rem;
   }
 }

--- a/src/pages/register/register.css
+++ b/src/pages/register/register.css
@@ -3,7 +3,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 24px;
+  padding: clamp(24px, 4vw, 56px);
   position: relative;
 }
 
@@ -21,33 +21,45 @@
 
 .register-card {
   width: 100%;
-  max-width: 460px;
-  padding: 42px 38px 38px;
+  max-width: 520px;
+  padding: 50px 42px 42px;
   position: relative;
   z-index: 1;
+  overflow: hidden;
+  border-radius: 28px;
   box-shadow:
     0 0 0 1px color-mix(in srgb, var(--accent-purple) 18%, transparent),
     var(--shadow-strong),
     0 4px 16px color-mix(in srgb, var(--accent-purple) 12%, transparent);
 }
 
+.register-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at top center, rgba(114, 184, 232, 0.12), transparent 42%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 32%);
+  pointer-events: none;
+}
+
 .register-logo {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 28px;
+  gap: 12px;
+  margin-bottom: 32px;
 }
 
 .register-logo-img {
-  height: 52px;
+  height: 58px;
   width: auto;
   object-fit: contain;
   filter: drop-shadow(0 0 12px rgba(124, 58, 237, 0.5));
 }
 
 .register-logo-title {
-  font-size: 1.6rem;
+  font-size: clamp(2rem, 3vw, 2.35rem);
   font-weight: 800;
   background: var(--gradient-purple);
   -webkit-background-clip: text;
@@ -58,16 +70,16 @@
 }
 
 .register-logo-sub {
-  font-size: 0.83rem;
-  color: var(--text-muted);
+  font-size: 0.94rem;
+  color: color-mix(in srgb, var(--text-secondary) 88%, white 12%);
   margin-top: 2px;
-  letter-spacing: 0.3px;
+  letter-spacing: 0.02em;
 }
 
 .register-form {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 18px;
 }
 
 .form-select {
@@ -129,16 +141,16 @@
 .field-help {
   display: inline-block;
   margin-top: 6px;
-  color: var(--text-muted);
-  font-size: 0.76rem;
+  color: color-mix(in srgb, var(--text-muted) 76%, white 24%);
+  font-size: 0.81rem;
   line-height: 1.5;
 }
 
 .register-footer {
-  margin-top: 20px;
+  margin-top: 24px;
   text-align: center;
-  font-size: 0.83rem;
-  color: var(--text-muted);
+  font-size: 0.9rem;
+  color: color-mix(in srgb, var(--text-muted) 70%, white 30%);
 }
 
 .register-footer a {
@@ -175,6 +187,24 @@
 
 @media (max-width: 480px) {
   .register-card {
-    padding: 36px 22px 32px;
+    max-width: 100%;
+    padding: 40px 22px 34px;
+    border-radius: 24px;
+  }
+
+  .register-logo {
+    margin-bottom: 28px;
+  }
+
+  .register-logo-img {
+    height: 54px;
+  }
+
+  .register-logo-title {
+    font-size: 1.95rem;
+  }
+
+  .register-logo-sub {
+    font-size: 0.92rem;
   }
 }

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -11,6 +11,42 @@ import './settings.css'
 
 type SettingsTab = 'profile' | 'notifications' | 'appearance' | 'security' | 'settlement'
 
+const SETTINGS_SECTION_META: Record<
+  SettingsTab,
+  { eyebrow: string; title: string; description: string; badge: string }
+> = {
+  profile: {
+    eyebrow: 'Profile',
+    title: '내 계정과 소속 정보를 정리합니다.',
+    description: '표시 이름, 역할, 팀 정보를 확인하고 개인 프로필을 안전하게 관리할 수 있습니다.',
+    badge: '계정 기본 정보',
+  },
+  notifications: {
+    eyebrow: 'Notifications',
+    title: '어떤 알림을 받을지 직접 고릅니다.',
+    description: '채팅, 캘린더, 이메일 알림을 역할에 맞게 조절해 방해를 줄입니다.',
+    badge: '알림 제어',
+  },
+  appearance: {
+    eyebrow: 'Appearance',
+    title: '작업 환경에 맞는 화면 분위기를 고릅니다.',
+    description: '라이트 모드와 다크 모드를 전환해 집중하기 좋은 화면을 유지합니다.',
+    badge: '테마 설정',
+  },
+  settlement: {
+    eyebrow: 'Settlement',
+    title: '내 지각비와 출근 기록을 빠르게 확인합니다.',
+    description: '월별 정산 결과와 상세 내역을 한 번에 보면서 누락이나 지각을 바로 점검할 수 있습니다.',
+    badge: '개인 정산',
+  },
+  security: {
+    eyebrow: 'Security',
+    title: '비밀번호와 계정 상태를 안전하게 관리합니다.',
+    description: '비밀번호 변경과 탈퇴 같은 민감한 작업을 한 곳에서 처리해 계정 통제를 단순하게 만듭니다.',
+    badge: '보안 관리',
+  },
+}
+
 function formatCurrency(amount: number) {
   return `${amount.toLocaleString('ko-KR')}원`
 }
@@ -115,6 +151,7 @@ export function Settings() {
     { id: 'light', label: '라이트 모드', description: '밝고 선명한 작업 환경', icon: <Sun size={18} /> },
     { id: 'dark', label: '다크 모드', description: '집중감을 높이는 어두운 화면', icon: <Moon size={18} /> },
   ]
+  const activeSectionMeta = SETTINGS_SECTION_META[activeTab]
 
   return (
     <div className="settings-page">
@@ -152,6 +189,15 @@ export function Settings() {
         </nav>
 
         <div className="settings-content glass">
+          <section className="settings-section-hero">
+            <div className="settings-section-hero-copy">
+              <p className="settings-section-eyebrow">{activeSectionMeta.eyebrow}</p>
+              <h3 className="settings-section-hero-title">{activeSectionMeta.title}</h3>
+              <p className="settings-section-hero-description">{activeSectionMeta.description}</p>
+            </div>
+            <span className="settings-section-badge">{activeSectionMeta.badge}</span>
+          </section>
+
           {activeTab === 'profile' && (
             <section className="settings-section">
               <h3>프로필 정보</h3>

--- a/src/pages/settings/settings.css
+++ b/src/pages/settings/settings.css
@@ -9,8 +9,8 @@
 
 .settings-header {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) clamp(320px, 28vw, 420px);
-  align-items: end;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+  align-items: center;
   gap: 20px;
 }
 
@@ -37,9 +37,10 @@
   display: flex;
   align-items: center;
   gap: 14px;
-  padding: 16px 18px;
+  padding: 14px 16px;
   justify-self: end;
   width: 100%;
+  min-height: 100%;
 }
 
 .settings-summary-icon {
@@ -70,9 +71,10 @@
 
 .settings-layout {
   display: grid;
-  grid-template-columns: clamp(220px, 18vw, 260px) minmax(0, 1fr);
+  grid-template-columns: clamp(220px, 18vw, 260px) minmax(0, 940px);
   gap: 24px;
   align-items: start;
+  justify-content: space-between;
 }
 
 .settings-nav {
@@ -115,6 +117,67 @@
   border-radius: 24px;
   padding: clamp(28px, 2vw, 34px);
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.settings-section-hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 22px 24px;
+  border-radius: 22px;
+  border: 1px solid var(--border-color);
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--accent-purple) 14%, transparent), transparent 62%),
+    color-mix(in srgb, var(--surface-muted) 72%, transparent);
+}
+
+.settings-section-hero-copy {
+  min-width: 0;
+}
+
+.settings-section-eyebrow {
+  margin: 0 0 10px;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.settings-section-hero-title {
+  margin: 0 0 8px;
+  font-size: clamp(1.35rem, 2.2vw, 1.7rem);
+  line-height: 1.2;
+}
+
+.settings-section-hero-description {
+  margin: 0;
+  max-width: 620px;
+  color: var(--text-secondary);
+  line-height: 1.65;
+}
+
+.settings-section-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 9px 14px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--accent-purple) 22%, transparent);
+  background: color-mix(in srgb, var(--accent-purple) 14%, transparent);
+  color: var(--text-primary);
+  font-size: 0.82rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 }
 
 .my-settlement-layout {
@@ -236,14 +299,14 @@
   }
 
   .settings-layout {
-    grid-template-columns: clamp(240px, 17vw, 280px) minmax(0, 1fr);
+    grid-template-columns: clamp(240px, 17vw, 280px) minmax(0, 980px);
     gap: 28px;
   }
 }
 
 .settings-section h3 {
   font-size: 20px;
-  margin-bottom: 24px;
+  margin: 0;
   padding-bottom: 12px;
   border-bottom: 1px solid var(--border-color);
 }
@@ -286,7 +349,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  margin-bottom: 20px;
+  margin-bottom: 0;
 }
 
 .setting-field label {
@@ -354,7 +417,7 @@
 }
 
 .danger-zone {
-  margin-top: 32px;
+  margin-top: 8px;
   padding: 20px;
   border-radius: 20px;
   border: 1px solid rgba(239, 68, 68, 0.2);
@@ -829,5 +892,42 @@
 
   .danger-zone-head {
     flex-direction: column;
+  }
+}
+.settings-section > .setting-field:first-of-type,
+.settings-section > .my-settlement-layout:first-of-type,
+.settings-section > .attendance-settings-card:first-of-type,
+.settings-section > .theme-options-grid:first-of-type,
+.settings-section > .profile-avatar-row:first-of-type,
+.settings-section > .setting-row:first-of-type {
+  margin-top: -2px;
+}
+
+@media (max-width: 1200px) {
+  .settings-layout {
+    grid-template-columns: 1fr;
+    justify-content: stretch;
+  }
+
+  .settings-nav {
+    position: static;
+  }
+}
+
+@media (max-width: 820px) {
+  .settings-header {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-summary-card {
+    justify-self: stretch;
+  }
+
+  .settings-section-hero {
+    flex-direction: column;
+  }
+
+  .settings-section-badge {
+    white-space: normal;
   }
 }

--- a/src/pages/verify-email/verify-email.css
+++ b/src/pages/verify-email/verify-email.css
@@ -3,7 +3,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 24px;
+  padding: clamp(24px, 4vw, 56px);
   position: relative;
 }
 
@@ -21,35 +21,47 @@
 
 .verify-email-card {
   width: 100%;
-  max-width: 500px;
-  padding: 42px 38px 38px;
+  max-width: 560px;
+  padding: 48px 42px 42px;
   position: relative;
   z-index: 1;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 24px;
+  overflow: hidden;
+  border-radius: 28px;
   box-shadow:
     0 0 0 1px color-mix(in srgb, var(--accent-purple) 16%, transparent),
     var(--shadow-strong),
     0 4px 18px color-mix(in srgb, var(--accent-blue) 12%, transparent);
 }
 
+.verify-email-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at top center, rgba(114, 184, 232, 0.16), transparent 44%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 32%);
+  pointer-events: none;
+}
+
 .verify-email-logo {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
 }
 
 .verify-email-logo-img {
-  height: 52px;
+  height: 58px;
   width: auto;
   object-fit: contain;
   filter: drop-shadow(0 0 12px rgba(59, 130, 246, 0.35));
 }
 
 .verify-email-logo-title {
-  font-size: 1.6rem;
+  font-size: clamp(2rem, 3vw, 2.35rem);
   font-weight: 800;
   background: var(--gradient-purple-blue);
   -webkit-background-clip: text;
@@ -60,17 +72,18 @@
 }
 
 .verify-email-logo-sub {
-  font-size: 0.83rem;
-  color: var(--text-muted);
-  letter-spacing: 0.3px;
+  font-size: 0.94rem;
+  color: color-mix(in srgb, var(--text-secondary) 88%, white 12%);
+  letter-spacing: 0.02em;
 }
 
 .verify-email-status-card,
 .verify-email-resend {
-  border-radius: 18px;
-  padding: 20px;
-  background: color-mix(in srgb, var(--bg-card-solid) 90%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
+  border-radius: 22px;
+  padding: 24px;
+  background: color-mix(in srgb, var(--bg-card-solid) 94%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 88%, white 12%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
 }
 
 .verify-email-status-card {
@@ -82,7 +95,7 @@
 
 .verify-email-status-card h1 {
   margin: 0;
-  font-size: 1.5rem;
+  font-size: clamp(1.75rem, 3vw, 2.1rem);
   line-height: 1.25;
   color: var(--text-primary);
 }
@@ -90,7 +103,7 @@
 .verify-email-status-card p,
 .verify-email-resend-copy {
   margin: 0;
-  color: var(--text-secondary);
+  color: color-mix(in srgb, var(--text-secondary) 88%, white 12%);
   line-height: 1.6;
 }
 
@@ -117,8 +130,8 @@
   gap: 4px;
   padding: 14px 16px;
   border-radius: 14px;
-  background: color-mix(in srgb, var(--accent-blue) 8%, transparent);
-  border: 1px solid color-mix(in srgb, var(--accent-blue) 18%, transparent);
+  background: color-mix(in srgb, var(--accent-blue) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-blue) 22%, transparent);
 }
 
 .verify-email-target span {
@@ -138,14 +151,14 @@
   align-items: center;
   justify-content: center;
   width: 100%;
-  min-height: 46px;
-  border-radius: 12px;
+  min-height: 52px;
+  border-radius: 14px;
   font-weight: 700;
   text-decoration: none;
   border: none;
   cursor: pointer;
   font-family: inherit;
-  font-size: 0.95rem;
+  font-size: 0.98rem;
 }
 
 .verify-email-primary-link,
@@ -179,6 +192,7 @@
   gap: 8px;
   font-weight: 700;
   color: var(--text-primary);
+  font-size: 1.02rem;
 }
 
 .verify-email-input-group {
@@ -188,22 +202,24 @@
 }
 
 .verify-email-input-group label {
-  font-size: 0.82rem;
+  font-size: 0.88rem;
   font-weight: 600;
-  color: var(--text-secondary);
+  color: color-mix(in srgb, var(--text-secondary) 85%, white 15%);
 }
 
 .verify-email-input {
   width: 100%;
-  padding: 12px 14px;
-  background: var(--bg-input);
-  border: 1px solid var(--border-color);
-  border-radius: 10px;
+  min-height: 52px;
+  padding: 13px 14px;
+  background: color-mix(in srgb, var(--bg-input) 84%, var(--bg-card-solid) 16%);
+  border: 1px solid color-mix(in srgb, var(--border-color) 92%, white 8%);
+  border-radius: 14px;
   color: var(--text-primary);
-  font-size: 0.93rem;
+  font-size: 0.96rem;
   font-family: inherit;
   transition: border-color 0.2s, box-shadow 0.2s, background 0.2s;
   outline: none;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
 }
 
 .verify-email-input:focus {
@@ -221,7 +237,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 0.84rem;
+  font-size: 0.88rem;
   line-height: 1.5;
 }
 
@@ -235,8 +251,8 @@
 
 .verify-email-footer {
   text-align: center;
-  font-size: 0.83rem;
-  color: var(--text-muted);
+  font-size: 0.9rem;
+  color: color-mix(in srgb, var(--text-muted) 70%, white 30%);
 }
 
 .verify-email-footer a {
@@ -246,11 +262,29 @@
 
 @media (max-width: 480px) {
   .verify-email-card {
-    padding: 34px 22px 28px;
+    max-width: 100%;
+    padding: 38px 22px 34px;
+    border-radius: 24px;
   }
 
   .verify-email-status-card,
   .verify-email-resend {
-    padding: 18px;
+    padding: 20px;
+  }
+
+  .verify-email-logo-img {
+    height: 54px;
+  }
+
+  .verify-email-logo-title {
+    font-size: 1.95rem;
+  }
+
+  .verify-email-logo-sub {
+    font-size: 0.92rem;
+  }
+
+  .verify-email-status-card h1 {
+    font-size: 1.9rem;
   }
 }

--- a/src/pages/work-schedules/work-schedules.css
+++ b/src/pages/work-schedules/work-schedules.css
@@ -2,6 +2,9 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
+  width: 100%;
+  max-width: var(--page-max-ultra);
+  margin: 0 auto;
 }
 
 .work-schedules-header {
@@ -23,11 +26,13 @@
   gap: 10px;
   padding: 12px 16px;
   border-radius: 16px;
+  max-width: 520px;
+  color: var(--text-secondary);
 }
 
 .work-schedules-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1.5fr) minmax(320px, 0.9fr);
+  grid-template-columns: minmax(0, 1.7fr) minmax(340px, 0.92fr);
   gap: 20px;
   align-items: start;
 }
@@ -36,6 +41,10 @@
 .work-schedules-editor-card {
   padding: 24px;
   border-radius: 24px;
+}
+
+.work-schedules-calendar-card {
+  min-width: 0;
 }
 
 .work-schedules-side {
@@ -50,6 +59,7 @@
   justify-content: space-between;
   gap: 16px;
   flex-wrap: wrap;
+  margin-bottom: 10px;
 }
 
 .work-schedules-scope-group {
@@ -86,6 +96,7 @@
   display: flex;
   gap: 12px;
   flex-wrap: wrap;
+  align-items: flex-end;
 }
 
 .work-schedules-select {
@@ -116,6 +127,7 @@
   justify-content: space-between;
   gap: 14px;
   flex-wrap: wrap;
+  margin-bottom: 12px;
 }
 
 .work-schedules-legend {
@@ -462,14 +474,40 @@
   .work-schedules-editor-card,
   .work-schedules-modal {
     padding: 18px;
+    border-radius: 20px;
+  }
+
+  .work-schedules-summary,
+  .work-schedules-toolbar,
+  .work-schedules-calendar-meta {
+    gap: 12px;
   }
 
   .work-schedules-select {
     min-width: 100%;
   }
 
+  .work-schedules-scope-group,
+  .work-schedules-legend {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: none;
+    padding-bottom: 2px;
+  }
+
+  .work-schedules-scope-group::-webkit-scrollbar,
+  .work-schedules-legend::-webkit-scrollbar {
+    display: none;
+  }
+
+  .scope-chip,
+  .legend-chip {
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+
   .work-schedules-calendar-shell .fc .fc-daygrid-day-frame {
-    min-height: 88px;
+    min-height: 78px;
   }
 
   .work-schedules-calendar-meta {
@@ -484,8 +522,33 @@
     font-size: 1rem;
   }
 
+  .work-schedules-calendar-shell .fc .fc-daygrid-event {
+    font-size: 0.72rem;
+  }
+
   .work-schedules-calendar-overlay {
     top: 10px;
     right: 10px;
+  }
+}
+
+@media (max-width: 420px) {
+  .work-schedules-calendar-shell .fc .fc-daygrid-day-frame {
+    min-height: 68px;
+  }
+
+  .work-schedules-calendar-shell .fc .fc-toolbar.fc-header-toolbar {
+    margin-bottom: 0.8rem;
+  }
+
+  .work-schedules-calendar-shell .fc .fc-button {
+    min-height: 38px;
+    padding: 0 10px;
+  }
+
+  .work-schedules-calendar-overlay {
+    position: static;
+    margin-bottom: 8px;
+    justify-content: center;
   }
 }

--- a/src/shared/api/mock/handlers/index.ts
+++ b/src/shared/api/mock/handlers/index.ts
@@ -1,9 +1,19 @@
+import { attendanceHandlers } from './attendance'
+import { authHandlers } from './auth'
+import { calendarHandlers } from './calendar'
 import { chatHandlers } from './chat'
 import { driveHandlers } from './drive'
+import { membersHandlers } from './members'
+import { operationsHandlers } from './operations'
 
-// auth, members, attendance, calendar — 실제 백엔드(api.yanus.bond) 사용
-// chat, drive — 백엔드 미구현으로 MSW mock 유지
+// 로컬 mock 모드에서는 핵심 사용자 흐름을 최대한 실제처럼 점검할 수 있게
+// 이미 준비된 도메인 핸들러를 함께 등록한다.
 export const handlers = [
+  ...authHandlers,
+  ...membersHandlers,
+  ...attendanceHandlers,
+  ...calendarHandlers,
+  ...operationsHandlers,
   ...chatHandlers,
   ...driveHandlers,
 ]

--- a/src/shared/api/mock/handlers/operations.ts
+++ b/src/shared/api/mock/handlers/operations.ts
@@ -1,0 +1,394 @@
+import { http, HttpResponse } from 'msw'
+import type { Leave } from '../../../../entities/leave/model/types'
+import type { AuditLog } from '../../../api/auditLogsApi'
+import type { AttendanceSettlement } from '../../../api/attendanceSettlementApi'
+import { getAuthMockUserByAuthorization } from './auth'
+
+type MockTaskPriority = 'HIGH' | 'MEDIUM' | 'LOW'
+
+interface MockTask {
+  id: number
+  title: string
+  date: string
+  time: string
+  priority: MockTaskPriority
+  done: boolean
+  isTeamTask: boolean
+  assigneeId: number | null
+  assigneeName: string | null
+  memberIds?: number[] | null
+  memberNames?: string[] | null
+}
+
+const today = new Date().toISOString().slice(0, 10)
+const tomorrow = new Date(Date.now() + (24 * 60 * 60 * 1000)).toISOString().slice(0, 10)
+
+let nextTaskId = 5
+let nextLeaveId = 4
+let autoCheckoutTime = '23:59:59'
+
+let mockTasks: MockTask[] = [
+  {
+    id: 1,
+    title: '주간 회의 안건 정리',
+    date: today,
+    time: '10:00:00',
+    priority: 'HIGH',
+    done: false,
+    isTeamTask: false,
+    assigneeId: 1,
+    assigneeName: '김리더',
+  },
+  {
+    id: 2,
+    title: '출퇴근 누락자 확인',
+    date: today,
+    time: '18:30:00',
+    priority: 'MEDIUM',
+    done: false,
+    isTeamTask: true,
+    assigneeId: 1,
+    assigneeName: '김리더',
+    memberIds: [1, 2],
+    memberNames: ['김리더', '박팀장'],
+  },
+  {
+    id: 3,
+    title: '신입 팀 공지 업로드',
+    date: tomorrow,
+    time: '14:00:00',
+    priority: 'LOW',
+    done: false,
+    isTeamTask: true,
+    assigneeId: 2,
+    assigneeName: '박팀장',
+    memberIds: [2, 3],
+    memberNames: ['박팀장', '이멤버'],
+  },
+  {
+    id: 4,
+    title: '정산 시트 점검',
+    date: today,
+    time: '20:00:00',
+    priority: 'HIGH',
+    done: true,
+    isTeamTask: false,
+    assigneeId: 1,
+    assigneeName: '김리더',
+  },
+]
+
+let mockLeaves: Leave[] = [
+  {
+    id: 1,
+    memberId: 1,
+    memberName: '김리더',
+    category: 'PERSONAL',
+    detail: '병원 진료',
+    date: today,
+    status: 'PENDING',
+    submittedAt: `${today}T09:10:00`,
+    reviewedAt: null,
+  },
+  {
+    id: 2,
+    memberId: 2,
+    memberName: '박팀장',
+    category: 'VACATION',
+    detail: '가족 일정',
+    date: tomorrow,
+    status: 'APPROVED',
+    submittedAt: `${today}T08:30:00`,
+    reviewedAt: `${today}T11:00:00`,
+  },
+  {
+    id: 3,
+    memberId: 3,
+    memberName: '이멤버',
+    category: 'SICK_LEAVE',
+    detail: '감기',
+    date: tomorrow,
+    status: 'REJECTED',
+    submittedAt: `${today}T07:45:00`,
+    reviewedAt: `${today}T10:20:00`,
+  },
+]
+
+const mockAuditLogs: AuditLog[] = [
+  {
+    id: 1,
+    actorId: 1,
+    actorRole: 'ADMIN',
+    targetId: 2,
+    action: 'ROLE_CHANGE',
+    previousValue: 'MEMBER',
+    newValue: 'TEAM_LEAD',
+    createdAt: `${today}T10:15:00`,
+  },
+  {
+    id: 2,
+    actorId: 1,
+    actorRole: 'ADMIN',
+    targetId: 3,
+    action: 'TEAM_CHANGE',
+    previousValue: '신입',
+    newValue: '3팀',
+    createdAt: `${today}T14:25:00`,
+  },
+  {
+    id: 3,
+    actorId: 1,
+    actorRole: 'ADMIN',
+    targetId: 5,
+    action: 'ACTIVATE',
+    previousValue: 'INACTIVE',
+    newValue: 'ACTIVE',
+    createdAt: `${today}T18:05:00`,
+  },
+]
+
+function getUserName(userId: number) {
+  if (userId === 1) return '김리더'
+  if (userId === 2) return '박팀장'
+  if (userId === 3) return '이멤버'
+  if (userId === 4) return '최개발'
+  return '정보안'
+}
+
+function getTeamName(userId: number) {
+  if (userId === 1 || userId === 4) return '1팀'
+  if (userId === 2) return '2팀'
+  if (userId === 3) return '3팀'
+  return '4팀'
+}
+
+function createSettlement(yearMonth: string, memberId: number): AttendanceSettlement {
+  const memberName = getUserName(memberId)
+  const teamName = getTeamName(memberId)
+  const baseDay = String((memberId % 4) + 1).padStart(2, '0')
+
+  return {
+    yearMonth,
+    memberId,
+    memberName,
+    teamName,
+    scheduledDays: 12,
+    attendedDays: 11,
+    lateDays: 2,
+    totalLateMinutes: 13,
+    lateFee: 1300,
+    items: [
+      {
+        date: `${yearMonth}-${baseDay}`,
+        scheduledStartTime: '09:00:00',
+        scheduledEndTime: '18:00:00',
+        checkInTime: `${yearMonth}-${baseDay}T09:05:00`,
+        checkOutTime: `${yearMonth}-${baseDay}T18:02:00`,
+        lateMinutes: 5,
+        fee: 500,
+        status: 'LATE',
+      },
+      {
+        date: `${yearMonth}-${String(Number(baseDay) + 3).padStart(2, '0')}`,
+        scheduledStartTime: '09:00:00',
+        scheduledEndTime: '18:00:00',
+        checkInTime: `${yearMonth}-${String(Number(baseDay) + 3).padStart(2, '0')}T09:08:00`,
+        checkOutTime: `${yearMonth}-${String(Number(baseDay) + 3).padStart(2, '0')}T18:01:00`,
+        lateMinutes: 8,
+        fee: 800,
+        status: 'LATE',
+      },
+      {
+        date: `${yearMonth}-${String(Number(baseDay) + 6).padStart(2, '0')}`,
+        scheduledStartTime: '09:00:00',
+        scheduledEndTime: '18:00:00',
+        checkInTime: `${yearMonth}-${String(Number(baseDay) + 6).padStart(2, '0')}T08:59:00`,
+        checkOutTime: `${yearMonth}-${String(Number(baseDay) + 6).padStart(2, '0')}T18:03:00`,
+        lateMinutes: 0,
+        fee: 0,
+        status: 'ON_TIME',
+      },
+    ],
+  }
+}
+
+function getCurrentUserId(authorization: string | null) {
+  return Number(getAuthMockUserByAuthorization(authorization).id)
+}
+
+function filterTasksByRange(tasks: MockTask[], startDate: string | null, endDate: string | null) {
+  return tasks.filter((task) => {
+    if (startDate && task.date < startDate) return false
+    if (endDate && task.date > endDate) return false
+    return true
+  })
+}
+
+export const operationsHandlers = [
+  http.get('/api/v1/tasks', ({ request }) => {
+    const url = new URL(request.url)
+    const type = url.searchParams.get('type')
+    const startDate = url.searchParams.get('startDate')
+    const endDate = url.searchParams.get('endDate')
+    const currentUserId = getCurrentUserId(request.headers.get('Authorization'))
+
+    let tasks = filterTasksByRange(mockTasks, startDate, endDate)
+    if (type === 'MY') {
+      tasks = tasks.filter((task) => !task.isTeamTask && task.assigneeId === currentUserId)
+    } else if (type === 'TEAM') {
+      tasks = tasks.filter((task) => task.isTeamTask)
+    }
+
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: tasks })
+  }),
+
+  http.post('/api/v1/tasks', async ({ request }) => {
+    const body = await request.json() as Omit<MockTask, 'id' | 'done' | 'assigneeName' | 'memberNames'>
+    const currentUserId = getCurrentUserId(request.headers.get('Authorization'))
+    const newTask: MockTask = {
+      id: nextTaskId++,
+      title: body.title,
+      date: body.date,
+      time: body.time,
+      priority: body.priority,
+      done: false,
+      isTeamTask: body.isTeamTask,
+      assigneeId: body.assigneeId ?? currentUserId,
+      assigneeName: getUserName(body.assigneeId ?? currentUserId),
+      memberIds: body.memberIds ?? null,
+      memberNames: body.memberIds?.map(getUserName) ?? null,
+    }
+
+    mockTasks = [...mockTasks, newTask]
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: newTask }, { status: 201 })
+  }),
+
+  http.put('/api/v1/tasks/:id', async ({ params, request }) => {
+    const id = Number(params.id)
+    const body = await request.json() as Partial<MockTask>
+    let updatedTask: MockTask | undefined
+
+    mockTasks = mockTasks.map((task) => {
+      if (task.id !== id) return task
+      updatedTask = {
+        ...task,
+        ...body,
+        memberNames: body.memberIds ? body.memberIds.map(getUserName) : task.memberNames,
+      }
+      return updatedTask
+    })
+
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: updatedTask })
+  }),
+
+  http.patch('/api/v1/tasks/:id/done', ({ params }) => {
+    const id = Number(params.id)
+    let updatedTask: MockTask | undefined
+
+    mockTasks = mockTasks.map((task) => {
+      if (task.id !== id) return task
+      updatedTask = { ...task, done: !task.done }
+      return updatedTask
+    })
+
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: updatedTask })
+  }),
+
+  http.delete('/api/v1/tasks/:id', ({ params }) => {
+    const id = Number(params.id)
+    mockTasks = mockTasks.filter((task) => task.id !== id)
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: null })
+  }),
+
+  http.get('/api/v1/leaves', ({ request }) => {
+    const currentUserId = getCurrentUserId(request.headers.get('Authorization'))
+    const leaves = mockLeaves.filter((leave) => leave.memberId === currentUserId)
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: leaves })
+  }),
+
+  http.post('/api/v1/leaves', async ({ request }) => {
+    const body = await request.json() as { category: Leave['category']; detail: string; date: string }
+    const currentUser = getAuthMockUserByAuthorization(request.headers.get('Authorization'))
+    const newLeave: Leave = {
+      id: nextLeaveId++,
+      memberId: Number(currentUser.id),
+      memberName: currentUser.name,
+      category: body.category,
+      detail: body.detail,
+      date: body.date,
+      status: 'PENDING',
+      submittedAt: new Date().toISOString(),
+      reviewedAt: null,
+    }
+
+    mockLeaves = [newLeave, ...mockLeaves]
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: newLeave }, { status: 201 })
+  }),
+
+  http.get('/api/v1/leaves/admin', () =>
+    HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: mockLeaves }),
+  ),
+
+  http.patch('/api/v1/leaves/:id/approve', ({ params }) => {
+    const id = Number(params.id)
+    let updatedLeave: Leave | undefined
+
+    mockLeaves = mockLeaves.map((leave) => {
+      if (leave.id !== id) return leave
+      updatedLeave = { ...leave, status: 'APPROVED', reviewedAt: new Date().toISOString() }
+      return updatedLeave
+    })
+
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: updatedLeave })
+  }),
+
+  http.patch('/api/v1/leaves/:id/reject', ({ params }) => {
+    const id = Number(params.id)
+    let updatedLeave: Leave | undefined
+
+    mockLeaves = mockLeaves.map((leave) => {
+      if (leave.id !== id) return leave
+      updatedLeave = { ...leave, status: 'REJECTED', reviewedAt: new Date().toISOString() }
+      return updatedLeave
+    })
+
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: updatedLeave })
+  }),
+
+  http.get('/api/v1/settings/auto-checkout-time', () =>
+    HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: { autoCheckoutTime },
+    }),
+  ),
+
+  http.patch('/api/v1/settings/auto-checkout-time', async ({ request }) => {
+    const body = await request.json() as { autoCheckoutTime: string }
+    autoCheckoutTime = body.autoCheckoutTime
+    return HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: { autoCheckoutTime },
+    })
+  }),
+
+  http.get('/api/v1/attendance-settlements/monthly', ({ request }) => {
+    const url = new URL(request.url)
+    const yearMonth = url.searchParams.get('yearMonth') ?? today.slice(0, 7)
+    const targetMemberId = url.searchParams.get('targetMemberId')
+    const memberId = targetMemberId
+      ? Number(targetMemberId)
+      : getCurrentUserId(request.headers.get('Authorization'))
+
+    return HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: createSettlement(yearMonth, memberId),
+    })
+  }),
+
+  http.get('/api/v1/audit-logs', () =>
+    HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: mockAuditLogs }),
+  ),
+]


### PR DESCRIPTION
## 작업 내용
- develop 브랜치의 최신 변경 사항을 main에 반영하는 `v1.0.0` 배포 PR입니다.
- 이번 배포에는 로컬 mock 기반 디자인/QA 검토 흐름 정리와 관리자 운영 설정 자동 체크아웃 시간 입력 보정이 포함됩니다.
- 인증/운영 화면의 시각 밀도 개선과 mock QA 안정화까지 반영된 최신 develop 상태를 배포합니다.

## 변경 이유
- 실서비스 인증에 묶이지 않고 로컬 mock만으로도 핵심 운영 화면을 반복 검토할 수 있어야 이후 운영 품질 점검이 빨라집니다.
- 관리자 페이지 `운영 설정`의 자동 체크아웃 시간 입력이 실제 브라우저에서 더 안정적으로 동작하는 최신 상태를 main 배포 브랜치에 반영해야 합니다.

## 상세 변경 사항
### 주요 변경
- [x] 로컬 mock 기반 QA 핸들러 확장 및 `.gstack` 아티팩트 경로 정리
- [x] 로그인/회원가입/이메일 인증, 출퇴근, 관리자, 근무 일정, 마이페이지 화면 디자인 폴리시 개선
- [x] 관리자 페이지 `운영 설정` 탭의 자동 체크아웃 시간 입력 형식 보정
- [x] mock 모드 MSW 시작 경고 제거 및 회귀 테스트 추가

### 추가 메모
- 자동 체크아웃 설정 위치는 기존 `#337` 흐름을 유지해 관리자 페이지 기준으로만 다뤘습니다.
- main 머지 후 `v1.0.0` 기준 최신 운영 화면 품질 상태로 배포하면 됩니다.

## 테스트
- [x] `npm run test:run -- src/pages/admin/__tests__/Admin.test.tsx src/pages/settings/__tests__/Settings.test.tsx src/app/__tests__/MainBootstrap.test.tsx`
- [x] `npm run build`
- [x] 로컬 mock 브라우저에서 관리자 운영 설정 자동 체크아웃 시간 입력/저장 확인

## 리뷰 포인트
- mock 기반 디자인/QA 흐름이 이후 운영 화면 검토에도 그대로 재사용 가능한지 확인 부탁드립니다.
- 관리자 출근 현황 상단 요약 카드와 주요 화면 밀도 조정이 실제 운영 흐름에서 더 자연스러운지 봐주세요.
- 관리자 운영 설정의 자동 체크아웃 시간 입력이 배포 환경에서도 안정적으로 보이는지 확인 부탁드립니다.

## 관련 이슈
- closes #340