### PR TITLE
release: v1.0.4

### DIFF
--- a/src/features/attendance/model/__tests__/useWorkSession.test.ts
+++ b/src/features/attendance/model/__tests__/useWorkSession.test.ts
@@ -13,6 +13,10 @@ const CLOCK_OUT_RECORD = {
   id: 1, memberId: 1, memberName: '테스터',
   workDate: '2026-03-22', checkInTime: '2026-03-22T09:00:00', checkOutTime: '2026-03-22T18:00:00', status: 'LEFT',
 }
+const OVERNIGHT_CLOCK_OUT_RECORD = {
+  id: 2, memberId: 1, memberName: '테스터',
+  workDate: '2026-03-21', checkInTime: '2026-03-21T23:00:00', checkOutTime: '2026-03-22T01:00:00', status: 'LEFT',
+}
 
 const server = setupServer(
   http.get('/api/v1/attendances/me', () =>
@@ -146,6 +150,29 @@ describe('useWorkSession', () => {
       expect(result.current.clockIn).toBeNull()
       expect(result.current.clockOut).toBeNull()
       expect(result.current.errorMessage).toBe('오늘 출근 기록을 초기화했습니다')
+    })
+
+    it('자정 넘겨 퇴근한 기록은 실제 workDate로 초기화 요청을 보낸다', async () => {
+      let requestedDate: string | null = null
+
+      server.use(
+        http.post('/api/v1/attendances/check-out', () =>
+          HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: OVERNIGHT_CLOCK_OUT_RECORD }),
+        ),
+        http.delete('/api/v1/attendances/me', ({ request }) => {
+          const url = new URL(request.url)
+          requestedDate = url.searchParams.get('date')
+          return new HttpResponse(null, { status: 200 })
+        }),
+      )
+
+      const { result } = await mountHook()
+      await act(async () => { await result.current.handleClockClick() })
+      await act(async () => { await result.current.handleClockClick() })
+      await act(async () => { await result.current.handleClockClick() })
+
+      expect(requestedDate).toBe('2026-03-21')
+      expect(result.current.status).toBe('idle')
     })
   })
 

--- a/src/features/attendance/model/useWorkSession.ts
+++ b/src/features/attendance/model/useWorkSession.ts
@@ -37,6 +37,7 @@ export function useWorkSession() {
   const [status, setStatus] = useState<WorkStatus>('idle')
   const [clockIn, setClockIn] = useState<Date | null>(null)
   const [clockOut, setClockOut] = useState<Date | null>(null)
+  const [attendanceDate, setAttendanceDate] = useState<string | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [toastType, setToastType] = useState<'error' | 'info'>('error')
   const [isLoading, setIsLoading] = useState(true)
@@ -50,6 +51,7 @@ export function useWorkSession() {
       setStatus('idle')
       setClockIn(null)
       setClockOut(null)
+      setAttendanceDate(null)
       return null
     }
 
@@ -57,12 +59,14 @@ export function useWorkSession() {
       setStatus('done')
       setClockIn(todayRecord.checkInTime ? new Date(todayRecord.checkInTime) : null)
       setClockOut(todayRecord.checkOutTime ? new Date(todayRecord.checkOutTime) : null)
+      setAttendanceDate(todayRecord.workDate)
       return todayRecord
     }
 
     setStatus('working')
     setClockIn(todayRecord.checkInTime ? new Date(todayRecord.checkInTime) : null)
     setClockOut(null)
+    setAttendanceDate(todayRecord.workDate)
     return todayRecord
   }
 
@@ -117,6 +121,7 @@ export function useWorkSession() {
         const record = await apiClockIn()
         setClockIn(record.checkInTime ? new Date(record.checkInTime) : new Date())
         setClockOut(null)
+        setAttendanceDate(record.workDate)
         setStatus('working')
       } catch (err) {
         if (err instanceof ApiError) {
@@ -144,6 +149,7 @@ export function useWorkSession() {
       try {
         const record = await apiClockOut()
         setClockOut(record.checkOutTime ? new Date(record.checkOutTime) : new Date())
+        setAttendanceDate(record.workDate)
         setStatus('done')
       } catch (err) {
         if (err instanceof ApiError) {
@@ -156,6 +162,7 @@ export function useWorkSession() {
             setStatus('idle')
             setClockIn(null)
             setClockOut(null)
+            setAttendanceDate(null)
             setToastType('error')
             setErrorMessage(err.message)
           } else {
@@ -172,11 +179,12 @@ export function useWorkSession() {
     } else if (status === 'done') {
       setIsLoading(true)
       try {
-        await resetMyAttendance(getTodayStr())
+        await resetMyAttendance(attendanceDate ?? getTodayStr())
         setToastType('info')
         setErrorMessage('오늘 출근 기록을 초기화했습니다')
         setClockIn(null)
         setClockOut(null)
+        setAttendanceDate(null)
         setStatus('idle')
       } catch (err) {
         if (err instanceof ApiError) {
@@ -185,6 +193,7 @@ export function useWorkSession() {
             setErrorMessage('초기화할 출근 기록이 없습니다')
             setClockIn(null)
             setClockOut(null)
+            setAttendanceDate(null)
             setStatus('idle')
           } else {
             setToastType('error')

--- a/src/pages/work-schedules/__tests__/WorkSchedules.test.tsx
+++ b/src/pages/work-schedules/__tests__/WorkSchedules.test.tsx
@@ -58,6 +58,15 @@ vi.mock('../../../shared/api/attendanceApi', () => ({
 
 import { WorkSchedules } from '../index'
 
+function addDays(date: string, days: number) {
+  const next = new Date(`${date}T12:00:00`)
+  next.setDate(next.getDate() + days)
+  const year = next.getFullYear()
+  const month = String(next.getMonth() + 1).padStart(2, '0')
+  const day = String(next.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
 describe('WorkSchedules 페이지', () => {
   beforeEach(() => {
     mockState = {
@@ -184,15 +193,16 @@ describe('WorkSchedules 페이지', () => {
     const startDateInput = await screen.findByLabelText('시작 날짜')
     const endDateInput = screen.getByLabelText('종료 날짜')
     const overnightCheckbox = screen.getByRole('checkbox')
+    const initialDate = (startDateInput as HTMLInputElement).value
 
-    expect(startDateInput).toHaveValue('2026-04-21')
-    expect(endDateInput).toHaveValue('2026-04-21')
-
-    fireEvent.click(overnightCheckbox)
-    expect(endDateInput).toHaveValue('2026-04-22')
+    expect(startDateInput).toHaveValue(initialDate)
+    expect(endDateInput).toHaveValue(initialDate)
 
     fireEvent.click(overnightCheckbox)
-    expect(endDateInput).toHaveValue('2026-04-21')
+    expect(endDateInput).toHaveValue(addDays(initialDate, 1))
+
+    fireEvent.click(overnightCheckbox)
+    expect(endDateInput).toHaveValue(initialDate)
 
     fireEvent.change(startDateInput, { target: { value: '2026-05-03' } })
     expect(endDateInput).toHaveValue('2026-05-03')


### PR DESCRIPTION
## 작업 내용
- develop 브랜치의 최신 변경 사항을 main에 반영하는 `v1.0.4` 배포 PR입니다.
- 이번 배포에는 자정 넘긴 출근 기록 초기화 날짜 기준 수정과 `WorkSchedules` 날짜 테스트 안정화가 포함됩니다.
- 야간 근무처럼 `workDate`가 전날인 출근 기록도 초기화가 정상 동작하고, 날짜별 일정 테스트도 실행일과 무관하게 통과하는 최신 develop 상태를 배포합니다.

## 변경 이유
- 백엔드는 초기화 요청의 `date`를 그대로 `workDate` 조회에 사용합니다.
- 프론트가 항상 오늘 날짜를 보내고 있어, 자정 넘겨 퇴근한 기록은 초기화가 실패하는 계약 불일치가 있었습니다.
- 추가로 `WorkSchedules` 테스트가 고정된 날짜 문자열을 기대하고 있어 GitHub Actions 실행일이 바뀌면 CI가 실패하고 있었습니다.

## 상세 변경 사항
### 주요 변경
- [x] 초기화 요청 시 실제 출근 기록의 `workDate` 사용
- [x] `useWorkSession` 상태에 출근 기록 날짜 추적 추가
- [x] 자정 넘긴 퇴근 기록 초기화 회귀 테스트 추가
- [x] `WorkSchedules` 날짜별 일정 테스트의 오늘 날짜 하드코딩 제거

### 추가 메모
- 일반 주간 근무 흐름은 그대로 유지하고, 야간 근무/자정 넘김 케이스만 보정한 좁은 범위 수정입니다.
- 날짜별 일정 테스트는 실행 시점의 기본 날짜를 기준으로 검증하도록 바꿔 CI/로컬 모두 안정적으로 통과하게 맞췄습니다.

## 테스트
- [x] `npm run test:run -- src/features/attendance/model/__tests__/useWorkSession.test.ts`
- [x] `npm run test:run -- src/pages/work-schedules/__tests__/WorkSchedules.test.tsx`
- [x] `npm run build`

## 리뷰 포인트
- 자정 넘긴 퇴근 직후에도 초기화가 정상 동작하는지 확인 부탁드립니다.
- 일반 출근/퇴근/초기화 흐름이 기존과 동일한지 봐주세요.
- 날짜별 일정 추가 모달 테스트가 실행일과 무관하게 안정적으로 유지되는지 봐주세요.

## 관련 이슈
- closes #355
- closes #358