### PR TITLE
[design] #363 - 날짜별 근무 일정 모달 범위 인지 개선

### DIFF
--- a/src/pages/work-schedules/__tests__/WorkSchedules.test.tsx
+++ b/src/pages/work-schedules/__tests__/WorkSchedules.test.tsx
@@ -175,6 +175,8 @@ describe('WorkSchedules 페이지', () => {
 
     await waitFor(() => {
       expect(screen.getByText('날짜별 근무 일정 추가')).toBeInTheDocument()
+      expect(screen.getByText('일정 범위')).toBeInTheDocument()
+      expect(screen.getByText('당일 근무')).toBeInTheDocument()
       expect(screen.getByLabelText('시작 날짜')).toBeInTheDocument()
       expect(screen.getByLabelText('종료 날짜')).toBeInTheDocument()
       expect(screen.getByRole('checkbox')).toBeInTheDocument()
@@ -200,6 +202,8 @@ describe('WorkSchedules 페이지', () => {
 
     fireEvent.click(overnightCheckbox)
     expect(endDateInput).toHaveValue(addDays(initialDate, 1))
+    expect(screen.getByText('다음날까지 이어지는 근무')).toBeInTheDocument()
+    expect(screen.getByText('18:00 · 다음날')).toBeInTheDocument()
 
     fireEvent.click(overnightCheckbox)
     expect(endDateInput).toHaveValue(initialDate)

--- a/src/pages/work-schedules/index.tsx
+++ b/src/pages/work-schedules/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { CalendarDays, Pencil, Plus, Trash2, UserRound, Users } from 'lucide-react'
+import { ArrowRight, CalendarDays, Pencil, Plus, Trash2, UserRound, Users } from 'lucide-react'
 import FullCalendar from '@fullcalendar/react'
 import dayGridPlugin from '@fullcalendar/daygrid'
 import interactionPlugin from '@fullcalendar/interaction'
@@ -744,6 +744,32 @@ export function WorkSchedules() {
             {modalState.mode !== 'detail' && (
               <>
                 <div className="work-schedules-modal-form">
+                  <div
+                    className={`work-schedules-modal-range-preview${
+                      modalState.endsNextDay ? ' overnight' : ''
+                    }`}
+                  >
+                    <div className="work-schedules-modal-range-heading">
+                      <span>일정 범위</span>
+                      <strong>{modalState.endsNextDay ? '다음날까지 이어지는 근무' : '당일 근무'}</strong>
+                    </div>
+                    <div className="work-schedules-modal-range-flow">
+                      <div className="work-schedules-modal-range-node">
+                        <span>시작</span>
+                        <strong>{formatDateLabel(modalState.date)}</strong>
+                        <small>{modalState.startTime}</small>
+                      </div>
+                      <ArrowRight className="work-schedules-modal-range-icon" size={18} aria-hidden="true" />
+                      <div className="work-schedules-modal-range-node">
+                        <span>종료</span>
+                        <strong>{formatDateLabel(modalEndDate)}</strong>
+                        <small>
+                          {modalState.endTime}
+                          {modalState.endsNextDay ? ' · 다음날' : ''}
+                        </small>
+                      </div>
+                    </div>
+                  </div>
                   <div className="work-schedules-modal-date-range">
                     <label className="work-schedules-modal-field">
                       <span>시작 날짜</span>
@@ -778,7 +804,7 @@ export function WorkSchedules() {
                       }
                     />
                   </label>
-                  <label className="work-schedules-modal-toggle">
+                  <label className={`work-schedules-modal-toggle${modalState.endsNextDay ? ' active' : ''}`}>
                     <span>
                       <strong>다음날 종료</strong>
                       <small>

--- a/src/pages/work-schedules/work-schedules.css
+++ b/src/pages/work-schedules/work-schedules.css
@@ -402,7 +402,7 @@
 }
 
 .work-schedules-modal {
-  width: min(560px, 100%);
+  width: min(620px, 100%);
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -445,6 +445,86 @@
   gap: 8px;
 }
 
+.work-schedules-modal-range-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px;
+  border-radius: 20px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 82%, var(--accent-purple));
+  background:
+    radial-gradient(circle at 14% 18%, color-mix(in srgb, var(--accent-purple) 18%, transparent), transparent 36%),
+    color-mix(in srgb, var(--surface-muted) 78%, transparent);
+}
+
+.work-schedules-modal-range-preview.overnight {
+  border-color: color-mix(in srgb, var(--accent-purple) 62%, var(--border-color));
+  background:
+    radial-gradient(circle at 12% 18%, color-mix(in srgb, var(--accent-purple) 28%, transparent), transparent 38%),
+    linear-gradient(135deg, color-mix(in srgb, var(--accent-purple) 16%, var(--surface-muted)), var(--surface-muted));
+}
+
+.work-schedules-modal-range-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.work-schedules-modal-range-heading span {
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.work-schedules-modal-range-heading strong {
+  color: var(--text-primary);
+  font-size: 0.86rem;
+}
+
+.work-schedules-modal-range-flow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: stretch;
+  gap: 12px;
+}
+
+.work-schedules-modal-range-node {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  padding: 12px;
+  border-radius: 16px;
+  border: 1px solid var(--border-color);
+  background: color-mix(in srgb, var(--bg-card) 76%, transparent);
+}
+
+.work-schedules-modal-range-node span {
+  color: var(--text-secondary);
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.work-schedules-modal-range-node strong {
+  color: var(--text-primary);
+  font-size: 0.96rem;
+  white-space: nowrap;
+}
+
+.work-schedules-modal-range-node small {
+  color: var(--accent-purple);
+  font-size: 1.18rem;
+  font-weight: 800;
+}
+
+.work-schedules-modal-range-icon {
+  align-self: center;
+  color: var(--text-secondary);
+}
+
 .work-schedules-modal-date-range {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -470,6 +550,13 @@
   border-radius: 16px;
   border: 1px solid var(--border-color);
   background: color-mix(in srgb, var(--surface-muted) 72%, transparent);
+  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.work-schedules-modal-toggle.active {
+  border-color: color-mix(in srgb, var(--accent-purple) 68%, var(--border-color));
+  background: color-mix(in srgb, var(--accent-purple) 14%, var(--surface-muted));
+  box-shadow: 0 14px 34px color-mix(in srgb, var(--accent-purple) 14%, transparent);
 }
 
 .work-schedules-modal-toggle span {
@@ -531,6 +618,20 @@
 
   .work-schedules-modal-date-range {
     grid-template-columns: 1fr;
+  }
+
+  .work-schedules-modal-range-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .work-schedules-modal-range-flow {
+    grid-template-columns: 1fr;
+  }
+
+  .work-schedules-modal-range-icon {
+    justify-self: center;
+    transform: rotate(90deg);
   }
 
   .work-schedules-select {


### PR DESCRIPTION
## 작업 내용
- 날짜별 근무 일정 모달 상단에 `일정 범위` 프리뷰를 추가했습니다.
- 당일/다음날 종료 상태에 따라 시작일, 종료일, 출근/퇴근 시간이 즉시 비교되도록 정리했습니다.
- `다음날 종료` 토글 활성 상태를 더 명확한 카드 톤과 테두리로 강조했습니다.
- 모달 폭과 반응형 레이아웃을 보정해 날짜 범위 입력이 답답하게 보이지 않도록 다듬었습니다.

## 변경 이유
- 시작 날짜와 종료 날짜 필드만으로는 사용자가 실제 저장 범위를 한눈에 읽기 어려웠습니다.
- 야간 근무처럼 다음날까지 이어지는 일정은 등록 실수가 운영 비용으로 바로 이어지므로, 저장 전 범위 인지를 더 강하게 만들어야 합니다.

## 테스트
- [x] `npm run test:run -- src/pages/work-schedules/__tests__/WorkSchedules.test.tsx`
- [x] `npm run build`
- [x] `npx eslint src/pages/work-schedules/index.tsx src/pages/work-schedules/__tests__/WorkSchedules.test.tsx`
- [x] 로컬 mock 화면에서 당일/다음날 종료 모달 시각 검증

## 참고
- `npm run lint`는 현재 레포에 포함된 `.claude/skill/gstack/**` 및 기존 React hook/refresh 룰 위반으로 실패합니다. 이번 변경 파일 대상 eslint는 통과했습니다.
- 로컬의 `docs/guides/git-conventions.md` 변경은 사용자 작업으로 보이며 이번 PR에 포함하지 않았습니다.

## 관련 이슈
- closes #363