### PR TITLE
release: v1.0.5

### DIFF
--- a/src/features/attendance/model/__tests__/useWorkSession.test.ts
+++ b/src/features/attendance/model/__tests__/useWorkSession.test.ts
@@ -174,6 +174,27 @@ describe('useWorkSession', () => {
       expect(requestedDate).toBe('2026-03-21')
       expect(result.current.status).toBe('idle')
     })
+
+    it('초기화 시 ATTENDANCE_NOT_FOUND도 기록 없음으로 처리한다', async () => {
+      server.use(
+        http.delete('/api/v1/attendances/me', () =>
+          HttpResponse.json(
+            { code: 'ATTENDANCE_NOT_FOUND', message: '출근 기록을 찾을 수 없습니다.', data: null },
+            { status: 404 },
+          ),
+        ),
+      )
+
+      const { result } = await mountHook()
+      await act(async () => { await result.current.handleClockClick() })
+      await act(async () => { await result.current.handleClockClick() })
+      await act(async () => { await result.current.handleClockClick() })
+
+      expect(result.current.status).toBe('idle')
+      expect(result.current.clockIn).toBeNull()
+      expect(result.current.clockOut).toBeNull()
+      expect(result.current.errorMessage).toBe('초기화할 출근 기록이 없습니다')
+    })
   })
 
   describe('localStorage', () => {

--- a/src/features/attendance/model/useWorkSession.ts
+++ b/src/features/attendance/model/useWorkSession.ts
@@ -188,7 +188,7 @@ export function useWorkSession() {
         setStatus('idle')
       } catch (err) {
         if (err instanceof ApiError) {
-          if (err.code === 'NOT_CHECKED_IN') {
+          if (err.code === 'NOT_CHECKED_IN' || err.code === 'ATTENDANCE_NOT_FOUND') {
             setToastType('info')
             setErrorMessage('초기화할 출근 기록이 없습니다')
             setClockIn(null)


### PR DESCRIPTION
## 작업 내용
- develop 브랜치의 최신 변경 사항을 main에 반영하는 `v1.0.5` 배포 PR입니다.
- 이번 배포에는 출근 기록 초기화 시 `ATTENDANCE_NOT_FOUND` 응답을 기록 없음 흐름으로 처리하는 프론트 보완이 포함됩니다.
- 백엔드의 초기화 삭제 보완과 함께, 없는 기록 초기화 시 사용자 상태가 `idle`로 정리되도록 계약을 맞췄습니다.

## 변경 이유
- 백엔드 `resetAttendance`는 출근 기록이 없을 때 `ATTENDANCE_NOT_FOUND`를 반환합니다.
- 프론트는 `NOT_CHECKED_IN`만 특별 처리하고 있어, 초기화 재시도나 중복 조작 시 사용자 흐름이 일관되지 않았습니다.

## 상세 변경 사항
### 주요 변경
- [x] 초기화 요청에서 `ATTENDANCE_NOT_FOUND`를 `기록 없음` 흐름으로 처리
- [x] 관련 회귀 테스트 추가

### 추가 메모
- 기존 `NOT_CHECKED_IN` 처리 방식은 유지하고, 없는 기록 초기화 응답만 같은 UX로 묶었습니다.
- 앱 코드 외 로컬 문서 변경은 이번 배포 범위에 포함하지 않았습니다.

## 테스트
- [x] `npm run test:run -- src/features/attendance/model/__tests__/useWorkSession.test.ts`
- [x] `npm run build`

## 리뷰 포인트
- 출근 기록이 이미 없어진 상태에서 초기화 버튼을 눌러도 에러 대신 안내 메시지로 정리되는지 확인 부탁드립니다.
- 일반 출근/퇴근/초기화 흐름이 기존과 동일한지 함께 봐주세요.

## 관련 이슈
- closes #360