### PR TITLE
[Feat] #343 - 관리자 출퇴근 예외 처리 흐름 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ api.md
 .claude/worktrees/
 .claude/settings.local.json
 .claude/todos/
+.claude/
 .vercel
 .env*.local
 playwright-report

--- a/src/features/attendance/model/__tests__/useWorkSession.test.ts
+++ b/src/features/attendance/model/__tests__/useWorkSession.test.ts
@@ -157,6 +157,53 @@ describe('useWorkSession', () => {
       expect(stored).not.toBeNull()
       expect(JSON.parse(stored!).status).toBe('working')
     })
+
+    it('서버에 오늘 기록이 없으면 이전 localStorage working 상태를 복구하지 않는다', async () => {
+      localStorage.setItem('yanus-work-session', JSON.stringify({
+        status: 'working',
+        clockIn: `${getTodayStr()}T09:00:00.000Z`,
+      }))
+
+      const { result } = await mountHook()
+
+      expect(result.current.status).toBe('idle')
+      expect(result.current.clockIn).toBeNull()
+      expect(localStorage.getItem('yanus-work-session')).toBeNull()
+    })
+
+    it('요청 실패 시에도 이전 날짜 localStorage 상태는 복구하지 않는다', async () => {
+      server.use(
+        http.get('/api/v1/attendances/me', () =>
+          HttpResponse.json({ code: 'SERVER_ERROR', message: '서버 오류', data: null }, { status: 500 }),
+        ),
+      )
+      localStorage.setItem('yanus-work-session', JSON.stringify({
+        status: 'working',
+        clockIn: '2026-03-21T09:00:00.000Z',
+      }))
+
+      const { result } = await mountHook()
+
+      expect(result.current.status).toBe('idle')
+      expect(result.current.clockIn).toBeNull()
+    })
+
+    it('요청 실패 시 오늘 localStorage 상태만 복구한다', async () => {
+      server.use(
+        http.get('/api/v1/attendances/me', () =>
+          HttpResponse.json({ code: 'SERVER_ERROR', message: '서버 오류', data: null }, { status: 500 }),
+        ),
+      )
+      localStorage.setItem('yanus-work-session', JSON.stringify({
+        status: 'working',
+        clockIn: `${getTodayStr()}T09:10:00.000Z`,
+      }))
+
+      const { result } = await mountHook()
+
+      expect(result.current.status).toBe('working')
+      expect(result.current.clockIn).not.toBeNull()
+    })
   })
 
   describe('에러 처리', () => {

--- a/src/features/attendance/model/useWorkSession.ts
+++ b/src/features/attendance/model/useWorkSession.ts
@@ -6,6 +6,33 @@ import { getTodayStr } from '../../../shared/lib/date'
 
 const STORAGE_KEY = 'yanus-work-session'
 
+interface StoredWorkSession {
+  status: WorkStatus
+  clockIn?: string
+  clockOut?: string
+}
+
+function readStoredSession(): StoredWorkSession | null {
+  const stored = localStorage.getItem(STORAGE_KEY)
+  if (!stored) return null
+
+  try {
+    return JSON.parse(stored) as StoredWorkSession
+  } catch {
+    return null
+  }
+}
+
+function isSameWorkday(value: string | undefined, todayStr: string) {
+  return Boolean(value && value.slice(0, 10) === todayStr)
+}
+
+function canRestoreStoredSession(session: StoredWorkSession | null, todayStr: string) {
+  if (!session) return false
+
+  return isSameWorkday(session.clockIn, todayStr) || isSameWorkday(session.clockOut, todayStr)
+}
+
 export function useWorkSession() {
   const [status, setStatus] = useState<WorkStatus>('idle')
   const [clockIn, setClockIn] = useState<Date | null>(null)
@@ -45,41 +72,41 @@ export function useWorkSession() {
 
   // 서버 출퇴근 기록으로 초기 상태 동기화
   useEffect(() => {
+    const todayStr = getTodayStr()
+
     syncTodayAttendance()
       .then((todayRecord) => {
         if (!todayRecord) {
-          const stored = localStorage.getItem(STORAGE_KEY)
-          if (stored) {
-            try {
-              const parsed = JSON.parse(stored) as { status: WorkStatus; clockIn?: string; clockOut?: string }
-              setStatus(parsed.status)
-              setClockIn(parsed.clockIn ? new Date(parsed.clockIn) : null)
-              setClockOut(parsed.clockOut ? new Date(parsed.clockOut) : null)
-            } catch {}
-          }
+          localStorage.removeItem(STORAGE_KEY)
         }
       })
       .catch(() => {
-        const stored = localStorage.getItem(STORAGE_KEY)
-        if (stored) {
-          try {
-            const parsed = JSON.parse(stored) as { status: WorkStatus; clockIn?: string; clockOut?: string }
-            setStatus(parsed.status)
-            setClockIn(parsed.clockIn ? new Date(parsed.clockIn) : null)
-            setClockOut(parsed.clockOut ? new Date(parsed.clockOut) : null)
-          } catch {}
+        const stored = readStoredSession()
+        if (canRestoreStoredSession(stored, todayStr) && stored) {
+          setStatus(stored.status)
+          setClockIn(stored.clockIn ? new Date(stored.clockIn) : null)
+          setClockOut(stored.clockOut ? new Date(stored.clockOut) : null)
+        } else {
+          localStorage.removeItem(STORAGE_KEY)
         }
       })
       .finally(() => setIsLoading(false))
   }, [])
 
   useEffect(() => {
+    if (isLoading) return
+
+    if (status === 'idle' && !clockIn && !clockOut) {
+      localStorage.removeItem(STORAGE_KEY)
+      return
+    }
+
     localStorage.setItem(STORAGE_KEY, JSON.stringify({
       status,
       clockIn: clockIn?.toISOString(),
       clockOut: clockOut?.toISOString(),
     }))
-  }, [status, clockIn, clockOut])
+  }, [status, clockIn, clockOut, isLoading])
 
   const handleClockClick = async () => {
     setErrorMessage(null)

--- a/src/features/attendance/ui/AttendanceExceptionBoard.css
+++ b/src/features/attendance/ui/AttendanceExceptionBoard.css
@@ -1,0 +1,361 @@
+.attendance-exception-board {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  margin-top: 18px;
+  padding: 22px;
+  border-radius: 22px;
+  border: 1px solid var(--border-color);
+  background:
+    linear-gradient(160deg, color-mix(in srgb, var(--accent-purple) 8%, transparent), transparent 38%),
+    color-mix(in srgb, var(--surface-muted) 72%, transparent);
+}
+
+.attendance-exception-bulk-btn,
+.attendance-exception-primary-btn,
+.attendance-exception-secondary-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 42px;
+  padding: 0 16px;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.attendance-exception-bulk-btn:disabled,
+.attendance-exception-primary-btn:disabled,
+.attendance-exception-secondary-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.attendance-exception-bulk-btn {
+  background: color-mix(in srgb, var(--accent-purple) 12%, transparent);
+  border-color: color-mix(in srgb, var(--accent-purple) 28%, transparent);
+}
+
+.attendance-exception-primary-btn {
+  background: var(--accent-purple);
+  border-color: transparent;
+  color: #fff;
+}
+
+.attendance-exception-secondary-btn.approve {
+  background: color-mix(in srgb, #28c76f 14%, transparent);
+  color: #28c76f;
+}
+
+.attendance-exception-secondary-btn.reject {
+  background: color-mix(in srgb, #ff5d73 14%, transparent);
+  color: #ff5d73;
+}
+
+.attendance-exception-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.attendance-exception-summary-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 18px;
+  border-radius: 18px;
+  border: 1px solid var(--border-color);
+  background: color-mix(in srgb, var(--surface) 82%, transparent);
+}
+
+.attendance-exception-summary-card.emphasis {
+  background: color-mix(in srgb, var(--accent-purple) 14%, transparent);
+  border-color: color-mix(in srgb, var(--accent-purple) 28%, transparent);
+}
+
+.attendance-exception-summary-card span {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.attendance-exception-summary-card strong {
+  font-size: 1.8rem;
+  color: var(--text-primary);
+  line-height: 1;
+}
+
+.attendance-exception-summary-card p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.55;
+}
+
+.attendance-exception-toolbar {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.attendance-exception-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.attendance-exception-field span {
+  font-size: 0.84rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.attendance-exception-field select {
+  min-height: 46px;
+  padding: 0 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  background: var(--surface-muted);
+  color: var(--text-primary);
+  font: inherit;
+}
+
+.attendance-exception-content {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(320px, 0.95fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.attendance-exception-table-wrap {
+  margin-top: 0;
+}
+
+.attendance-exception-table {
+  width: 100%;
+  min-width: 720px;
+  border-collapse: collapse;
+}
+
+.attendance-exception-table th,
+.attendance-exception-table td {
+  padding: 14px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  text-align: left;
+}
+
+.attendance-exception-table th {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  font-weight: 700;
+}
+
+.attendance-exception-table td {
+  color: var(--text-primary);
+  font-size: 0.9rem;
+}
+
+.attendance-exception-table tbody tr {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.attendance-exception-table tbody tr:hover td {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.attendance-exception-table tbody tr.selected td {
+  background: color-mix(in srgb, var(--accent-purple) 12%, transparent);
+}
+
+.attendance-exception-pill,
+.attendance-exception-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 86px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.attendance-exception-pill.MISSED_CHECK_IN,
+.attendance-exception-status.REJECTED {
+  background: color-mix(in srgb, #ff5d73 14%, transparent);
+  color: #ff5d73;
+}
+
+.attendance-exception-pill.MISSED_CHECK_OUT {
+  background: color-mix(in srgb, #ff9f43 16%, transparent);
+  color: #ff9f43;
+}
+
+.attendance-exception-pill.LATE,
+.attendance-exception-status.OPEN {
+  background: color-mix(in srgb, #f4b740 16%, transparent);
+  color: #f4b740;
+}
+
+.attendance-exception-pill.NO_SCHEDULE,
+.attendance-exception-status.RESOLVED {
+  background: color-mix(in srgb, var(--accent-purple) 14%, transparent);
+  color: var(--text-primary);
+}
+
+.attendance-exception-status.APPROVED {
+  background: color-mix(in srgb, #28c76f 14%, transparent);
+  color: #28c76f;
+}
+
+.attendance-exception-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  border-radius: 20px;
+  border: 1px solid var(--border-color);
+  background: color-mix(in srgb, var(--surface) 78%, transparent);
+}
+
+.attendance-exception-detail-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.attendance-exception-detail-head h4 {
+  margin: 6px 0 8px;
+  font-size: 1.05rem;
+  color: var(--text-primary);
+}
+
+.attendance-exception-detail-head p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.attendance-exception-detail-eyebrow {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.attendance-exception-detail-meta {
+  display: grid;
+  gap: 12px;
+}
+
+.attendance-exception-meta-card {
+  display: flex;
+  gap: 12px;
+  padding: 14px;
+  border-radius: 16px;
+  border: 1px solid var(--border-color);
+  background: color-mix(in srgb, var(--surface-muted) 72%, transparent);
+}
+
+.attendance-exception-meta-card svg {
+  flex-shrink: 0;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.attendance-exception-meta-card div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.attendance-exception-meta-card strong {
+  color: var(--text-primary);
+  font-size: 0.92rem;
+}
+
+.attendance-exception-meta-card span {
+  color: var(--text-secondary);
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+.attendance-exception-note-field {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.attendance-exception-note-field > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.attendance-exception-note-field textarea {
+  min-height: 120px;
+  resize: vertical;
+  padding: 14px;
+  border-radius: 14px;
+  border: 1px solid var(--border-color);
+  background: var(--surface-muted);
+  color: var(--text-primary);
+  font: inherit;
+  line-height: 1.6;
+}
+
+.attendance-exception-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+:root[data-theme='light'] .attendance-exception-table th,
+:root[data-theme='light'] .attendance-exception-table td {
+  border-bottom-color: rgba(84, 102, 146, 0.12);
+}
+
+:root[data-theme='light'] .attendance-exception-table tbody tr:hover td {
+  background: rgba(84, 102, 146, 0.05);
+}
+
+:root[data-theme='light'] .attendance-exception-table tbody tr.selected td {
+  background: rgba(126, 91, 239, 0.08);
+}
+
+@media (max-width: 1100px) {
+  .attendance-exception-summary-grid,
+  .attendance-exception-toolbar,
+  .attendance-exception-content {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .attendance-exception-board {
+    padding: 18px;
+  }
+
+  .attendance-exception-detail-head {
+    flex-direction: column;
+  }
+
+  .attendance-exception-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .attendance-exception-primary-btn {
+    grid-column: span 2;
+  }
+}

--- a/src/features/attendance/ui/AttendanceExceptionBoard.tsx
+++ b/src/features/attendance/ui/AttendanceExceptionBoard.tsx
@@ -1,0 +1,366 @@
+import { useEffect, useMemo, useState } from 'react'
+import { AlertTriangle, CheckCheck, ClipboardList, MessageSquareText } from 'lucide-react'
+import type {
+  AttendanceException,
+  AttendanceExceptionStatus,
+  AttendanceExceptionSummary,
+  AttendanceExceptionType,
+} from '../../../shared/api/attendanceExceptionsApi'
+import { formatTeamName } from '../../../shared/lib/team'
+import { DataTableScroll } from '../../../shared/ui/DataTableSection'
+import { EmptyState } from '../../../shared/ui/EmptyState'
+import { SectionHeader } from '../../../shared/ui/SectionHeader'
+import './AttendanceExceptionBoard.css'
+
+type AttendanceExceptionTypeFilter = AttendanceExceptionType | 'ALL'
+type AttendanceExceptionStatusFilter = AttendanceExceptionStatus | 'ALL'
+
+interface AttendanceExceptionBoardProps {
+  date: string
+  summary: AttendanceExceptionSummary | null
+  items: AttendanceException[]
+  loading: boolean
+  teamOptions: string[]
+  selectedType: AttendanceExceptionTypeFilter
+  selectedStatus: AttendanceExceptionStatusFilter
+  selectedTeamName: string
+  actionLoading: boolean
+  bulkLoading: boolean
+  onTypeChange: (nextType: AttendanceExceptionTypeFilter) => void
+  onStatusChange: (nextStatus: AttendanceExceptionStatusFilter) => void
+  onTeamChange: (nextTeamName: string) => void
+  onSaveNote: (exceptionId: number, note: string) => void
+  onApprove: (exceptionId: number, note: string) => void
+  onReject: (exceptionId: number, note: string) => void
+  onResolve: (exceptionId: number, note: string) => void
+  onBulkAutoCheckout: () => void
+}
+
+const typeLabels: Record<AttendanceExceptionType, string> = {
+  MISSED_CHECK_IN: '미출근',
+  MISSED_CHECK_OUT: '미퇴근',
+  LATE: '지각',
+  NO_SCHEDULE: '근무 일정 없음',
+}
+
+const statusLabels: Record<AttendanceExceptionStatus, string> = {
+  OPEN: '처리 대기',
+  APPROVED: '승인 완료',
+  REJECTED: '반려됨',
+  RESOLVED: '처리 완료',
+}
+
+const typeOptions: { value: AttendanceExceptionTypeFilter; label: string }[] = [
+  { value: 'ALL', label: '전체 유형' },
+  { value: 'MISSED_CHECK_IN', label: typeLabels.MISSED_CHECK_IN },
+  { value: 'MISSED_CHECK_OUT', label: typeLabels.MISSED_CHECK_OUT },
+  { value: 'LATE', label: typeLabels.LATE },
+  { value: 'NO_SCHEDULE', label: typeLabels.NO_SCHEDULE },
+]
+
+const statusOptions: { value: AttendanceExceptionStatusFilter; label: string }[] = [
+  { value: 'ALL', label: '전체 상태' },
+  { value: 'OPEN', label: statusLabels.OPEN },
+  { value: 'APPROVED', label: statusLabels.APPROVED },
+  { value: 'REJECTED', label: statusLabels.REJECTED },
+  { value: 'RESOLVED', label: statusLabels.RESOLVED },
+]
+
+function formatTime(value: string | null) {
+  return value ? value.slice(11, 16) : '-'
+}
+
+function formatScheduleTime(value: string | null) {
+  return value ? value.slice(0, 5) : '-'
+}
+
+function describeException(exception: AttendanceException) {
+  if (exception.type === 'MISSED_CHECK_OUT') {
+    return '퇴근 기록이 누락된 상태입니다. 자동 체크아웃 또는 사유 확인이 필요합니다.'
+  }
+
+  if (exception.type === 'MISSED_CHECK_IN') {
+    return '근무 일정은 있었지만 출근 기록이 남지 않았습니다.'
+  }
+
+  if (exception.type === 'LATE') {
+    return '예정 출근 시간보다 늦게 체크인해 정산 검토가 필요한 상태입니다.'
+  }
+
+  return '근무 일정 없이 출근 기록이 있어 운영 메모와 정산 판단이 필요합니다.'
+}
+
+export function AttendanceExceptionBoard({
+  date,
+  summary,
+  items,
+  loading,
+  teamOptions,
+  selectedType,
+  selectedStatus,
+  selectedTeamName,
+  actionLoading,
+  bulkLoading,
+  onTypeChange,
+  onStatusChange,
+  onTeamChange,
+  onSaveNote,
+  onApprove,
+  onReject,
+  onResolve,
+  onBulkAutoCheckout,
+}: AttendanceExceptionBoardProps) {
+  const [selectedExceptionId, setSelectedExceptionId] = useState<number | null>(null)
+  const [noteDraft, setNoteDraft] = useState('')
+
+  const selectedException = useMemo(
+    () => items.find((item) => item.id === selectedExceptionId) ?? null,
+    [items, selectedExceptionId],
+  )
+
+  useEffect(() => {
+    if (items.length === 0) {
+      setSelectedExceptionId(null)
+      return
+    }
+
+    if (selectedExceptionId && items.some((item) => item.id === selectedExceptionId)) {
+      return
+    }
+
+    setSelectedExceptionId(items[0].id)
+  }, [items, selectedExceptionId])
+
+  useEffect(() => {
+    setNoteDraft(selectedException?.note ?? '')
+  }, [selectedException])
+
+  const openMissedCheckoutCount = items.filter(
+    (item) => item.type === 'MISSED_CHECK_OUT' && item.status === 'OPEN',
+  ).length
+
+  return (
+    <section className="attendance-exception-board">
+      <SectionHeader
+        eyebrow="Operations"
+        title="출퇴근 예외 처리"
+        description="총무와 팀장이 오늘 운영 이슈를 한 화면에서 보고, 메모와 처리 상태를 바로 남길 수 있습니다."
+        actions={(
+          <button
+            type="button"
+            className="attendance-exception-bulk-btn"
+            onClick={onBulkAutoCheckout}
+            disabled={bulkLoading || openMissedCheckoutCount === 0}
+          >
+            <CheckCheck size={16} />
+            {bulkLoading ? '일괄 처리 중...' : `오늘 미퇴근자 일괄 처리${openMissedCheckoutCount > 0 ? ` (${openMissedCheckoutCount})` : ''}`}
+          </button>
+        )}
+      />
+
+      <div className="attendance-exception-summary-grid">
+        <article className="attendance-exception-summary-card emphasis">
+          <span>처리 대기</span>
+          <strong>{summary?.openCount ?? 0}건</strong>
+          <p>{date} 기준으로 아직 판단이 필요한 예외입니다.</p>
+        </article>
+        <article className="attendance-exception-summary-card">
+          <span>미출근</span>
+          <strong>{summary?.missedCheckInCount ?? 0}건</strong>
+          <p>근무 일정은 있었지만 출근 기록이 없는 인원입니다.</p>
+        </article>
+        <article className="attendance-exception-summary-card">
+          <span>미퇴근</span>
+          <strong>{summary?.missedCheckOutCount ?? 0}건</strong>
+          <p>출근 후 퇴근 기록이 누락된 인원입니다.</p>
+        </article>
+        <article className="attendance-exception-summary-card">
+          <span>지각 / 무일정</span>
+          <strong>{(summary?.lateCount ?? 0) + (summary?.noScheduleCount ?? 0)}건</strong>
+          <p>정산과 운영 메모를 함께 확인해야 하는 예외입니다.</p>
+        </article>
+      </div>
+
+      <div className="attendance-exception-toolbar">
+        <label className="attendance-exception-field">
+          <span>유형 필터</span>
+          <select value={selectedType} onChange={(event) => onTypeChange(event.target.value as AttendanceExceptionTypeFilter)}>
+            {typeOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="attendance-exception-field">
+          <span>상태 필터</span>
+          <select value={selectedStatus} onChange={(event) => onStatusChange(event.target.value as AttendanceExceptionStatusFilter)}>
+            {statusOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="attendance-exception-field">
+          <span>팀 필터</span>
+          <select value={selectedTeamName} onChange={(event) => onTeamChange(event.target.value)}>
+            <option value="">전체 팀</option>
+            {teamOptions.map((teamName) => (
+              <option key={teamName} value={teamName}>
+                {formatTeamName(teamName)}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {loading ? (
+        <EmptyState
+          compact
+          title="출퇴근 예외를 정리하는 중입니다."
+          description="오늘 운영 이슈를 유형별로 묶어 관리자 화면에 준비하고 있습니다."
+        />
+      ) : items.length === 0 ? (
+        <EmptyState
+          compact
+          title="현재 조건에 맞는 출퇴근 예외가 없습니다."
+          description="필터를 바꾸거나, 오늘 기준 예외가 새로 발생하면 이곳에 표시됩니다."
+        />
+      ) : (
+        <div className="attendance-exception-content">
+          <DataTableScroll className="attendance-exception-table-wrap">
+            <table className="attendance-exception-table">
+              <thead>
+                <tr>
+                  <th>유형</th>
+                  <th>멤버</th>
+                  <th>팀</th>
+                  <th>예정</th>
+                  <th>실제</th>
+                  <th>상태</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((exception) => (
+                  <tr
+                    key={exception.id}
+                    className={exception.id === selectedExceptionId ? 'selected' : ''}
+                    onClick={() => setSelectedExceptionId(exception.id)}
+                  >
+                    <td>
+                      <span className={`attendance-exception-pill ${exception.type}`}>
+                        {typeLabels[exception.type]}
+                      </span>
+                    </td>
+                    <td>{exception.memberName}</td>
+                    <td>{formatTeamName(exception.teamName)}</td>
+                    <td>
+                      {formatScheduleTime(exception.scheduledStartTime)} - {formatScheduleTime(exception.scheduledEndTime)}
+                    </td>
+                    <td>
+                      {formatTime(exception.checkInTime)} - {formatTime(exception.checkOutTime)}
+                    </td>
+                    <td>
+                      <span className={`attendance-exception-status ${exception.status}`}>
+                        {statusLabels[exception.status]}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </DataTableScroll>
+
+          {selectedException && (
+            <article className="attendance-exception-detail">
+              <div className="attendance-exception-detail-head">
+                <div>
+                  <span className="attendance-exception-detail-eyebrow">선택한 예외</span>
+                  <h4>{selectedException.memberName} · {typeLabels[selectedException.type]}</h4>
+                  <p>{describeException(selectedException)}</p>
+                </div>
+                <div className={`attendance-exception-status ${selectedException.status}`}>
+                  {statusLabels[selectedException.status]}
+                </div>
+              </div>
+
+              <div className="attendance-exception-detail-meta">
+                <div className="attendance-exception-meta-card">
+                  <ClipboardList size={16} />
+                  <div>
+                    <strong>기록 정보</strong>
+                    <span>{selectedException.workDate} · {formatTeamName(selectedException.teamName)}</span>
+                    <span>예정 {formatScheduleTime(selectedException.scheduledStartTime)} - {formatScheduleTime(selectedException.scheduledEndTime)}</span>
+                    <span>실제 {formatTime(selectedException.checkInTime)} - {formatTime(selectedException.checkOutTime)}</span>
+                  </div>
+                </div>
+                <div className="attendance-exception-meta-card">
+                  <AlertTriangle size={16} />
+                  <div>
+                    <strong>사유 / 처리 이력</strong>
+                    <span>{selectedException.reason || '등록된 사유가 없습니다.'}</span>
+                    <span>
+                      승인 {selectedException.approvedBy ? `${selectedException.approvedBy} · ${selectedException.approvedAt?.slice(0, 16)?.replace('T', ' ')}` : '-'}
+                    </span>
+                    <span>
+                      처리 {selectedException.resolvedBy ? `${selectedException.resolvedBy} · ${selectedException.resolvedAt?.slice(0, 16)?.replace('T', ' ')}` : '-'}
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              <label className="attendance-exception-note-field">
+                <span>
+                  <MessageSquareText size={16} />
+                  운영 메모
+                </span>
+                <textarea
+                  aria-label="출퇴근 예외 메모 입력"
+                  value={noteDraft}
+                  onChange={(event) => setNoteDraft(event.target.value)}
+                  placeholder="예: 동아리 행사 후 퇴근 누락, 사유서 제출 예정"
+                />
+              </label>
+
+              <div className="attendance-exception-actions">
+                <button
+                  type="button"
+                  className="attendance-exception-secondary-btn"
+                  onClick={() => onSaveNote(selectedException.id, noteDraft)}
+                  disabled={actionLoading}
+                >
+                  {actionLoading ? '저장 중...' : '메모 저장'}
+                </button>
+                <button
+                  type="button"
+                  className="attendance-exception-secondary-btn approve"
+                  onClick={() => onApprove(selectedException.id, noteDraft)}
+                  disabled={actionLoading || selectedException.status === 'APPROVED'}
+                >
+                  승인
+                </button>
+                <button
+                  type="button"
+                  className="attendance-exception-secondary-btn reject"
+                  onClick={() => onReject(selectedException.id, noteDraft)}
+                  disabled={actionLoading || selectedException.status === 'REJECTED'}
+                >
+                  반려
+                </button>
+                <button
+                  type="button"
+                  className="attendance-exception-primary-btn"
+                  onClick={() => onResolve(selectedException.id, noteDraft)}
+                  disabled={actionLoading || selectedException.status === 'RESOLVED'}
+                >
+                  {actionLoading ? '처리 중...' : '처리 완료'}
+                </button>
+              </div>
+            </article>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/features/attendance/ui/index.ts
+++ b/src/features/attendance/ui/index.ts
@@ -1,4 +1,5 @@
 export { AnimatedClockRing } from './AnimatedClockRing'
+export { AttendanceExceptionBoard } from './AttendanceExceptionBoard'
 export type { WorkStatus } from './AnimatedClockRing'
 export { ClockTimePicker } from './ClockTimePicker'
 export { SetWorkDaysPersonal } from './SetWorkDaysPersonal'

--- a/src/pages/admin/__tests__/Admin.test.tsx
+++ b/src/pages/admin/__tests__/Admin.test.tsx
@@ -7,6 +7,7 @@ import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
 import { AppProvider, useApp } from '../../../features/auth/model'
 import type { User } from '../../../entities/user/model/types'
+import type { AttendanceException } from '../../../shared/api/attendanceExceptionsApi'
 import { getTodayStr } from '../../../shared/lib/date'
 import { Admin } from '../index'
 
@@ -92,6 +93,93 @@ const mockSettlement = {
 
 const mockTemporaryPassword = 'A1b2C3d4'
 const mockAutoCheckoutTime = '23:59:59'
+const initialAttendanceExceptions: AttendanceException[] = [
+  {
+    id: 1,
+    memberId: 1,
+    memberName: '이서연',
+    teamName: '2팀',
+    workDate: TODAY_STR,
+    type: 'MISSED_CHECK_OUT',
+    status: 'OPEN',
+    note: '행사 정리 후 퇴근 누락',
+    reason: '회의 마감 후 정리',
+    approvedBy: null,
+    approvedAt: null,
+    resolvedBy: null,
+    resolvedAt: null,
+    attendanceRecordId: 1,
+    scheduledStartTime: '09:00:00',
+    scheduledEndTime: '18:00:00',
+    checkInTime: `${TODAY_STR}T09:00:00`,
+    checkOutTime: null,
+  },
+  {
+    id: 2,
+    memberId: 2,
+    memberName: '강민준',
+    teamName: '1팀',
+    workDate: TODAY_STR,
+    type: 'LATE',
+    status: 'OPEN',
+    note: '교통 지연',
+    reason: '지하철 지연',
+    approvedBy: null,
+    approvedAt: null,
+    resolvedBy: null,
+    resolvedAt: null,
+    attendanceRecordId: 2,
+    scheduledStartTime: '09:00:00',
+    scheduledEndTime: '18:00:00',
+    checkInTime: `${TODAY_STR}T09:11:00`,
+    checkOutTime: `${TODAY_STR}T18:03:00`,
+  },
+  {
+    id: 3,
+    memberId: 3,
+    memberName: '김민준',
+    teamName: '1팀',
+    workDate: TODAY_STR,
+    type: 'MISSED_CHECK_IN',
+    status: 'REJECTED',
+    note: '출근 누락 사유 불충분',
+    reason: '개인 전달만 있음',
+    approvedBy: null,
+    approvedAt: null,
+    resolvedBy: null,
+    resolvedAt: null,
+    attendanceRecordId: null,
+    scheduledStartTime: '13:00:00',
+    scheduledEndTime: '18:00:00',
+    checkInTime: null,
+    checkOutTime: null,
+  },
+]
+
+let mockAttendanceExceptions = initialAttendanceExceptions.map((item) => ({ ...item }))
+
+function buildAttendanceExceptionSummary(items: typeof mockAttendanceExceptions, filteredCount: number) {
+  return items.reduce(
+    (summary, item) => ({
+      totalCount: summary.totalCount + 1,
+      filteredCount,
+      openCount: summary.openCount + (item.status === 'OPEN' ? 1 : 0),
+      missedCheckInCount: summary.missedCheckInCount + (item.type === 'MISSED_CHECK_IN' ? 1 : 0),
+      missedCheckOutCount: summary.missedCheckOutCount + (item.type === 'MISSED_CHECK_OUT' ? 1 : 0),
+      lateCount: summary.lateCount + (item.type === 'LATE' ? 1 : 0),
+      noScheduleCount: summary.noScheduleCount + (item.type === 'NO_SCHEDULE' ? 1 : 0),
+    }),
+    {
+      totalCount: 0,
+      filteredCount,
+      openCount: 0,
+      missedCheckInCount: 0,
+      missedCheckOutCount: 0,
+      lateCount: 0,
+      noScheduleCount: 0,
+    },
+  )
+}
 
 const server = setupServer(
   http.get('/api/v1/auth/me', () =>
@@ -187,10 +275,92 @@ const server = setupServer(
       data: { autoCheckoutTime: body.autoCheckoutTime },
     })
   }),
+  http.get('/api/v1/attendance-exceptions', ({ request }) => {
+    const url = new URL(request.url)
+    const type = url.searchParams.get('type')
+    const status = url.searchParams.get('status')
+    const teamName = url.searchParams.get('teamName')
+    const filtered = mockAttendanceExceptions.filter((item) => {
+      if (type && item.type !== type) return false
+      if (status && item.status !== status) return false
+      if (teamName && item.teamName !== teamName) return false
+      return true
+    })
+
+    return HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: {
+        date: TODAY_STR,
+        summary: buildAttendanceExceptionSummary(mockAttendanceExceptions, filtered.length),
+        items: filtered,
+      },
+    })
+  }),
+  http.patch('/api/v1/attendance-exceptions/:id', async ({ params, request }) => {
+    const body = await request.json() as { note?: string }
+    const targetId = Number(params.id)
+    const updated = mockAttendanceExceptions.find((item) => item.id === targetId)
+    if (updated) {
+      updated.note = body.note ?? updated.note
+    }
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: updated })
+  }),
+  http.post('/api/v1/attendance-exceptions/:id/approve', async ({ params, request }) => {
+    const body = await request.json() as { note?: string }
+    const targetId = Number(params.id)
+    const updated = mockAttendanceExceptions.find((item) => item.id === targetId)
+    if (updated) {
+      updated.status = 'APPROVED'
+      updated.note = body.note ?? updated.note
+      updated.approvedBy = '관리자'
+      updated.approvedAt = `${TODAY_STR}T10:00:00`
+    }
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: updated })
+  }),
+  http.post('/api/v1/attendance-exceptions/:id/reject', async ({ params, request }) => {
+    const body = await request.json() as { note?: string }
+    const targetId = Number(params.id)
+    const updated = mockAttendanceExceptions.find((item) => item.id === targetId)
+    if (updated) {
+      updated.status = 'REJECTED'
+      updated.note = body.note ?? updated.note
+    }
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: updated })
+  }),
+  http.post('/api/v1/attendance-exceptions/:id/resolve', async ({ params, request }) => {
+    const body = await request.json() as { note?: string }
+    const targetId = Number(params.id)
+    const updated = mockAttendanceExceptions.find((item) => item.id === targetId)
+    if (updated) {
+      updated.status = 'RESOLVED'
+      updated.note = body.note ?? updated.note
+      updated.resolvedBy = '관리자'
+      updated.resolvedAt = `${TODAY_STR}T10:05:00`
+    }
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: updated })
+  }),
+  http.post('/api/v1/attendance-exceptions/bulk-auto-checkout', () => {
+    const targets = mockAttendanceExceptions.filter((item) => item.type === 'MISSED_CHECK_OUT' && item.status === 'OPEN')
+    for (const target of targets) {
+      target.status = 'RESOLVED'
+      target.checkOutTime = `${TODAY_STR}T${mockAutoCheckoutTime}`
+      target.resolvedBy = '관리자'
+      target.resolvedAt = `${TODAY_STR}T11:00:00`
+    }
+    return HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: { processedCount: targets.length, updatedIds: targets.map((item) => item.id) },
+    })
+  }),
 )
 
 beforeAll(() => server.listen())
-afterEach(() => server.resetHandlers())
+afterEach(() => {
+  server.resetHandlers()
+  mockAttendanceExceptions = initialAttendanceExceptions.map((item) => ({ ...item }))
+})
 afterAll(() => server.close())
 
 function AdminBootstrap({ children }: { children: ReactNode }) {
@@ -335,18 +505,61 @@ describe('Admin 페이지', () => {
   it('출근 현황 탭에 요약 카운트가 표시된다', async () => {
     renderAdmin()
     await waitFor(() => {
-      expect(screen.getByText('근무 중')).toBeInTheDocument()
-      expect(screen.getByText('퇴근')).toBeInTheDocument()
-      expect(screen.getByText('미출근')).toBeInTheDocument()
+      expect(screen.getAllByText('근무 중').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('퇴근').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('미출근').length).toBeGreaterThan(0)
     })
   })
 
   it('출근 현황 탭 기본 필터(근무 중)에 근무 중인 팀원만 표시된다', async () => {
     renderAdmin()
     await waitFor(() => {
-      expect(screen.getByText('이서연')).toBeInTheDocument()
+      expect(screen.getAllByText('이서연').length).toBeGreaterThan(0)
     })
-    expect(screen.queryByText('김민준')).not.toBeInTheDocument()
+    const attendanceSection = screen.getByRole('heading', { name: '팀원 출근 현황' }).closest('.team-attendance-status')
+    expect(attendanceSection).not.toBeNull()
+    expect(within(attendanceSection as HTMLElement).queryByText('김민준')).not.toBeInTheDocument()
+  })
+
+  it('출근 예외 처리 보드에서 오늘 예외 요약과 목록을 확인할 수 있다', async () => {
+    renderAdmin()
+
+    expect(await screen.findByRole('heading', { name: '출퇴근 예외 처리' })).toBeInTheDocument()
+    expect(screen.getAllByText('처리 대기').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('미퇴근').length).toBeGreaterThan(0)
+    expect(screen.getByText('지각 / 무일정')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('행사 정리 후 퇴근 누락')).toBeInTheDocument()
+    })
+  })
+
+  it('출근 예외 처리 보드에서 메모 저장과 승인 액션을 수행할 수 있다', async () => {
+    const user = userEvent.setup()
+    renderAdmin()
+
+    await screen.findByRole('heading', { name: '출퇴근 예외 처리' })
+    await user.click(screen.getByText('강민준'))
+    await user.clear(screen.getByLabelText('출퇴근 예외 메모 입력'))
+    await user.type(screen.getByLabelText('출퇴근 예외 메모 입력'), '교통 이슈 확인 완료')
+    await user.click(screen.getByRole('button', { name: '메모 저장' }))
+
+    expect(await screen.findByText('출퇴근 예외 메모를 저장했습니다')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: '승인' }))
+
+    expect(await screen.findByText('출퇴근 예외를 승인했습니다')).toBeInTheDocument()
+    expect(screen.getAllByText('승인 완료').length).toBeGreaterThan(0)
+  })
+
+  it('출근 예외 처리 보드에서 오늘 미퇴근자를 일괄 처리할 수 있다', async () => {
+    const user = userEvent.setup()
+    renderAdmin()
+
+    await screen.findByRole('heading', { name: '출퇴근 예외 처리' })
+    await user.click(screen.getByRole('button', { name: '오늘 미퇴근자 일괄 처리 (1)' }))
+
+    expect(await screen.findByText('오늘 미퇴근자 1건을 일괄 처리했습니다')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '오늘 미퇴근자 일괄 처리' })).toBeDisabled()
   })
 
   it('감사 로그 탭 클릭 시 로그 테이블이 표시된다', async () => {

--- a/src/pages/admin/__tests__/Admin.test.tsx
+++ b/src/pages/admin/__tests__/Admin.test.tsx
@@ -537,7 +537,7 @@ describe('Admin 페이지', () => {
     const user = userEvent.setup()
     renderAdmin()
 
-    await screen.findByRole('heading', { name: '출퇴근 예외 처리' })
+    await screen.findByDisplayValue('행사 정리 후 퇴근 누락')
     await user.click(screen.getByText('강민준'))
     await user.clear(screen.getByLabelText('출퇴근 예외 메모 입력'))
     await user.type(screen.getByLabelText('출퇴근 예외 메모 입력'), '교통 이슈 확인 완료')
@@ -555,7 +555,7 @@ describe('Admin 페이지', () => {
     const user = userEvent.setup()
     renderAdmin()
 
-    await screen.findByRole('heading', { name: '출퇴근 예외 처리' })
+    await screen.findByRole('button', { name: '오늘 미퇴근자 일괄 처리 (1)' })
     await user.click(screen.getByRole('button', { name: '오늘 미퇴근자 일괄 처리 (1)' }))
 
     expect(await screen.findByText('오늘 미퇴근자 1건을 일괄 처리했습니다')).toBeInTheDocument()

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,9 +1,23 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import { Clock3, Crown, Download, FolderPlus, History, Save, Trash2, Users } from 'lucide-react'
 import { useApp } from '../../features/auth/model'
-import { TeamAttendanceStatus } from '../../features/attendance/ui'
+import { AttendanceExceptionBoard, TeamAttendanceStatus } from '../../features/attendance/ui'
 import { getAttendanceByDate, getAttendanceByDates } from '../../shared/api/attendanceApi'
 import type { AttendanceRecord } from '../../shared/api/attendanceApi'
+import {
+  approveAttendanceException,
+  bulkAutoCheckoutAttendanceExceptions,
+  getAttendanceExceptions,
+  rejectAttendanceException,
+  resolveAttendanceException,
+  updateAttendanceException,
+} from '../../shared/api/attendanceExceptionsApi'
+import type {
+  AttendanceException,
+  AttendanceExceptionStatus,
+  AttendanceExceptionSummary,
+  AttendanceExceptionType,
+} from '../../shared/api/attendanceExceptionsApi'
 import { getMonthlyAttendanceSettlement } from '../../shared/api/attendanceSettlementApi'
 import type { AttendanceSettlement } from '../../shared/api/attendanceSettlementApi'
 import { getAuditLogs } from '../../shared/api/auditLogsApi'
@@ -42,6 +56,8 @@ import './admin.css'
 
 type Tab = 'attendance' | 'members' | 'teams' | 'audit' | 'settlement' | 'settings'
 type SettlementView = 'overall' | 'team' | 'member'
+type AttendanceExceptionTypeFilter = AttendanceExceptionType | 'ALL'
+type AttendanceExceptionStatusFilter = AttendanceExceptionStatus | 'ALL'
 
 const ALL_ROLES: UserRole[] = ['MEMBER', 'TEAM_LEAD', 'ADMIN']
 const roleLabels: Record<string, string> = {
@@ -101,6 +117,14 @@ export function Admin() {
   const { state, loadMembers, refreshMembers, refreshTeams } = useApp()
   const [tab, setTab] = useState<Tab>('attendance')
   const [records, setRecords] = useState<AttendanceRecord[]>([])
+  const [attendanceExceptions, setAttendanceExceptions] = useState<AttendanceException[]>([])
+  const [attendanceExceptionSummary, setAttendanceExceptionSummary] = useState<AttendanceExceptionSummary | null>(null)
+  const [attendanceExceptionLoading, setAttendanceExceptionLoading] = useState(false)
+  const [attendanceExceptionActionLoading, setAttendanceExceptionActionLoading] = useState(false)
+  const [bulkAutoCheckoutLoading, setBulkAutoCheckoutLoading] = useState(false)
+  const [selectedAttendanceExceptionType, setSelectedAttendanceExceptionType] = useState<AttendanceExceptionTypeFilter>('ALL')
+  const [selectedAttendanceExceptionStatus, setSelectedAttendanceExceptionStatus] = useState<AttendanceExceptionStatusFilter>('ALL')
+  const [selectedAttendanceExceptionTeamName, setSelectedAttendanceExceptionTeamName] = useState('')
   const [auditLogs, setAuditLogs] = useState<AuditLog[]>([])
   const [auditLoading, setAuditLoading] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
@@ -128,10 +152,20 @@ export function Admin() {
   const todayStr = getTodayStr()
   const members = useMemo(() => sortUsersByTeamAndName(state.users), [state.users])
   const teamOptions = useMemo(() => getTeamOptions(members, state.teams), [members, state.teams])
+  const activeMembers = useMemo(
+    () => members.filter((member) => member.status !== 'INACTIVE'),
+    [members],
+  )
   const settlementMemberOptions = useMemo(
     () => members.filter((member) => member.status !== 'INACTIVE'),
     [members],
   )
+  const attendanceExceptionTeamOptions = useMemo(() => {
+    const activeTeamNames = new Set(activeMembers.map((member) => member.team))
+    return teamOptions
+      .filter((team) => activeTeamNames.has(team.name))
+      .map((team) => team.name)
+  }, [activeMembers, teamOptions])
   const settlementTeamOptions = useMemo(() => {
     const activeTeamNames = new Set(settlementMemberOptions.map((member) => member.team))
     return teamOptions
@@ -140,10 +174,6 @@ export function Admin() {
   }, [settlementMemberOptions, teamOptions])
   const settlement = settlements.find((item) => String(item.memberId) === selectedSettlementMemberId) ?? null
   const settlementSummary = useMemo(() => rollupAttendanceSettlements(settlements), [settlements])
-  const activeMembers = useMemo(
-    () => members.filter((member) => member.status !== 'INACTIVE'),
-    [members],
-  )
   const activeTeamCount = useMemo(
     () => new Set(activeMembers.map((member) => member.team)).size,
     [activeMembers],
@@ -170,6 +200,12 @@ export function Admin() {
   ).length ?? 0
 
   useEffect(() => {
+    if (!selectedAttendanceExceptionTeamName) return
+    if (attendanceExceptionTeamOptions.includes(selectedAttendanceExceptionTeamName)) return
+    setSelectedAttendanceExceptionTeamName('')
+  }, [attendanceExceptionTeamOptions, selectedAttendanceExceptionTeamName])
+
+  useEffect(() => {
     if (!selectedSettlementMemberId) return
     if (settlementMemberOptions.some((member) => member.id === selectedSettlementMemberId)) return
     setSelectedSettlementMemberId('')
@@ -193,13 +229,46 @@ export function Admin() {
     }
   }
 
-  useEffect(() => {
-    getAttendanceByDate(todayStr)
-      .then((attendanceList) => {
-        setRecords(attendanceList)
-      })
-      .catch((err) => setErrorMessage(err instanceof Error ? err.message : '관리 데이터를 불러오지 못했습니다'))
+  const loadTodayAttendanceRecords = useCallback(async () => {
+    try {
+      const attendanceList = await getAttendanceByDate(todayStr)
+      setRecords(attendanceList)
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '관리 데이터를 불러오지 못했습니다')
+    }
   }, [todayStr])
+
+  const loadAttendanceExceptionList = useCallback(async () => {
+    setAttendanceExceptionLoading(true)
+    try {
+      const response = await getAttendanceExceptions({
+        date: todayStr,
+        type: selectedAttendanceExceptionType,
+        status: selectedAttendanceExceptionStatus,
+        teamName: selectedAttendanceExceptionTeamName || undefined,
+      })
+      setAttendanceExceptions(response.items)
+      setAttendanceExceptionSummary(response.summary)
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '출퇴근 예외 목록을 불러오지 못했습니다')
+    } finally {
+      setAttendanceExceptionLoading(false)
+    }
+  }, [
+    selectedAttendanceExceptionStatus,
+    selectedAttendanceExceptionTeamName,
+    selectedAttendanceExceptionType,
+    todayStr,
+  ])
+
+  useEffect(() => {
+    void loadTodayAttendanceRecords()
+  }, [loadTodayAttendanceRecords])
+
+  useEffect(() => {
+    if (tab !== 'attendance') return
+    void loadAttendanceExceptionList()
+  }, [loadAttendanceExceptionList, tab])
 
   useEffect(() => {
     if (tab !== 'audit') return
@@ -490,6 +559,74 @@ export function Admin() {
     }
   }
 
+  const handleSaveAttendanceExceptionNote = async (exceptionId: number, note: string) => {
+    setAttendanceExceptionActionLoading(true)
+    try {
+      await updateAttendanceException(exceptionId, { note })
+      await loadAttendanceExceptionList()
+      setSuccessMessage('출퇴근 예외 메모를 저장했습니다')
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '출퇴근 예외 메모 저장에 실패했습니다')
+    } finally {
+      setAttendanceExceptionActionLoading(false)
+    }
+  }
+
+  const handleApproveAttendanceException = async (exceptionId: number, note: string) => {
+    setAttendanceExceptionActionLoading(true)
+    try {
+      await approveAttendanceException(exceptionId, { note })
+      await loadAttendanceExceptionList()
+      setSuccessMessage('출퇴근 예외를 승인했습니다')
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '출퇴근 예외 승인에 실패했습니다')
+    } finally {
+      setAttendanceExceptionActionLoading(false)
+    }
+  }
+
+  const handleRejectAttendanceException = async (exceptionId: number, note: string) => {
+    setAttendanceExceptionActionLoading(true)
+    try {
+      await rejectAttendanceException(exceptionId, { note })
+      await loadAttendanceExceptionList()
+      setSuccessMessage('출퇴근 예외를 반려했습니다')
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '출퇴근 예외 반려에 실패했습니다')
+    } finally {
+      setAttendanceExceptionActionLoading(false)
+    }
+  }
+
+  const handleResolveAttendanceException = async (exceptionId: number, note: string) => {
+    setAttendanceExceptionActionLoading(true)
+    try {
+      await resolveAttendanceException(exceptionId, { note })
+      await loadAttendanceExceptionList()
+      setSuccessMessage('출퇴근 예외를 처리 완료로 변경했습니다')
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '출퇴근 예외 처리 완료에 실패했습니다')
+    } finally {
+      setAttendanceExceptionActionLoading(false)
+    }
+  }
+
+  const handleBulkAutoCheckout = async () => {
+    setBulkAutoCheckoutLoading(true)
+    try {
+      const result = await bulkAutoCheckoutAttendanceExceptions({ date: todayStr })
+      await Promise.all([
+        loadAttendanceExceptionList(),
+        loadTodayAttendanceRecords(),
+      ])
+      setSuccessMessage(`오늘 미퇴근자 ${result.processedCount}건을 일괄 처리했습니다`)
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '일괄 자동 체크아웃 처리에 실패했습니다')
+    } finally {
+      setBulkAutoCheckoutLoading(false)
+    }
+  }
+
   const handleAutoCheckoutSave = async () => {
     if (!autoCheckoutTime) return
 
@@ -601,6 +738,26 @@ export function Admin() {
             </article>
           </div>
           <TeamAttendanceStatus members={members} records={records} date={todayStr} />
+          <AttendanceExceptionBoard
+            date={todayStr}
+            summary={attendanceExceptionSummary}
+            items={attendanceExceptions}
+            loading={attendanceExceptionLoading}
+            teamOptions={attendanceExceptionTeamOptions}
+            selectedType={selectedAttendanceExceptionType}
+            selectedStatus={selectedAttendanceExceptionStatus}
+            selectedTeamName={selectedAttendanceExceptionTeamName}
+            actionLoading={attendanceExceptionActionLoading}
+            bulkLoading={bulkAutoCheckoutLoading}
+            onTypeChange={setSelectedAttendanceExceptionType}
+            onStatusChange={setSelectedAttendanceExceptionStatus}
+            onTeamChange={setSelectedAttendanceExceptionTeamName}
+            onSaveNote={(exceptionId, note) => void handleSaveAttendanceExceptionNote(exceptionId, note)}
+            onApprove={(exceptionId, note) => void handleApproveAttendanceException(exceptionId, note)}
+            onReject={(exceptionId, note) => void handleRejectAttendanceException(exceptionId, note)}
+            onResolve={(exceptionId, note) => void handleResolveAttendanceException(exceptionId, note)}
+            onBulkAutoCheckout={() => void handleBulkAutoCheckout()}
+          />
         </div>
       )}
 

--- a/src/shared/api/attendanceExceptionsApi.ts
+++ b/src/shared/api/attendanceExceptionsApi.ts
@@ -1,0 +1,109 @@
+import { baseClient } from './baseClient'
+
+export type AttendanceExceptionType =
+  | 'MISSED_CHECK_IN'
+  | 'MISSED_CHECK_OUT'
+  | 'LATE'
+  | 'NO_SCHEDULE'
+
+export type AttendanceExceptionStatus =
+  | 'OPEN'
+  | 'APPROVED'
+  | 'REJECTED'
+  | 'RESOLVED'
+
+export interface AttendanceException {
+  id: number
+  memberId: number
+  memberName: string
+  teamName: string
+  workDate: string
+  type: AttendanceExceptionType
+  status: AttendanceExceptionStatus
+  note: string | null
+  reason: string | null
+  approvedBy: string | null
+  approvedAt: string | null
+  resolvedBy: string | null
+  resolvedAt: string | null
+  attendanceRecordId: number | null
+  scheduledStartTime: string | null
+  scheduledEndTime: string | null
+  checkInTime: string | null
+  checkOutTime: string | null
+}
+
+export interface AttendanceExceptionSummary {
+  totalCount: number
+  filteredCount: number
+  openCount: number
+  missedCheckInCount: number
+  missedCheckOutCount: number
+  lateCount: number
+  noScheduleCount: number
+}
+
+export interface AttendanceExceptionListResponse {
+  date: string
+  summary: AttendanceExceptionSummary
+  items: AttendanceException[]
+}
+
+export interface AttendanceExceptionQuery {
+  date: string
+  type?: AttendanceExceptionType | 'ALL'
+  status?: AttendanceExceptionStatus | 'ALL'
+  teamName?: string
+}
+
+export interface AttendanceExceptionUpdatePayload {
+  note?: string
+  reason?: string
+}
+
+export interface AttendanceExceptionActionPayload {
+  note?: string
+}
+
+export interface AttendanceExceptionBulkAutoCheckoutPayload {
+  date: string
+  memberIds?: number[]
+}
+
+export interface AttendanceExceptionBulkAutoCheckoutResult {
+  processedCount: number
+  updatedIds: number[]
+}
+
+export const getAttendanceExceptions = ({ date, type, status, teamName }: AttendanceExceptionQuery) => {
+  const params = new URLSearchParams({ date })
+
+  if (type && type !== 'ALL') {
+    params.set('type', type)
+  }
+
+  if (status && status !== 'ALL') {
+    params.set('status', status)
+  }
+
+  if (teamName) {
+    params.set('teamName', teamName)
+  }
+
+  return baseClient.get<AttendanceExceptionListResponse>(`/api/v1/attendance-exceptions?${params.toString()}`)
+}
+
+export const updateAttendanceException = (exceptionId: number, body: AttendanceExceptionUpdatePayload) =>
+  baseClient.patch<AttendanceException>(`/api/v1/attendance-exceptions/${exceptionId}`, body)
+
+export const approveAttendanceException = (exceptionId: number, body: AttendanceExceptionActionPayload = {}) =>
+  baseClient.post<AttendanceException>(`/api/v1/attendance-exceptions/${exceptionId}/approve`, body)
+
+export const rejectAttendanceException = (exceptionId: number, body: AttendanceExceptionActionPayload = {}) =>
+  baseClient.post<AttendanceException>(`/api/v1/attendance-exceptions/${exceptionId}/reject`, body)
+
+export const resolveAttendanceException = (exceptionId: number, body: AttendanceExceptionActionPayload = {}) =>
+  baseClient.post<AttendanceException>(`/api/v1/attendance-exceptions/${exceptionId}/resolve`, body)
+
+export const bulkAutoCheckoutAttendanceExceptions = (body: AttendanceExceptionBulkAutoCheckoutPayload) =>
+  baseClient.post<AttendanceExceptionBulkAutoCheckoutResult>('/api/v1/attendance-exceptions/bulk-auto-checkout', body)

--- a/src/shared/api/mock/handlers/operations.ts
+++ b/src/shared/api/mock/handlers/operations.ts
@@ -1,6 +1,13 @@
 import { http, HttpResponse } from 'msw'
 import type { Leave } from '../../../../entities/leave/model/types'
 import type { AuditLog } from '../../../api/auditLogsApi'
+import type {
+  AttendanceException,
+  AttendanceExceptionListResponse,
+  AttendanceExceptionStatus,
+  AttendanceExceptionSummary,
+  AttendanceExceptionType,
+} from '../../../api/attendanceExceptionsApi'
 import type { AttendanceSettlement } from '../../../api/attendanceSettlementApi'
 import { getAuthMockUserByAuthorization } from './auth'
 
@@ -147,6 +154,89 @@ const mockAuditLogs: AuditLog[] = [
   },
 ]
 
+let mockAttendanceExceptions: AttendanceException[] = [
+  {
+    id: 1,
+    memberId: 2,
+    memberName: '박팀장',
+    teamName: '2팀',
+    workDate: today,
+    type: 'MISSED_CHECK_OUT',
+    status: 'OPEN',
+    note: '스터디룸 정리 후 퇴근 버튼을 누르지 못했습니다.',
+    reason: '행사 마감 후 정리하다가 퇴근 누락',
+    approvedBy: null,
+    approvedAt: null,
+    resolvedBy: null,
+    resolvedAt: null,
+    attendanceRecordId: 201,
+    scheduledStartTime: '09:00:00',
+    scheduledEndTime: '18:00:00',
+    checkInTime: `${today}T09:02:00`,
+    checkOutTime: null,
+  },
+  {
+    id: 2,
+    memberId: 3,
+    memberName: '이멤버',
+    teamName: '3팀',
+    workDate: today,
+    type: 'LATE',
+    status: 'OPEN',
+    note: '교통 지연 사유 확인 필요',
+    reason: '지하철 지연',
+    approvedBy: null,
+    approvedAt: null,
+    resolvedBy: null,
+    resolvedAt: null,
+    attendanceRecordId: 202,
+    scheduledStartTime: '09:00:00',
+    scheduledEndTime: '18:00:00',
+    checkInTime: `${today}T09:14:00`,
+    checkOutTime: `${today}T18:05:00`,
+  },
+  {
+    id: 3,
+    memberId: 4,
+    memberName: '최개발',
+    teamName: '1팀',
+    workDate: today,
+    type: 'NO_SCHEDULE',
+    status: 'APPROVED',
+    note: '행사 준비용 임시 근무로 승인',
+    reason: '신입 OT 준비 지원',
+    approvedBy: '관리자',
+    approvedAt: `${today}T11:20:00`,
+    resolvedBy: null,
+    resolvedAt: null,
+    attendanceRecordId: 203,
+    scheduledStartTime: null,
+    scheduledEndTime: null,
+    checkInTime: `${today}T10:01:00`,
+    checkOutTime: `${today}T16:42:00`,
+  },
+  {
+    id: 4,
+    memberId: 5,
+    memberName: '정보안',
+    teamName: '4팀',
+    workDate: today,
+    type: 'MISSED_CHECK_IN',
+    status: 'OPEN',
+    note: '',
+    reason: '출근 체크를 놓쳤다고 구두 전달',
+    approvedBy: null,
+    approvedAt: null,
+    resolvedBy: null,
+    resolvedAt: null,
+    attendanceRecordId: null,
+    scheduledStartTime: '13:00:00',
+    scheduledEndTime: '18:00:00',
+    checkInTime: null,
+    checkOutTime: null,
+  },
+]
+
 function getUserName(userId: number) {
   if (userId === 1) return '김리더'
   if (userId === 2) return '박팀장'
@@ -222,6 +312,76 @@ function filterTasksByRange(tasks: MockTask[], startDate: string | null, endDate
     if (endDate && task.date > endDate) return false
     return true
   })
+}
+
+function matchesAttendanceExceptionType(type: AttendanceExceptionType | null, targetType: AttendanceExceptionType) {
+  return !type || type === targetType
+}
+
+function matchesAttendanceExceptionStatus(status: AttendanceExceptionStatus | null, targetStatus: AttendanceExceptionStatus) {
+  return !status || status === targetStatus
+}
+
+function buildAttendanceExceptionSummary(items: AttendanceException[], filteredCount: number): AttendanceExceptionSummary {
+  return items.reduce<AttendanceExceptionSummary>(
+    (summary, item) => ({
+      totalCount: summary.totalCount + 1,
+      filteredCount,
+      openCount: summary.openCount + (item.status === 'OPEN' ? 1 : 0),
+      missedCheckInCount: summary.missedCheckInCount + (item.type === 'MISSED_CHECK_IN' ? 1 : 0),
+      missedCheckOutCount: summary.missedCheckOutCount + (item.type === 'MISSED_CHECK_OUT' ? 1 : 0),
+      lateCount: summary.lateCount + (item.type === 'LATE' ? 1 : 0),
+      noScheduleCount: summary.noScheduleCount + (item.type === 'NO_SCHEDULE' ? 1 : 0),
+    }),
+    {
+      totalCount: 0,
+      filteredCount,
+      openCount: 0,
+      missedCheckInCount: 0,
+      missedCheckOutCount: 0,
+      lateCount: 0,
+      noScheduleCount: 0,
+    },
+  )
+}
+
+function filterAttendanceExceptions({
+  date,
+  type,
+  status,
+  teamName,
+}: {
+  date: string
+  type: AttendanceExceptionType | null
+  status: AttendanceExceptionStatus | null
+  teamName: string | null
+}) {
+  const baseItems = mockAttendanceExceptions.filter((item) => item.workDate === date)
+
+  return {
+    baseItems,
+    filteredItems: baseItems.filter((item) => {
+      if (!matchesAttendanceExceptionType(type, item.type)) return false
+      if (!matchesAttendanceExceptionStatus(status, item.status)) return false
+      if (teamName && item.teamName !== teamName) return false
+      return true
+    }),
+  }
+}
+
+function updateAttendanceException(
+  exceptionId: number,
+  updater: (current: AttendanceException) => AttendanceException,
+) {
+  let updated: AttendanceException | null = null
+
+  mockAttendanceExceptions = mockAttendanceExceptions.map((item) => {
+    if (item.id !== exceptionId) return item
+    updated = updater(item)
+    return updated
+  })
+
+  return updated
 }
 
 export const operationsHandlers = [
@@ -370,6 +530,107 @@ export const operationsHandlers = [
       code: 'SUCCESS',
       message: 'ok',
       data: { autoCheckoutTime },
+    })
+  }),
+
+  http.get('/api/v1/attendance-exceptions', ({ request }) => {
+    const url = new URL(request.url)
+    const date = url.searchParams.get('date') ?? today
+    const type = url.searchParams.get('type') as AttendanceExceptionType | null
+    const status = url.searchParams.get('status') as AttendanceExceptionStatus | null
+    const teamName = url.searchParams.get('teamName')
+
+    const { baseItems, filteredItems } = filterAttendanceExceptions({ date, type, status, teamName })
+    const response: AttendanceExceptionListResponse = {
+      date,
+      summary: buildAttendanceExceptionSummary(baseItems, filteredItems.length),
+      items: filteredItems,
+    }
+
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: response })
+  }),
+
+  http.patch('/api/v1/attendance-exceptions/:id', async ({ params, request }) => {
+    const id = Number(params.id)
+    const body = await request.json() as { note?: string; reason?: string }
+    const updated = updateAttendanceException(id, (item) => ({
+      ...item,
+      note: body.note ?? item.note,
+      reason: body.reason ?? item.reason,
+    }))
+
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: updated })
+  }),
+
+  http.post('/api/v1/attendance-exceptions/:id/approve', async ({ params, request }) => {
+    const id = Number(params.id)
+    const body = await request.json() as { note?: string }
+    const updated = updateAttendanceException(id, (item) => ({
+      ...item,
+      status: 'APPROVED',
+      note: body.note ?? item.note,
+      approvedBy: '관리자',
+      approvedAt: new Date().toISOString(),
+    }))
+
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: updated })
+  }),
+
+  http.post('/api/v1/attendance-exceptions/:id/reject', async ({ params, request }) => {
+    const id = Number(params.id)
+    const body = await request.json() as { note?: string }
+    const updated = updateAttendanceException(id, (item) => ({
+      ...item,
+      status: 'REJECTED',
+      note: body.note ?? item.note,
+    }))
+
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: updated })
+  }),
+
+  http.post('/api/v1/attendance-exceptions/:id/resolve', async ({ params, request }) => {
+    const id = Number(params.id)
+    const body = await request.json() as { note?: string }
+    const updated = updateAttendanceException(id, (item) => ({
+      ...item,
+      status: 'RESOLVED',
+      note: body.note ?? item.note,
+      resolvedBy: '관리자',
+      resolvedAt: new Date().toISOString(),
+    }))
+
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: updated })
+  }),
+
+  http.post('/api/v1/attendance-exceptions/bulk-auto-checkout', async ({ request }) => {
+    const body = await request.json() as { date: string; memberIds?: number[] }
+    const targetDate = body.date ?? today
+    const targetMemberIds = new Set(body.memberIds ?? [])
+    const shouldFilterMembers = targetMemberIds.size > 0
+    const updatedIds: number[] = []
+
+    mockAttendanceExceptions = mockAttendanceExceptions.map((item) => {
+      if (item.workDate !== targetDate || item.type !== 'MISSED_CHECK_OUT') return item
+      if (shouldFilterMembers && !targetMemberIds.has(item.memberId)) return item
+
+      updatedIds.push(item.id)
+      return {
+        ...item,
+        status: 'RESOLVED',
+        note: item.note || `자동 체크아웃 기준 ${autoCheckoutTime}로 일괄 처리`,
+        checkOutTime: `${targetDate}T${autoCheckoutTime}`,
+        resolvedBy: '관리자',
+        resolvedAt: new Date().toISOString(),
+      }
+    })
+
+    return HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: {
+        processedCount: updatedIds.length,
+        updatedIds,
+      },
     })
   }),
 


### PR DESCRIPTION
## 작업 내용
- 관리자 `출근 현황` 탭에서 미출근, 미퇴근, 지각, 근무 일정 없음 예외를 한 화면에서 확인하고 처리할 수 있는 예외 처리 보드를 추가했습니다.
- 백엔드 API가 준비되기 전에도 흐름을 끝까지 검토할 수 있도록 출퇴근 예외 처리용 프론트 API 타입과 mock 핸들러를 함께 정리했습니다.
- 다음날까지 남아 보일 수 있던 stale `working` 로컬 상태 복구를 줄여 서버 상태와 어긋나는 출근 표시를 완화했습니다.

## 변경 이유
- 총무와 팀장이 매일 확인하는 운영 pain은 월말 정산보다 `당일 예외 처리`에 더 가깝기 때문에, 운영자 화면 안에서 즉시 판단 가능한 흐름이 먼저 필요했습니다.
- 백엔드 개발과 프론트 개발을 병렬로 진행하려면 mock 기반 UI/테스트가 미리 준비되어 있어야 합니다.
- 기존 `useWorkSession`은 서버에 오늘 기록이 없어도 오래된 localStorage 상태가 남아 잘못 `근무 중`으로 보일 여지가 있었습니다.

## 상세 변경 사항
### 주요 변경
- [x] `attendanceExceptionsApi` 추가 및 관리자 예외 처리용 mock API 구현
- [x] 관리자 `출근 현황` 탭에 예외 요약, 필터, 메모, 승인/반려/처리 완료, 미퇴근 일괄 처리 UI 추가
- [x] `useWorkSession`의 stale local 상태 복구 방지 로직 보강
- [x] 관리자/출퇴근 훅 회귀 테스트 추가

### 추가 메모
- 현재 예외 처리 API는 프론트 계약과 mock 기준으로 먼저 준비한 상태이며, 백엔드 완료 후 응답 shape만 맞추면 바로 교체할 수 있습니다.
- `.claude/`는 이 브랜치에서도 전체 ignore 되도록 정리했습니다.

## 테스트
- [x] `npm run test:run -- src/pages/admin/__tests__/Admin.test.tsx src/features/attendance/model/__tests__/useWorkSession.test.ts`
- [x] `npm run build`

## 리뷰 포인트
- 관리자 `출근 현황` 탭 안에 예외 처리 보드를 함께 두는 흐름이 실제 운영 동선에 자연스러운지 확인 부탁드립니다.
- 예외 처리 액션 범위를 v1 기준으로 `메모 / 승인 / 반려 / 처리 완료 / 미퇴근 일괄 처리`까지만 둔 것이 적절한지 봐주세요.
- 백엔드 예외 처리 API가 들어올 때 현재 프론트 계약 이름과 상태 모델을 그대로 가져가도 되는지 검토 부탁드립니다.

## 관련 이슈
- closes #343