### PR TITLE
[fix] #345 - 마이페이지 섹션 메뉴와 본문 간격 조정

### DIFF
--- a/src/pages/settings/settings.css
+++ b/src/pages/settings/settings.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   gap: 24px;
   width: 100%;
-  max-width: var(--page-max-wide);
+  max-width: 1320px;
   margin: 0 auto;
 }
 
@@ -71,10 +71,10 @@
 
 .settings-layout {
   display: grid;
-  grid-template-columns: clamp(220px, 18vw, 260px) minmax(0, 940px);
-  gap: 24px;
+  grid-template-columns: clamp(188px, 15vw, 220px) minmax(0, 1fr);
+  gap: 14px;
   align-items: start;
-  justify-content: space-between;
+  justify-content: start;
 }
 
 .settings-nav {
@@ -117,6 +117,8 @@
   border-radius: 24px;
   padding: clamp(28px, 2vw, 34px);
   min-width: 0;
+  width: 100%;
+  max-width: 980px;
   display: flex;
   flex-direction: column;
   gap: 24px;
@@ -299,8 +301,8 @@
   }
 
   .settings-layout {
-    grid-template-columns: clamp(240px, 17vw, 280px) minmax(0, 980px);
-    gap: 28px;
+    grid-template-columns: clamp(196px, 14vw, 228px) minmax(0, 1fr);
+    gap: 16px;
   }
 }
 


### PR DESCRIPTION
## 작업 내용
- 마이페이지에서 왼쪽 섹션 메뉴와 오른쪽 본문이 지나치게 벌어져 보이던 레이아웃을 조정했습니다.
- 메뉴 폭, 본문 최대폭, 컬럼 간격을 함께 다듬어 섹션 선택과 본문이 하나의 설정 화면처럼 읽히도록 정리했습니다.

## 변경 이유
- 데스크톱 화면에서 마이페이지 섹션 메뉴와 본문 카드가 너무 멀리 떨어져 있어 시선 이동이 길고 사용감이 어색했습니다.
- 보안/정산 같은 폼 중심 화면은 운영 페이지보다 더 압축된 읽기 폭이 적합한데, 기존 레이아웃은 초광폭 페이지 기준이라 설정 화면 맥락과 맞지 않았습니다.

## 상세 변경 사항
### 주요 변경
- [x] 마이페이지 전체 최대폭을 줄여 초광폭 배치 완화
- [x] 섹션 메뉴 컬럼 폭과 본문 컬럼 gap 축소
- [x] 본문 카드 최대폭을 제한해 왼쪽 메뉴와 시각적으로 더 가깝게 정렬

### 추가 메모
- 모바일/태블릿 구간의 단일 컬럼 반응형 규칙은 그대로 유지했습니다.
- 변경 범위는 `src/pages/settings/settings.css` 한 파일입니다.

## 테스트
- [x] `npm run test:run`
- [x] `npm run build`

## 리뷰 포인트
- 데스크톱에서 마이페이지 섹션 메뉴와 본문 카드가 이전보다 자연스럽게 한 덩어리처럼 보이는지 확인 부탁드립니다.
- 보안/정산 탭처럼 폼과 표가 섞인 화면에서도 읽기 폭이 과하게 넓지 않은지 봐주세요.

## 관련 이슈
- closes #345
