### PR TITLE
[fix] #355 - 자정 넘긴 출근 기록 초기화 날짜 기준 수정

### DIFF
--- a/src/features/attendance/model/__tests__/useWorkSession.test.ts
+++ b/src/features/attendance/model/__tests__/useWorkSession.test.ts
@@ -13,6 +13,10 @@ const CLOCK_OUT_RECORD = {
   id: 1, memberId: 1, memberName: '테스터',
   workDate: '2026-03-22', checkInTime: '2026-03-22T09:00:00', checkOutTime: '2026-03-22T18:00:00', status: 'LEFT',
 }
+const OVERNIGHT_CLOCK_OUT_RECORD = {
+  id: 2, memberId: 1, memberName: '테스터',
+  workDate: '2026-03-21', checkInTime: '2026-03-21T23:00:00', checkOutTime: '2026-03-22T01:00:00', status: 'LEFT',
+}
 
 const server = setupServer(
   http.get('/api/v1/attendances/me', () =>
@@ -146,6 +150,29 @@ describe('useWorkSession', () => {
       expect(result.current.clockIn).toBeNull()
       expect(result.current.clockOut).toBeNull()
       expect(result.current.errorMessage).toBe('오늘 출근 기록을 초기화했습니다')
+    })
+
+    it('자정 넘겨 퇴근한 기록은 실제 workDate로 초기화 요청을 보낸다', async () => {
+      let requestedDate: string | null = null
+
+      server.use(
+        http.post('/api/v1/attendances/check-out', () =>
+          HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: OVERNIGHT_CLOCK_OUT_RECORD }),
+        ),
+        http.delete('/api/v1/attendances/me', ({ request }) => {
+          const url = new URL(request.url)
+          requestedDate = url.searchParams.get('date')
+          return new HttpResponse(null, { status: 200 })
+        }),
+      )
+
+      const { result } = await mountHook()
+      await act(async () => { await result.current.handleClockClick() })
+      await act(async () => { await result.current.handleClockClick() })
+      await act(async () => { await result.current.handleClockClick() })
+
+      expect(requestedDate).toBe('2026-03-21')
+      expect(result.current.status).toBe('idle')
     })
   })
 

--- a/src/features/attendance/model/useWorkSession.ts
+++ b/src/features/attendance/model/useWorkSession.ts
@@ -37,6 +37,7 @@ export function useWorkSession() {
   const [status, setStatus] = useState<WorkStatus>('idle')
   const [clockIn, setClockIn] = useState<Date | null>(null)
   const [clockOut, setClockOut] = useState<Date | null>(null)
+  const [attendanceDate, setAttendanceDate] = useState<string | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [toastType, setToastType] = useState<'error' | 'info'>('error')
   const [isLoading, setIsLoading] = useState(true)
@@ -50,6 +51,7 @@ export function useWorkSession() {
       setStatus('idle')
       setClockIn(null)
       setClockOut(null)
+      setAttendanceDate(null)
       return null
     }
 
@@ -57,12 +59,14 @@ export function useWorkSession() {
       setStatus('done')
       setClockIn(todayRecord.checkInTime ? new Date(todayRecord.checkInTime) : null)
       setClockOut(todayRecord.checkOutTime ? new Date(todayRecord.checkOutTime) : null)
+      setAttendanceDate(todayRecord.workDate)
       return todayRecord
     }
 
     setStatus('working')
     setClockIn(todayRecord.checkInTime ? new Date(todayRecord.checkInTime) : null)
     setClockOut(null)
+    setAttendanceDate(todayRecord.workDate)
     return todayRecord
   }
 
@@ -117,6 +121,7 @@ export function useWorkSession() {
         const record = await apiClockIn()
         setClockIn(record.checkInTime ? new Date(record.checkInTime) : new Date())
         setClockOut(null)
+        setAttendanceDate(record.workDate)
         setStatus('working')
       } catch (err) {
         if (err instanceof ApiError) {
@@ -144,6 +149,7 @@ export function useWorkSession() {
       try {
         const record = await apiClockOut()
         setClockOut(record.checkOutTime ? new Date(record.checkOutTime) : new Date())
+        setAttendanceDate(record.workDate)
         setStatus('done')
       } catch (err) {
         if (err instanceof ApiError) {
@@ -156,6 +162,7 @@ export function useWorkSession() {
             setStatus('idle')
             setClockIn(null)
             setClockOut(null)
+            setAttendanceDate(null)
             setToastType('error')
             setErrorMessage(err.message)
           } else {
@@ -172,11 +179,12 @@ export function useWorkSession() {
     } else if (status === 'done') {
       setIsLoading(true)
       try {
-        await resetMyAttendance(getTodayStr())
+        await resetMyAttendance(attendanceDate ?? getTodayStr())
         setToastType('info')
         setErrorMessage('오늘 출근 기록을 초기화했습니다')
         setClockIn(null)
         setClockOut(null)
+        setAttendanceDate(null)
         setStatus('idle')
       } catch (err) {
         if (err instanceof ApiError) {
@@ -185,6 +193,7 @@ export function useWorkSession() {
             setErrorMessage('초기화할 출근 기록이 없습니다')
             setClockIn(null)
             setClockOut(null)
+            setAttendanceDate(null)
             setStatus('idle')
           } else {
             setToastType('error')


### PR DESCRIPTION
## 작업 내용
- 출근 기록 초기화 시 항상 오늘 날짜를 보내던 흐름을 실제 출근 기록의 `workDate` 기준으로 보내도록 수정했습니다.
- 자정 넘겨 퇴근한 기록도 같은 기준으로 초기화되도록 `useWorkSession` 상태를 보강했습니다.
- 야간 근무 회귀 테스트를 추가했습니다.

## 변경 이유
- 백엔드는 `DELETE /api/v1/attendances/me?date=...`로 받은 날짜를 그대로 `workDate` 조회에 사용합니다.
- 프론트가 초기화 시 항상 오늘 날짜를 보내고 있어, 자정 넘겨 퇴근한 기록처럼 `workDate`가 전날인 경우 초기화가 실패했습니다.

## 상세 변경 사항
### 주요 변경
- [x] `useWorkSession`에서 현재 출근 기록의 `workDate` 추적
- [x] 초기화 요청 시 실제 출근 기록 날짜 사용
- [x] 자정 넘긴 퇴근 기록 초기화 회귀 테스트 추가

### 추가 메모
- 백엔드 `AttendanceController.resetAttendance()`와 `AttendanceService.resetAttendance()`는 전달받은 날짜 기준으로 삭제하므로, 이번 수정은 프론트-백엔드 계약 불일치를 맞추는 성격입니다.

## 테스트
- [x] `npm run test:run -- src/features/attendance/model/__tests__/useWorkSession.test.ts`
- [x] `npm run build`

## 리뷰 포인트
- 자정 넘긴 퇴근 직후에도 초기화가 정상 동작하는지 확인 부탁드립니다.
- 일반 주간 근무 출근/퇴근/초기화 흐름이 기존과 동일한지 봐주세요.

## 관련 이슈
- closes #355