### PR TITLE
[QA] #371 - 지각 정산 야간근무 반영 검증

### DIFF
--- a/docs/troubleshooting/attendance-exceptions.md
+++ b/docs/troubleshooting/attendance-exceptions.md
@@ -64,6 +64,26 @@
 
 ---
 
+## 야간 근무가 지각 정산 합산에서 빠지는지 확인
+
+### 증상
+
+- 개인 정산 화면에서 `22:00 ~ 다음날 06:00` 근무가 단일 날짜 근무처럼 보인다.
+- 관리자 전체/팀 정산의 지각 분, 지각비 합산이 야간 지각 항목을 포함하는지 확신하기 어렵다.
+
+### 원인
+
+- 정산 응답은 `scheduledStartTime`, `scheduledEndTime`만으로는 종료일을 표현할 수 없다.
+- 화면이나 mock이 `scheduledStartAt`, `scheduledEndAt`을 무시하면 `06:00`이 당일 종료처럼 보인다.
+
+### 해결
+
+- 정산 항목도 예외 처리와 동일하게 `endsNextDay`, `scheduledStartAt`, `scheduledEndAt`을 유지한다.
+- 개인 설정 정산, 관리자 전체/팀/개인 정산 모두 `formatScheduleRangeLabel`로 `22:00 - 다음날 06:00`을 표시한다.
+- 회귀 테스트: `src/pages/settings/__tests__/Settings.test.tsx`, `src/pages/admin/__tests__/Admin.test.tsx`, `src/shared/lib/__tests__/attendanceSettlement.test.ts`에서 야간 지각 8분/800원 항목을 확인한다.
+
+---
+
 ## 로컬 mock QA 체크리스트
 
 - `.env.local`에 `VITE_USE_MOCK=true`를 설정한다.
@@ -71,4 +91,4 @@
 - `22:00 - 다음날 06:00` 미퇴근 항목이 보이는지 확인한다.
 - 메모 저장, 승인, 반려, 처리 완료를 각각 실행한다.
 - `오늘 미퇴근자 일괄 처리` 후 실제 시간이 `22:02 - 06:00`처럼 다음날 종료 시각으로 표시되는지 확인한다.
-
+- 지각비 정산에서 야간 지각 항목이 개인/팀/전체 합산에 포함되는지 확인한다.

--- a/src/pages/admin/__tests__/Admin.test.tsx
+++ b/src/pages/admin/__tests__/Admin.test.tsx
@@ -17,6 +17,8 @@ tomorrowDate.setDate(tomorrowDate.getDate() + 1)
 const TOMORROW_STR = toDateString(tomorrowDate)
 const CURRENT_YEAR_MONTH = TODAY_STR.slice(0, 7)
 const CURRENT_LATE_DATE = `${CURRENT_YEAR_MONTH}-04`
+const CURRENT_OVERNIGHT_DATE = `${CURRENT_YEAR_MONTH}-07`
+const CURRENT_OVERNIGHT_END_DATE = `${CURRENT_YEAR_MONTH}-08`
 const CURRENT_NO_SCHEDULE_DATE = `${CURRENT_YEAR_MONTH}-18`
 
 const mockMembers = [
@@ -77,18 +79,34 @@ const mockSettlement = {
   teamName: '1팀',
   scheduledDays: 12,
   attendedDays: 11,
-  lateDays: 3,
-  totalLateMinutes: 27,
-  lateFee: 2700,
+  lateDays: 2,
+  totalLateMinutes: 15,
+  lateFee: 1500,
   items: [
     {
       date: CURRENT_LATE_DATE,
       scheduledStartTime: '09:00:00',
       scheduledEndTime: '18:00:00',
+      endsNextDay: false,
+      scheduledStartAt: `${CURRENT_LATE_DATE}T09:00:00`,
+      scheduledEndAt: `${CURRENT_LATE_DATE}T18:00:00`,
       checkInTime: `${CURRENT_LATE_DATE}T09:07:10`,
       checkOutTime: `${CURRENT_LATE_DATE}T18:02:01`,
       lateMinutes: 7,
       fee: 700,
+      status: 'LATE',
+    },
+    {
+      date: CURRENT_OVERNIGHT_DATE,
+      scheduledStartTime: '22:00:00',
+      scheduledEndTime: '06:00:00',
+      endsNextDay: true,
+      scheduledStartAt: `${CURRENT_OVERNIGHT_DATE}T22:00:00`,
+      scheduledEndAt: `${CURRENT_OVERNIGHT_END_DATE}T06:00:00`,
+      checkInTime: `${CURRENT_OVERNIGHT_DATE}T22:08:00`,
+      checkOutTime: `${CURRENT_OVERNIGHT_END_DATE}T06:01:00`,
+      lateMinutes: 8,
+      fee: 800,
       status: 'LATE',
     },
   ],
@@ -624,11 +642,14 @@ describe('Admin 페이지', () => {
     expect(screen.getByRole('tab', { name: '전체' })).toHaveAttribute('aria-selected', 'true')
     expect(screen.getByRole('heading', { name: '전체 정산 요약' })).toBeInTheDocument()
     expect(screen.getByText('월별 전체 지각비')).toBeInTheDocument()
-    expect(screen.getByText('6,700원')).toBeInTheDocument()
+    expect(screen.getByText('7,500원')).toBeInTheDocument()
     expect(screen.getByText('미기재 출근')).toBeInTheDocument()
-    expect(screen.getByText('2건')).toBeInTheDocument()
+    expect(screen.getAllByText('2건').length).toBeGreaterThan(0)
     expect(screen.getAllByText('김민준').length).toBeGreaterThan(0)
     expect(screen.getAllByText('3,000원').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('강민준').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('1,500원').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('15분').length).toBeGreaterThan(0)
   })
 
   it('지각비 정산 탭의 팀 섹션에서 팀별 정산을 볼 수 있다', async () => {
@@ -642,7 +663,9 @@ describe('Admin 페이지', () => {
 
     expect(await screen.findByRole('heading', { name: '1팀 정산 요약' })).toBeInTheDocument()
     expect(screen.getByText('팀 전체 지각비')).toBeInTheDocument()
+    expect(screen.getByText('4,500원')).toBeInTheDocument()
     expect(screen.getAllByText('강민준').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('1,500원').length).toBeGreaterThan(0)
   })
 
   it('지각비 정산 탭의 개인 섹션에서 멤버별 상세 정산을 볼 수 있다', async () => {
@@ -656,7 +679,14 @@ describe('Admin 페이지', () => {
 
     expect(await screen.findByRole('heading', { name: '강민준 상세 정산' })).toBeInTheDocument()
     expect(screen.getByText(CURRENT_LATE_DATE)).toBeInTheDocument()
+    expect(screen.getByText(CURRENT_OVERNIGHT_DATE)).toBeInTheDocument()
+    expect(screen.getByText('22:00 - 다음날 06:00')).toBeInTheDocument()
+    expect(screen.getByText('22:08')).toBeInTheDocument()
+    expect(screen.getByText('06:01')).toBeInTheDocument()
+    expect(screen.getByText('8분')).toBeInTheDocument()
     expect(screen.getAllByText('700원').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('800원').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('1,500원').length).toBeGreaterThan(0)
     expect(screen.getByRole('button', { name: '개인 출근 내역 CSV' })).toBeInTheDocument()
   })
 

--- a/src/pages/settings/__tests__/Settings.test.tsx
+++ b/src/pages/settings/__tests__/Settings.test.tsx
@@ -58,17 +58,33 @@ describe('Settings 페이지', () => {
       scheduledDays: 10,
       attendedDays: 9,
       lateDays: 2,
-      totalLateMinutes: 12,
-      lateFee: 1200,
+      totalLateMinutes: 15,
+      lateFee: 1500,
       items: [
         {
           date: '2026-03-04',
           scheduledStartTime: '09:00:00',
           scheduledEndTime: '18:00:00',
+          endsNextDay: false,
+          scheduledStartAt: '2026-03-04T09:00:00',
+          scheduledEndAt: '2026-03-04T18:00:00',
           checkInTime: '2026-03-04T09:07:00',
           checkOutTime: '2026-03-04T18:02:00',
           lateMinutes: 7,
           fee: 700,
+          status: 'LATE',
+        },
+        {
+          date: '2026-03-07',
+          scheduledStartTime: '22:00:00',
+          scheduledEndTime: '06:00:00',
+          endsNextDay: true,
+          scheduledStartAt: '2026-03-07T22:00:00',
+          scheduledEndAt: '2026-03-08T06:00:00',
+          checkInTime: '2026-03-07T22:08:00',
+          checkOutTime: '2026-03-08T06:01:00',
+          lateMinutes: 8,
+          fee: 800,
           status: 'LATE',
         },
       ],
@@ -111,8 +127,13 @@ describe('Settings 페이지', () => {
     fireEvent.click(screen.getByText('정산'))
 
     expect(await screen.findByText('개인 지각비 정산')).toBeInTheDocument()
-    expect(screen.getByText('1,200원')).toBeInTheDocument()
+    expect(screen.getByText('1,500원')).toBeInTheDocument()
     expect(screen.getByText('2026-03-04')).toBeInTheDocument()
+    expect(screen.getByText('2026-03-07')).toBeInTheDocument()
+    expect(screen.getByText('22:00 - 다음날 06:00')).toBeInTheDocument()
+    expect(screen.getByText('22:08')).toBeInTheDocument()
+    expect(screen.getByText('8분')).toBeInTheDocument()
+    expect(screen.getByText('800원')).toBeInTheDocument()
   })
 
   it('테마 카드 클릭 시 setTheme가 호출된다', () => {

--- a/src/shared/api/__tests__/attendanceSettlementApi.test.ts
+++ b/src/shared/api/__tests__/attendanceSettlementApi.test.ts
@@ -10,9 +10,9 @@ const settlementResponse = {
   teamName: '1팀',
   scheduledDays: 12,
   attendedDays: 11,
-  lateDays: 3,
-  totalLateMinutes: 27,
-  lateFee: 2700,
+  lateDays: 2,
+  totalLateMinutes: 15,
+  lateFee: 1500,
   items: [
     {
       date: '2026-03-04',
@@ -25,6 +25,19 @@ const settlementResponse = {
       checkOutTime: '2026-03-04T18:02:01',
       lateMinutes: 7,
       fee: 700,
+      status: 'LATE',
+    },
+    {
+      date: '2026-03-07',
+      scheduledStartTime: '22:00:00',
+      scheduledEndTime: '06:00:00',
+      endsNextDay: true,
+      scheduledStartAt: '2026-03-07T22:00:00',
+      scheduledEndAt: '2026-03-08T06:00:00',
+      checkInTime: '2026-03-07T22:08:00',
+      checkOutTime: '2026-03-08T06:01:00',
+      lateMinutes: 8,
+      fee: 800,
       status: 'LATE',
     },
   ],
@@ -59,12 +72,22 @@ describe('attendanceSettlementApi', () => {
     expect(result).toMatchObject({
       yearMonth: '2026-03',
       memberName: '강민준',
-      lateFee: 2700,
+      lateFee: 1500,
     })
     expect(result.items[0]).toMatchObject({
       date: '2026-03-04',
       status: 'LATE',
       fee: 700,
+    })
+    expect(result.items[1]).toMatchObject({
+      date: '2026-03-07',
+      endsNextDay: true,
+      scheduledStartAt: '2026-03-07T22:00:00',
+      scheduledEndAt: '2026-03-08T06:00:00',
+      checkInTime: '2026-03-07T22:08:00',
+      checkOutTime: '2026-03-08T06:01:00',
+      lateMinutes: 8,
+      fee: 800,
     })
   })
 

--- a/src/shared/lib/__tests__/attendanceSettlement.test.ts
+++ b/src/shared/lib/__tests__/attendanceSettlement.test.ts
@@ -10,9 +10,9 @@ const baseSettlement: AttendanceSettlement = {
   teamName: '1팀',
   scheduledDays: 12,
   attendedDays: 11,
-  lateDays: 3,
-  totalLateMinutes: 27,
-  lateFee: 2700,
+  lateDays: 2,
+  totalLateMinutes: 15,
+  lateFee: 1500,
   items: [
     {
       date: '2026-03-04',
@@ -25,6 +25,19 @@ const baseSettlement: AttendanceSettlement = {
       checkOutTime: '2026-03-04T18:02:01',
       lateMinutes: 7,
       fee: 700,
+      status: 'LATE',
+    },
+    {
+      date: '2026-03-07',
+      scheduledStartTime: '22:00:00',
+      scheduledEndTime: '06:00:00',
+      endsNextDay: true,
+      scheduledStartAt: '2026-03-07T22:00:00',
+      scheduledEndAt: '2026-03-08T06:00:00',
+      checkInTime: '2026-03-07T22:08:00',
+      checkOutTime: '2026-03-08T06:01:00',
+      lateMinutes: 8,
+      fee: 800,
       status: 'LATE',
     },
   ],
@@ -46,7 +59,7 @@ describe('attendanceSettlement', () => {
 
     const result = applyNoScheduleAttendanceFee(baseSettlement, records)
 
-    expect(result.lateFee).toBe(700 + NO_SCHEDULE_ATTENDANCE_FEE)
+    expect(result.lateFee).toBe(1500 + NO_SCHEDULE_ATTENDANCE_FEE)
     expect(result.items).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -88,7 +101,26 @@ describe('attendanceSettlement', () => {
     const summary = rollupAttendanceSettlements(settlements)
 
     expect(summary.memberCount).toBe(2)
-    expect(summary.totalLateFee).toBe(5700)
+    expect(summary.totalLateFee).toBe(4500)
     expect(summary.noScheduleAttendanceCount).toBe(1)
+  })
+
+  it('야간 근무 지각 정산 항목은 다음날 종료 계약을 유지한 채 합산한다', () => {
+    const summary = rollupAttendanceSettlements([baseSettlement])
+    const overnightItem = baseSettlement.items.find((item) => item.endsNextDay)
+
+    expect(overnightItem).toMatchObject({
+      scheduledStartTime: '22:00:00',
+      scheduledEndTime: '06:00:00',
+      scheduledStartAt: '2026-03-07T22:00:00',
+      scheduledEndAt: '2026-03-08T06:00:00',
+      checkInTime: '2026-03-07T22:08:00',
+      checkOutTime: '2026-03-08T06:01:00',
+      lateMinutes: 8,
+      fee: 800,
+      status: 'LATE',
+    })
+    expect(summary.totalLateMinutes).toBe(15)
+    expect(summary.totalLateFee).toBe(1500)
   })
 })


### PR DESCRIPTION
## 관련 이슈
closes #371

## 작업 내용
- 지각 정산 QA 데이터에 야간 근무 지각 항목 추가
  - `22:00 ~ 다음날 06:00`
  - `22:08` 출근, `06:01` 퇴근
  - 지각 8분 / 800원
- 개인 설정 정산 화면 테스트 보강
  - 야간 근무가 `22:00 - 다음날 06:00`으로 표시되는지 검증
  - 야간 지각 분/금액이 개인 합계에 포함되는지 검증
- 관리자 지각비 정산 테스트 보강
  - 전체 정산 합산에 야간 지각 금액 반영 검증
  - 팀 정산 합산에 야간 지각 금액 반영 검증
  - 개인 상세 정산에서 야간 근무의 실제 출근/퇴근과 지각비 표시 검증
- 정산 API/lib 회귀 테스트 보강
  - `endsNextDay`, `scheduledStartAt`, `scheduledEndAt` 계약 유지 검증
  - rollup 합산에서 야간 지각 항목 포함 검증
- 트러블슈팅 문서에 야간 근무 지각 정산 QA 체크포인트 추가

## 검증
- `npm run test:run -- src/shared/lib/__tests__/attendanceSettlement.test.ts src/shared/api/__tests__/attendanceSettlementApi.test.ts src/pages/settings/__tests__/Settings.test.tsx src/pages/admin/__tests__/Admin.test.tsx`
- `npm run test:run`
- `npm run build`
- `git diff --check`

## 메모
- 실제 앱 로직은 이미 `formatScheduleRangeLabel`로 야간 근무를 표현하고 있어, 이번 작업은 QA 회귀망 보강 중심입니다.
- 기존 로컬 변경 `docs/guides/git-conventions.md`는 이번 PR에 포함하지 않았습니다.