### PR TITLE
[fix] #360 - 출근 기록 초기화 ATTENDANCE_NOT_FOUND 처리 보완

### DIFF
--- a/src/features/attendance/model/__tests__/useWorkSession.test.ts
+++ b/src/features/attendance/model/__tests__/useWorkSession.test.ts
@@ -174,6 +174,27 @@ describe('useWorkSession', () => {
       expect(requestedDate).toBe('2026-03-21')
       expect(result.current.status).toBe('idle')
     })
+
+    it('초기화 시 ATTENDANCE_NOT_FOUND도 기록 없음으로 처리한다', async () => {
+      server.use(
+        http.delete('/api/v1/attendances/me', () =>
+          HttpResponse.json(
+            { code: 'ATTENDANCE_NOT_FOUND', message: '출근 기록을 찾을 수 없습니다.', data: null },
+            { status: 404 },
+          ),
+        ),
+      )
+
+      const { result } = await mountHook()
+      await act(async () => { await result.current.handleClockClick() })
+      await act(async () => { await result.current.handleClockClick() })
+      await act(async () => { await result.current.handleClockClick() })
+
+      expect(result.current.status).toBe('idle')
+      expect(result.current.clockIn).toBeNull()
+      expect(result.current.clockOut).toBeNull()
+      expect(result.current.errorMessage).toBe('초기화할 출근 기록이 없습니다')
+    })
   })
 
   describe('localStorage', () => {

--- a/src/features/attendance/model/useWorkSession.ts
+++ b/src/features/attendance/model/useWorkSession.ts
@@ -188,7 +188,7 @@ export function useWorkSession() {
         setStatus('idle')
       } catch (err) {
         if (err instanceof ApiError) {
-          if (err.code === 'NOT_CHECKED_IN') {
+          if (err.code === 'NOT_CHECKED_IN' || err.code === 'ATTENDANCE_NOT_FOUND') {
             setToastType('info')
             setErrorMessage('초기화할 출근 기록이 없습니다')
             setClockIn(null)


### PR DESCRIPTION
## 작업 내용
- `useWorkSession`에서 초기화 요청 실패 코드 `ATTENDANCE_NOT_FOUND`를 `NOT_CHECKED_IN`과 동일하게 처리합니다.
- 백엔드가 기록 없음 상황에서 404 `ATTENDANCE_NOT_FOUND`를 반환해도 사용자에겐 "초기화할 출근 기록이 없습니다"로 안내하고 상태를 `idle`로 정리합니다.

## 변경 이유
- 백엔드 `resetAttendance`는 기록이 없을 때 `ATTENDANCE_NOT_FOUND`를 반환합니다.
- 프론트는 `NOT_CHECKED_IN`만 특별 처리하고 있어, 없는 기록 초기화 시 사용자 흐름이 일관되지 않았습니다.

## 테스트
- `npm run test:run -- src/features/attendance/model/__tests__/useWorkSession.test.ts`
- `npm run build`

## 관련 이슈
- closes #360