### PR TITLE
[fix] #352 - 날짜별 근무 일정 모달 종료 날짜 범위 반영

### DIFF
--- a/src/pages/work-schedules/__tests__/WorkSchedules.test.tsx
+++ b/src/pages/work-schedules/__tests__/WorkSchedules.test.tsx
@@ -166,8 +166,38 @@ describe('WorkSchedules 페이지', () => {
 
     await waitFor(() => {
       expect(screen.getByText('날짜별 근무 일정 추가')).toBeInTheDocument()
-      expect(document.querySelector('input[type="date"]')).not.toBeNull()
+      expect(screen.getByLabelText('시작 날짜')).toBeInTheDocument()
+      expect(screen.getByLabelText('종료 날짜')).toBeInTheDocument()
       expect(screen.getByRole('checkbox')).toBeInTheDocument()
     })
+  })
+
+  it('다음날 종료를 켜면 종료 날짜가 다음날로 바뀌고 끄면 같은 날로 돌아온다', async () => {
+    render(<WorkSchedules />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '날짜별 일정 추가' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: '날짜별 일정 추가' }))
+
+    const startDateInput = await screen.findByLabelText('시작 날짜')
+    const endDateInput = screen.getByLabelText('종료 날짜')
+    const overnightCheckbox = screen.getByRole('checkbox')
+
+    expect(startDateInput).toHaveValue('2026-04-21')
+    expect(endDateInput).toHaveValue('2026-04-21')
+
+    fireEvent.click(overnightCheckbox)
+    expect(endDateInput).toHaveValue('2026-04-22')
+
+    fireEvent.click(overnightCheckbox)
+    expect(endDateInput).toHaveValue('2026-04-21')
+
+    fireEvent.change(startDateInput, { target: { value: '2026-05-03' } })
+    expect(endDateInput).toHaveValue('2026-05-03')
+
+    fireEvent.click(overnightCheckbox)
+    expect(endDateInput).toHaveValue('2026-05-04')
   })
 })

--- a/src/pages/work-schedules/index.tsx
+++ b/src/pages/work-schedules/index.tsx
@@ -129,6 +129,19 @@ function formatTimeLabel(time: string) {
   return time.slice(0, 5)
 }
 
+function getEndDate(date: string, endsNextDay: boolean) {
+  if (!endsNextDay) return date
+  return toIsoDate(addDays(new Date(`${date}T12:00:00`), 1))
+}
+
+function formatDateLabel(date: string) {
+  return new Intl.DateTimeFormat('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date(`${date}T12:00:00`))
+}
+
 function getEventColors(kind: 'recurring' | 'date-event', isMine: boolean) {
   if (kind === 'date-event') {
     return isMine
@@ -490,6 +503,18 @@ export function WorkSchedules() {
     return '근무 일정 상세'
   }, [modalState])
 
+  const modalEndDate = useMemo(
+    () => (modalState ? getEndDate(modalState.date, modalState.endsNextDay) : ''),
+    [modalState],
+  )
+
+  const modalDateRangeLabel = useMemo(() => {
+    if (!modalState) return ''
+    const startDateLabel = formatDateLabel(modalState.date)
+    if (!modalState.endsNextDay) return `${startDateLabel} 하루 일정`
+    return `${startDateLabel} ~ ${formatDateLabel(modalEndDate)}`
+  }, [modalEndDate, modalState])
+
   return (
     <div className="work-schedules-page">
       {errorMessage && (
@@ -659,7 +684,7 @@ export function WorkSchedules() {
             <div className="work-schedules-modal-header">
               <div>
                 <h3>{modalTitle}</h3>
-                <p>{modalState.date}</p>
+                <p>{modalDateRangeLabel}</p>
               </div>
               <button type="button" className="work-schedules-modal-close" onClick={() => setModalState(null)}>
                 닫기
@@ -719,16 +744,22 @@ export function WorkSchedules() {
             {modalState.mode !== 'detail' && (
               <>
                 <div className="work-schedules-modal-form">
-                  <label className="work-schedules-modal-field">
-                    <span>날짜</span>
-                    <input
-                      type="date"
-                      value={modalState.date}
-                      onChange={(event) =>
-                        setModalState((prev) => (prev ? { ...prev, date: event.target.value } : prev))
-                      }
-                    />
-                  </label>
+                  <div className="work-schedules-modal-date-range">
+                    <label className="work-schedules-modal-field">
+                      <span>시작 날짜</span>
+                      <input
+                        type="date"
+                        value={modalState.date}
+                        onChange={(event) =>
+                          setModalState((prev) => (prev ? { ...prev, date: event.target.value } : prev))
+                        }
+                      />
+                    </label>
+                    <label className="work-schedules-modal-field">
+                      <span>종료 날짜</span>
+                      <input type="date" value={modalEndDate} readOnly />
+                    </label>
+                  </div>
                   <label className="work-schedules-modal-field">
                     <span>출근 시간</span>
                     <TimeInput
@@ -751,7 +782,7 @@ export function WorkSchedules() {
                     <span>
                       <strong>다음날 종료</strong>
                       <small>
-                        야간 근무처럼 자정을 넘기는 일정이면 켜 주세요.
+                        야간 근무처럼 자정을 넘기는 일정이면 종료 날짜가 다음날로 자동 설정됩니다.
                       </small>
                     </span>
                     <input

--- a/src/pages/work-schedules/work-schedules.css
+++ b/src/pages/work-schedules/work-schedules.css
@@ -445,6 +445,12 @@
   gap: 8px;
 }
 
+.work-schedules-modal-date-range {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
 .work-schedules-detail-item strong,
 .work-schedules-modal-field span {
   font-size: 0.82rem;
@@ -490,6 +496,11 @@
   flex-shrink: 0;
 }
 
+.work-schedules-modal-field input[readonly] {
+  color: var(--text-secondary);
+  cursor: default;
+}
+
 .work-schedules-modal-actions {
   display: flex;
   align-items: center;
@@ -516,6 +527,10 @@
   .work-schedules-toolbar,
   .work-schedules-calendar-meta {
     gap: 12px;
+  }
+
+  .work-schedules-modal-date-range {
+    grid-template-columns: 1fr;
   }
 
   .work-schedules-select {


### PR DESCRIPTION
## 작업 내용
- 날짜별 근무 일정 모달에서 `시작 날짜`와 `종료 날짜`를 함께 보이도록 정리했습니다.
- `다음날 종료`를 켜면 종료 날짜가 자동으로 다음날로 바뀌고, 끄면 다시 시작 날짜와 같은 날로 돌아오게 맞췄습니다.
- 모달 상단 설명도 단일 날짜가 아니라 실제 날짜 범위로 읽히도록 정리했습니다.
- 관련 UI 테스트를 추가했습니다.

## 변경 이유
- 현재 모달은 `date + endsNextDay`로 저장되더라도 화면상으로는 단일 날짜처럼 보여, 야간 근무 일정이 직관적으로 읽히지 않았습니다.
- 사용자가 `다음날 종료`를 켰을 때 실제로 어떤 날짜 범위로 저장되는지 즉시 이해할 수 있어야 합니다.

## 상세 변경 사항
### 주요 변경
- [x] 날짜별 근무 일정 모달에 시작 날짜/종료 날짜 필드 추가
- [x] `다음날 종료` 토글 상태에 따라 종료 날짜 자동 계산 반영
- [x] 모달 헤더의 날짜 문구를 범위 기준으로 변경
- [x] 관련 테스트 추가

### 추가 메모
- 저장 계약은 기존 `date + endsNextDay`를 그대로 유지하고, 화면에서만 날짜 범위를 명확하게 보여주는 방식으로 정리했습니다.

## 테스트
- [x] `npm run test:run -- src/pages/work-schedules/__tests__/WorkSchedules.test.tsx`
- [x] `npm run build`

## 리뷰 포인트
- `다음날 종료`를 켠 상태에서 종료 날짜가 즉시 다음날로 바뀌는 흐름이 자연스러운지 확인 부탁드립니다.
- 단일 날짜 일정과 야간 일정이 같은 모달 구조 안에서 충분히 구분되는지 봐주세요.

## 관련 이슈
- closes #352