### PR TITLE
[test] #358 - WorkSchedules 날짜 테스트의 오늘 날짜 의존 제거

### DIFF
--- a/src/pages/work-schedules/__tests__/WorkSchedules.test.tsx
+++ b/src/pages/work-schedules/__tests__/WorkSchedules.test.tsx
@@ -58,6 +58,15 @@ vi.mock('../../../shared/api/attendanceApi', () => ({
 
 import { WorkSchedules } from '../index'
 
+function addDays(date: string, days: number) {
+  const next = new Date(`${date}T12:00:00`)
+  next.setDate(next.getDate() + days)
+  const year = next.getFullYear()
+  const month = String(next.getMonth() + 1).padStart(2, '0')
+  const day = String(next.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
 describe('WorkSchedules 페이지', () => {
   beforeEach(() => {
     mockState = {
@@ -184,15 +193,16 @@ describe('WorkSchedules 페이지', () => {
     const startDateInput = await screen.findByLabelText('시작 날짜')
     const endDateInput = screen.getByLabelText('종료 날짜')
     const overnightCheckbox = screen.getByRole('checkbox')
+    const initialDate = (startDateInput as HTMLInputElement).value
 
-    expect(startDateInput).toHaveValue('2026-04-21')
-    expect(endDateInput).toHaveValue('2026-04-21')
-
-    fireEvent.click(overnightCheckbox)
-    expect(endDateInput).toHaveValue('2026-04-22')
+    expect(startDateInput).toHaveValue(initialDate)
+    expect(endDateInput).toHaveValue(initialDate)
 
     fireEvent.click(overnightCheckbox)
-    expect(endDateInput).toHaveValue('2026-04-21')
+    expect(endDateInput).toHaveValue(addDays(initialDate, 1))
+
+    fireEvent.click(overnightCheckbox)
+    expect(endDateInput).toHaveValue(initialDate)
 
     fireEvent.change(startDateInput, { target: { value: '2026-05-03' } })
     expect(endDateInput).toHaveValue('2026-05-03')


### PR DESCRIPTION
## 작업 내용
- `WorkSchedules` 날짜별 일정 테스트에서 오늘 날짜 하드코딩을 제거했습니다.
- 테스트가 실행 시점의 기본 날짜를 기준으로 다음날 종료 동작을 검증하도록 수정했습니다.

## 변경 이유
- GitHub Actions에서 현재 날짜가 바뀌면 테스트가 고정된 `2026-04-21`을 기대해 실패하고 있었습니다.
- 날짜에 독립적인 검증으로 바꿔 CI/로컬 모두 안정적으로 통과하도록 맞췄습니다.

## 테스트
- `npm run test:run -- src/pages/work-schedules/__tests__/WorkSchedules.test.tsx`
- `npm run build`

## 관련 이슈
- closes #358