### PR TITLE
release: v1.0.6

### DIFF
--- a/src/pages/admin/admin.css
+++ b/src/pages/admin/admin.css
@@ -758,6 +758,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 20px;
+  overflow-y: auto;
   z-index: 1000;
   backdrop-filter: blur(4px);
 }
@@ -772,6 +774,9 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
+  max-height: calc(100vh - 40px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .admin-modal h3 {

--- a/src/pages/calendar/calendar.css
+++ b/src/pages/calendar/calendar.css
@@ -322,6 +322,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 20px;
+  overflow-y: auto;
   z-index: 200;
 }
 
@@ -333,6 +335,9 @@
   width: min(480px, calc(100vw - 32px));
   max-width: calc(100vw - 32px);
   min-width: 0;
+  max-height: calc(100vh - 40px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
   box-shadow: var(--shadow-strong);
 }
 

--- a/src/pages/chat/chat.css
+++ b/src/pages/chat/chat.css
@@ -613,6 +613,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 20px;
+  overflow-y: auto;
   z-index: 1000;
 }
 
@@ -620,6 +622,9 @@
   padding: 24px;
   min-width: 320px;
   border-radius: 12px;
+  max-height: calc(100vh - 40px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .link-modal h4 {

--- a/src/pages/dashboard/dashboard.css
+++ b/src/pages/dashboard/dashboard.css
@@ -553,6 +553,7 @@
   align-items: center;
   justify-content: center;
   padding: 20px;
+  overflow-y: auto;
   background: rgba(10, 14, 32, 0.52);
   z-index: 1200;
 }
@@ -564,6 +565,9 @@
   display: flex;
   flex-direction: column;
   gap: 18px;
+  max-height: calc(100vh - 40px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .dashboard-detail-head,

--- a/src/pages/members/members.css
+++ b/src/pages/members/members.css
@@ -415,6 +415,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 20px;
+  overflow-y: auto;
   z-index: 1000;
 }
 
@@ -422,6 +424,9 @@
   padding: 28px;
   max-width: 420px;
   width: 90%;
+  max-height: calc(100vh - 40px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .change-role-modal h3 {
@@ -517,6 +522,9 @@
   border-radius: 16px;
   min-width: 360px;
   max-width: 480px;
+  max-height: calc(100vh - 40px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .modal-header-row {

--- a/src/pages/team-management/team-management.css
+++ b/src/pages/team-management/team-management.css
@@ -164,6 +164,7 @@
   align-items: center;
   justify-content: center;
   padding: 20px;
+  overflow-y: auto;
   background: rgba(10, 14, 32, 0.46);
   z-index: 1200;
 }
@@ -175,6 +176,9 @@
   display: flex;
   flex-direction: column;
   gap: 18px;
+  max-height: calc(100vh - 40px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .team-management-modal h3,

--- a/src/pages/work-schedules/__tests__/WorkSchedules.test.tsx
+++ b/src/pages/work-schedules/__tests__/WorkSchedules.test.tsx
@@ -175,6 +175,8 @@ describe('WorkSchedules 페이지', () => {
 
     await waitFor(() => {
       expect(screen.getByText('날짜별 근무 일정 추가')).toBeInTheDocument()
+      expect(screen.getByText('일정 범위')).toBeInTheDocument()
+      expect(screen.getByText('당일 근무')).toBeInTheDocument()
       expect(screen.getByLabelText('시작 날짜')).toBeInTheDocument()
       expect(screen.getByLabelText('종료 날짜')).toBeInTheDocument()
       expect(screen.getByRole('checkbox')).toBeInTheDocument()
@@ -200,6 +202,8 @@ describe('WorkSchedules 페이지', () => {
 
     fireEvent.click(overnightCheckbox)
     expect(endDateInput).toHaveValue(addDays(initialDate, 1))
+    expect(screen.getByText('다음날까지 이어지는 근무')).toBeInTheDocument()
+    expect(screen.getByText('18:00 · 다음날')).toBeInTheDocument()
 
     fireEvent.click(overnightCheckbox)
     expect(endDateInput).toHaveValue(initialDate)

--- a/src/pages/work-schedules/index.tsx
+++ b/src/pages/work-schedules/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { CalendarDays, Pencil, Plus, Trash2, UserRound, Users } from 'lucide-react'
+import { ArrowRight, CalendarDays, Pencil, Plus, Trash2, UserRound, Users } from 'lucide-react'
 import FullCalendar from '@fullcalendar/react'
 import dayGridPlugin from '@fullcalendar/daygrid'
 import interactionPlugin from '@fullcalendar/interaction'
@@ -744,6 +744,32 @@ export function WorkSchedules() {
             {modalState.mode !== 'detail' && (
               <>
                 <div className="work-schedules-modal-form">
+                  <div
+                    className={`work-schedules-modal-range-preview${
+                      modalState.endsNextDay ? ' overnight' : ''
+                    }`}
+                  >
+                    <div className="work-schedules-modal-range-heading">
+                      <span>일정 범위</span>
+                      <strong>{modalState.endsNextDay ? '다음날까지 이어지는 근무' : '당일 근무'}</strong>
+                    </div>
+                    <div className="work-schedules-modal-range-flow">
+                      <div className="work-schedules-modal-range-node">
+                        <span>시작</span>
+                        <strong>{formatDateLabel(modalState.date)}</strong>
+                        <small>{modalState.startTime}</small>
+                      </div>
+                      <ArrowRight className="work-schedules-modal-range-icon" size={18} aria-hidden="true" />
+                      <div className="work-schedules-modal-range-node">
+                        <span>종료</span>
+                        <strong>{formatDateLabel(modalEndDate)}</strong>
+                        <small>
+                          {modalState.endTime}
+                          {modalState.endsNextDay ? ' · 다음날' : ''}
+                        </small>
+                      </div>
+                    </div>
+                  </div>
                   <div className="work-schedules-modal-date-range">
                     <label className="work-schedules-modal-field">
                       <span>시작 날짜</span>
@@ -778,7 +804,7 @@ export function WorkSchedules() {
                       }
                     />
                   </label>
-                  <label className="work-schedules-modal-toggle">
+                  <label className={`work-schedules-modal-toggle${modalState.endsNextDay ? ' active' : ''}`}>
                     <span>
                       <strong>다음날 종료</strong>
                       <small>

--- a/src/pages/work-schedules/work-schedules.css
+++ b/src/pages/work-schedules/work-schedules.css
@@ -402,7 +402,7 @@
 }
 
 .work-schedules-modal {
-  width: min(560px, 100%);
+  width: min(620px, 100%);
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -445,6 +445,86 @@
   gap: 8px;
 }
 
+.work-schedules-modal-range-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px;
+  border-radius: 20px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 82%, var(--accent-purple));
+  background:
+    radial-gradient(circle at 14% 18%, color-mix(in srgb, var(--accent-purple) 18%, transparent), transparent 36%),
+    color-mix(in srgb, var(--surface-muted) 78%, transparent);
+}
+
+.work-schedules-modal-range-preview.overnight {
+  border-color: color-mix(in srgb, var(--accent-purple) 62%, var(--border-color));
+  background:
+    radial-gradient(circle at 12% 18%, color-mix(in srgb, var(--accent-purple) 28%, transparent), transparent 38%),
+    linear-gradient(135deg, color-mix(in srgb, var(--accent-purple) 16%, var(--surface-muted)), var(--surface-muted));
+}
+
+.work-schedules-modal-range-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.work-schedules-modal-range-heading span {
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.work-schedules-modal-range-heading strong {
+  color: var(--text-primary);
+  font-size: 0.86rem;
+}
+
+.work-schedules-modal-range-flow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: stretch;
+  gap: 12px;
+}
+
+.work-schedules-modal-range-node {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  padding: 12px;
+  border-radius: 16px;
+  border: 1px solid var(--border-color);
+  background: color-mix(in srgb, var(--bg-card) 76%, transparent);
+}
+
+.work-schedules-modal-range-node span {
+  color: var(--text-secondary);
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.work-schedules-modal-range-node strong {
+  color: var(--text-primary);
+  font-size: 0.96rem;
+  white-space: nowrap;
+}
+
+.work-schedules-modal-range-node small {
+  color: var(--accent-purple);
+  font-size: 1.18rem;
+  font-weight: 800;
+}
+
+.work-schedules-modal-range-icon {
+  align-self: center;
+  color: var(--text-secondary);
+}
+
 .work-schedules-modal-date-range {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -470,6 +550,13 @@
   border-radius: 16px;
   border: 1px solid var(--border-color);
   background: color-mix(in srgb, var(--surface-muted) 72%, transparent);
+  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.work-schedules-modal-toggle.active {
+  border-color: color-mix(in srgb, var(--accent-purple) 68%, var(--border-color));
+  background: color-mix(in srgb, var(--accent-purple) 14%, var(--surface-muted));
+  box-shadow: 0 14px 34px color-mix(in srgb, var(--accent-purple) 14%, transparent);
 }
 
 .work-schedules-modal-toggle span {
@@ -531,6 +618,20 @@
 
   .work-schedules-modal-date-range {
     grid-template-columns: 1fr;
+  }
+
+  .work-schedules-modal-range-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .work-schedules-modal-range-flow {
+    grid-template-columns: 1fr;
+  }
+
+  .work-schedules-modal-range-icon {
+    justify-self: center;
+    transform: rotate(90deg);
   }
 
   .work-schedules-select {

--- a/src/pages/work-schedules/work-schedules.css
+++ b/src/pages/work-schedules/work-schedules.css
@@ -399,6 +399,7 @@
   align-items: center;
   justify-content: center;
   padding: 20px;
+  overflow-y: auto;
 }
 
 .work-schedules-modal {
@@ -408,6 +409,9 @@
   gap: 20px;
   padding: 24px;
   border-radius: 24px;
+  max-height: calc(100vh - 40px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .work-schedules-modal-header {


### PR DESCRIPTION
## 작업 내용
- develop 브랜치의 최신 변경 사항을 main에 반영하는 `v1.0.6` 배포 PR입니다.
- 이번 배포에는 날짜별 근무 일정 모달의 디자인 리뷰 보정과 전체 페이지/모달 디자인 QA 보강이 포함됩니다.
- 당일/다음날 종료 일정의 실제 시작·종료 범위를 등록 전 바로 읽을 수 있도록 최신 develop 상태를 배포합니다.
- 주요 모달이 작은 화면이나 긴 콘텐츠에서도 하단 액션을 잃지 않도록 뷰포트 안전성을 보강했습니다.

## 변경 이유
- 날짜별 근무 일정 모달은 시작/종료 날짜 필드가 있어도 실제 저장 범위가 즉시 눈에 들어오지 않았습니다.
- 야간 근무처럼 다음날까지 이어지는 일정은 운영자가 날짜를 잘못 해석하면 등록 실수로 이어질 수 있어, 범위 인지를 더 강하게 보강했습니다.
- 전체 화면 디자인 QA 중 여러 모달 계열이 화면 높이가 낮을 때 하단 버튼이 잘릴 수 있는 구조라, overlay 스크롤과 modal 최대 높이 규칙을 통일했습니다.

## 상세 변경 사항
### 주요 변경
- [x] 날짜별 근무 일정 모달에 `일정 범위` 프리뷰 추가
- [x] 당일/다음날 종료 상태에 따라 시작일, 종료일, 출근/퇴근 시간 비교 표시
- [x] `다음날 종료` 토글 활성 상태 시각 강조
- [x] 모달 폭과 모바일 레이아웃 보정
- [x] 채팅, 캘린더, 대시보드, 멤버, 관리자, 팀 관리, 근무 일정 모달에 뷰포트 안전 규칙 적용
- [x] 관련 UI 테스트 갱신 및 전체 디자인 QA 화면 점검

### 추가 메모
- 앱 코드 외 로컬 문서 변경은 이번 배포 범위에 포함하지 않았습니다.
- develop 머지는 사용자 지침에 따라 CI 대기 없이 완료했고, main PR은 머지하지 않고 열어둡니다.

## 테스트
- [x] `npm run test:run -- src/pages/work-schedules/__tests__/WorkSchedules.test.tsx`
- [x] `npm run test:run -- src/pages/admin/__tests__/Admin.test.tsx src/pages/calendar/__tests__ src/pages/chat/__tests__/Chat.test.tsx src/pages/dashboard/__tests__/Dashboard.test.tsx src/pages/members/__tests__/Members.test.tsx src/pages/team-management/__tests__/TeamManagement.test.tsx src/pages/work-schedules/__tests__/WorkSchedules.test.tsx`
- [x] `npm run build`
- [x] `npx eslint src/pages/work-schedules/index.tsx src/pages/work-schedules/__tests__/WorkSchedules.test.tsx`
- [x] 로컬 mock 화면에서 당일/다음날 종료 모달 시각 검증
- [x] 전체 주요 페이지 및 모달 수동 디자인 QA

## 참고
- `npm run lint`는 현재 레포에 포함된 `.claude/skill/gstack/**` 및 기존 React hook/refresh 룰 위반으로 실패합니다. 이번 변경 파일 대상 eslint는 통과했습니다.

## 리뷰 포인트
- 날짜별 근무 일정 모달에서 범위 프리뷰가 등록 실수를 줄일 만큼 충분히 눈에 띄는지 확인 부탁드립니다.
- `다음날 종료` 활성 상태가 기존 디자인 톤 안에서 과하지 않게 구분되는지 봐주세요.
- 전체 모달에서 작은 화면일 때 스크롤/하단 액션 접근성이 자연스러운지 확인 부탁드립니다.

## 관련 이슈
- #363
- #366