### PR TITLE
feat: 날짜별 근무 일정 범위 조회 API 연동

### DIFF
--- a/src/pages/work-schedules/__tests__/WorkSchedules.test.tsx
+++ b/src/pages/work-schedules/__tests__/WorkSchedules.test.tsx
@@ -4,6 +4,8 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 const mockGetAllWorkSchedules = vi.fn()
 const mockGetTeamWorkSchedules = vi.fn()
 const mockGetWorkScheduleEvents = vi.fn()
+const mockGetTeamWorkScheduleEvents = vi.fn()
+const mockGetAllWorkScheduleEvents = vi.fn()
 const mockCreateWorkScheduleEvent = vi.fn()
 let capturedEvents: Array<Record<string, unknown>> = []
 
@@ -51,6 +53,8 @@ vi.mock('../../../shared/api/attendanceApi', () => ({
   getAllWorkSchedules: (...args: unknown[]) => mockGetAllWorkSchedules(...args),
   getTeamWorkSchedules: (...args: unknown[]) => mockGetTeamWorkSchedules(...args),
   getWorkScheduleEvents: (...args: unknown[]) => mockGetWorkScheduleEvents(...args),
+  getTeamWorkScheduleEvents: (...args: unknown[]) => mockGetTeamWorkScheduleEvents(...args),
+  getAllWorkScheduleEvents: (...args: unknown[]) => mockGetAllWorkScheduleEvents(...args),
   createWorkScheduleEvent: (...args: unknown[]) => mockCreateWorkScheduleEvent(...args),
   updateWorkScheduleEvent: vi.fn(),
   deleteWorkScheduleEvent: vi.fn(),
@@ -69,6 +73,8 @@ function addDays(date: string, days: number) {
 
 describe('WorkSchedules 페이지', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
+    capturedEvents = []
     mockState = {
       currentUser: { id: '1', name: '관리자', role: 'ADMIN', team: '1팀' },
       users: [
@@ -97,6 +103,40 @@ describe('WorkSchedules 페이지', () => {
       },
     ])
     mockGetWorkScheduleEvents.mockResolvedValue([
+      {
+        id: 100,
+        date: '2026-03-30',
+        startTime: '09:00:00',
+        endTime: '18:00:00',
+        endsNextDay: false,
+        memberId: 1,
+        memberName: '관리자',
+        teamName: '1팀',
+      },
+    ])
+    mockGetTeamWorkScheduleEvents.mockResolvedValue([
+      {
+        id: 101,
+        date: '2026-03-30',
+        startTime: '13:00:00',
+        endTime: '18:00:00',
+        endsNextDay: false,
+        memberId: 2,
+        memberName: '팀원',
+        teamName: '1팀',
+      },
+    ])
+    mockGetAllWorkScheduleEvents.mockResolvedValue([
+      {
+        id: 100,
+        date: '2026-03-30',
+        startTime: '09:00:00',
+        endTime: '18:00:00',
+        endsNextDay: false,
+        memberId: 1,
+        memberName: '관리자',
+        teamName: '1팀',
+      },
       {
         id: 101,
         date: '2026-03-30',
@@ -130,7 +170,7 @@ describe('WorkSchedules 페이지', () => {
 
     await waitFor(() => {
       expect(mockGetAllWorkSchedules).toHaveBeenCalled()
-      expect(mockGetWorkScheduleEvents).toHaveBeenCalled()
+      expect(mockGetAllWorkScheduleEvents).toHaveBeenCalled()
       expect(screen.getByTestId('mock-calendar')).toBeInTheDocument()
     })
 
@@ -141,6 +181,26 @@ describe('WorkSchedules 페이지', () => {
         return start.includes('T22:00:00') && end.slice(0, 10) > start.slice(0, 10)
       }),
     ).toBe(true)
+    expect(
+      capturedEvents.some((event) => {
+        const meta = event.extendedProps as { item?: { memberId?: number; memberName?: string } } | undefined
+        return meta?.item?.memberId === 2 && meta.item.memberName === '팀원'
+      }),
+    ).toBe(true)
+  })
+
+  it('관리자가 팀별 필터를 선택하면 팀 날짜별 일정 API를 사용한다', async () => {
+    render(<WorkSchedules />)
+
+    await waitFor(() => {
+      expect(mockGetAllWorkScheduleEvents).toHaveBeenCalled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: '팀별' }))
+
+    await waitFor(() => {
+      expect(mockGetTeamWorkScheduleEvents).toHaveBeenCalledWith(1, expect.any(String), expect.any(String))
+    })
   })
 
   it('일반 멤버는 우리 팀과 개인 필터만 본다', async () => {
@@ -161,6 +221,7 @@ describe('WorkSchedules 페이지', () => {
 
     await waitFor(() => {
       expect(mockGetTeamWorkSchedules).toHaveBeenCalled()
+      expect(mockGetTeamWorkScheduleEvents).toHaveBeenCalledWith(1, expect.any(String), expect.any(String))
     })
   })
 

--- a/src/pages/work-schedules/index.tsx
+++ b/src/pages/work-schedules/index.tsx
@@ -13,7 +13,9 @@ import { SetWorkDaysPersonal } from '../../features/attendance/ui'
 import {
   createWorkScheduleEvent,
   deleteWorkScheduleEvent,
+  getAllWorkScheduleEvents,
   getAllWorkSchedules,
+  getTeamWorkScheduleEvents,
   getTeamWorkSchedules,
   getWorkScheduleEvents,
   updateWorkScheduleEvent,
@@ -359,8 +361,40 @@ export function WorkSchedules() {
 
     setIsLoading(true)
     try {
+      const loadDateEvents = async () => {
+        if (scope === 'all' && canViewAll) {
+          return getAllWorkScheduleEvents(calendarRange.start, calendarRange.end)
+        }
+
+        if (scope === 'team') {
+          const teamId = selectedTeam?.id ?? currentTeam?.id ?? null
+          if (!teamId) return []
+          return getTeamWorkScheduleEvents(teamId, calendarRange.start, calendarRange.end)
+        }
+
+        if (scope === 'person' && selectedMemberId === currentUserId) {
+          return getWorkScheduleEvents(calendarRange.start, calendarRange.end)
+        }
+
+        if (scope === 'person' && canViewAll) {
+          const allEvents = await getAllWorkScheduleEvents(calendarRange.start, calendarRange.end)
+          return allEvents.filter((item) => String(item.memberId) === selectedMemberId)
+        }
+
+        if (scope === 'person' && canViewTeam) {
+          const selectedMember = selectableMembers.find((member) => member.id === selectedMemberId)
+          const teamName = selectedMember?.team ?? currentTeamName
+          const teamId = allTeams.find((team) => team.name === teamName)?.id ?? currentTeam?.id ?? null
+          if (!teamId) return []
+          const teamEvents = await getTeamWorkScheduleEvents(teamId, calendarRange.start, calendarRange.end)
+          return teamEvents.filter((item) => String(item.memberId) === selectedMemberId)
+        }
+
+        return getWorkScheduleEvents(calendarRange.start, calendarRange.end)
+      }
+
       const [events, schedules] = await Promise.all([
-        getWorkScheduleEvents(calendarRange.start, calendarRange.end),
+        loadDateEvents(),
         (async () => {
           if (scope === 'all' && canViewAll) {
             return getAllWorkSchedules()
@@ -399,7 +433,21 @@ export function WorkSchedules() {
       setIsLoading(false)
       setHasLoadedCalendar(true)
     }
-  }, [calendarRange.end, calendarRange.start, canViewAll, currentTeam, currentUser, scope, selectedMemberId, selectedTeam])
+  }, [
+    allTeams,
+    calendarRange.end,
+    calendarRange.start,
+    canViewAll,
+    canViewTeam,
+    currentTeam,
+    currentTeamName,
+    currentUser,
+    currentUserId,
+    scope,
+    selectableMembers,
+    selectedMemberId,
+    selectedTeam,
+  ])
 
   useEffect(() => {
     loadCalendarData()

--- a/src/shared/api/__tests__/attendanceApi.test.ts
+++ b/src/shared/api/__tests__/attendanceApi.test.ts
@@ -15,6 +15,8 @@ import {
   getAllWorkSchedules,
   getTeamWorkSchedules,
   getWorkScheduleEvents,
+  getTeamWorkScheduleEvents,
+  getAllWorkScheduleEvents,
   updateWorkScheduleEvent,
 } from '../attendanceApi'
 
@@ -36,6 +38,16 @@ const WORK_SCHEDULE_EVENTS = [
     memberId: 1,
     memberName: '김리더',
     teamName: '1팀',
+  },
+  {
+    id: 102,
+    date: '2026-03-28',
+    startTime: '22:00:00',
+    endTime: '06:00:00',
+    endsNextDay: true,
+    memberId: 2,
+    memberName: '박팀장',
+    teamName: '2팀',
   },
 ]
 
@@ -78,6 +90,20 @@ const server = setupServer(
     }),
   ),
   http.get('/api/v1/work-schedule-events', () =>
+    HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: WORK_SCHEDULE_EVENTS.filter((item) => item.memberId === 1),
+    }),
+  ),
+  http.get('/api/v1/work-schedule-events/team/:teamId', ({ params }) =>
+    HttpResponse.json({
+      code: 'SUCCESS',
+      message: 'ok',
+      data: WORK_SCHEDULE_EVENTS.filter((item) => String(params.teamId) === (item.teamName === '1팀' ? '1' : '2')),
+    }),
+  ),
+  http.get('/api/v1/work-schedule-events/all', () =>
     HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: WORK_SCHEDULE_EVENTS }),
   ),
   http.post('/api/v1/work-schedule-events', async ({ request }) => {
@@ -219,6 +245,18 @@ describe('workScheduleApi', () => {
     const events = await getWorkScheduleEvents('2026-03-01', '2026-03-31')
     expect(events).toHaveLength(1)
     expect(events[0]).toMatchObject({ memberName: '김리더', date: '2026-03-31' })
+  })
+
+  it('getTeamWorkScheduleEvents() 팀 날짜별 근무 일정 이벤트를 반환한다', async () => {
+    const events = await getTeamWorkScheduleEvents(2, '2026-03-01', '2026-03-31')
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({ memberName: '박팀장', teamName: '2팀', endsNextDay: true })
+  })
+
+  it('getAllWorkScheduleEvents() 전체 날짜별 근무 일정 이벤트를 반환한다', async () => {
+    const events = await getAllWorkScheduleEvents('2026-03-01', '2026-03-31')
+    expect(events).toHaveLength(2)
+    expect(events.map((item) => item.memberName)).toEqual(['김리더', '박팀장'])
   })
 
   it('createWorkScheduleEvent() 날짜별 근무 일정을 생성한다', async () => {

--- a/src/shared/api/attendanceApi.ts
+++ b/src/shared/api/attendanceApi.ts
@@ -115,6 +115,14 @@ export const getTeamWorkSchedules = (teamId: number) =>
 export const getWorkScheduleEvents = (startDate: string, endDate: string) =>
   baseClient.get<WorkScheduleEventItem[]>(`/api/v1/work-schedule-events?startDate=${startDate}&endDate=${endDate}`)
 
+export const getTeamWorkScheduleEvents = (teamId: number, startDate: string, endDate: string) =>
+  baseClient.get<WorkScheduleEventItem[]>(
+    `/api/v1/work-schedule-events/team/${teamId}?startDate=${startDate}&endDate=${endDate}`,
+  )
+
+export const getAllWorkScheduleEvents = (startDate: string, endDate: string) =>
+  baseClient.get<WorkScheduleEventItem[]>(`/api/v1/work-schedule-events/all?startDate=${startDate}&endDate=${endDate}`)
+
 export const createWorkScheduleEvent = (body: WorkScheduleEventPayload) =>
   baseClient.post<WorkScheduleEventItem>('/api/v1/work-schedule-events', body)
 

--- a/src/shared/api/mock/handlers/attendance.ts
+++ b/src/shared/api/mock/handlers/attendance.ts
@@ -68,6 +68,21 @@ function syncMyMemberWorkSchedules() {
   )
 }
 
+function filterWorkScheduleEventsByDate(items: WorkScheduleEventItem[], startDate: string | null, endDate: string | null) {
+  return items.filter((item) => {
+    if (startDate && item.date < startDate) return false
+    if (endDate && item.date > endDate) return false
+    return true
+  })
+}
+
+function getTeamNameById(teamId: number) {
+  if (teamId === 1) return '1팀'
+  if (teamId === 2) return '2팀'
+  if (teamId === 3) return '3팀'
+  return '4팀'
+}
+
 let workScheduleEvents: WorkScheduleEventItem[] = [
   {
     id: 101,
@@ -170,11 +185,7 @@ export const attendanceHandlers = [
 
   http.get('/api/v1/work-schedules/team/:teamId', ({ params }) => {
     const teamId = Number(params.teamId)
-    const teamName =
-      teamId === 1 ? '1팀' :
-      teamId === 2 ? '2팀' :
-      teamId === 3 ? '3팀' :
-      '4팀'
+    const teamName = getTeamNameById(teamId)
 
     return HttpResponse.json({
       code: 'SUCCESS',
@@ -188,11 +199,34 @@ export const attendanceHandlers = [
     const startDate = url.searchParams.get('startDate')
     const endDate = url.searchParams.get('endDate')
 
-    const filtered = workScheduleEvents.filter((item) => {
-      if (startDate && item.date < startDate) return false
-      if (endDate && item.date > endDate) return false
-      return true
-    })
+    const filtered = filterWorkScheduleEventsByDate(
+      workScheduleEvents.filter((item) => item.memberId === 1),
+      startDate,
+      endDate,
+    )
+
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: filtered })
+  }),
+
+  http.get('/api/v1/work-schedule-events/team/:teamId', ({ params, request }) => {
+    const url = new URL(request.url)
+    const startDate = url.searchParams.get('startDate')
+    const endDate = url.searchParams.get('endDate')
+    const teamName = getTeamNameById(Number(params.teamId))
+    const filtered = filterWorkScheduleEventsByDate(
+      workScheduleEvents.filter((item) => item.teamName === teamName),
+      startDate,
+      endDate,
+    )
+
+    return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: filtered })
+  }),
+
+  http.get('/api/v1/work-schedule-events/all', ({ request }) => {
+    const url = new URL(request.url)
+    const startDate = url.searchParams.get('startDate')
+    const endDate = url.searchParams.get('endDate')
+    const filtered = filterWorkScheduleEventsByDate(workScheduleEvents, startDate, endDate)
 
     return HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: filtered })
   }),


### PR DESCRIPTION
## 관련 이슈
closes #386

## 작업 내용
- `getTeamWorkScheduleEvents`, `getAllWorkScheduleEvents` API 클라이언트 추가
- 근무 일정 캘린더가 조회 범위에 따라 날짜별 일정 API를 선택하도록 수정
  - 전체: `GET /api/v1/work-schedule-events/all`
  - 팀: `GET /api/v1/work-schedule-events/team/{teamId}`
  - 본인 개인: 기존 `GET /api/v1/work-schedule-events`
  - 타인 개인: 권한 범위 API 조회 후 멤버 필터링
- MSW mock에서 본인/팀/전체 날짜별 일정 조회 응답을 백엔드 계약에 맞게 분리
- API/화면 테스트로 관리자 전체 조회, 팀 조회, 일반 멤버 팀 조회 흐름 보강

## 검증
- [x] `npm test -- src/shared/api/__tests__/attendanceApi.test.ts src/pages/work-schedules/__tests__/WorkSchedules.test.tsx`
- [x] `npm run test:run`
- [x] `npx eslint src/shared/api/attendanceApi.ts src/pages/work-schedules/index.tsx src/shared/api/__tests__/attendanceApi.test.ts src/pages/work-schedules/__tests__/WorkSchedules.test.tsx src/shared/api/mock/handlers/attendance.ts`
- [x] `npm run build`

## 참고
- `npm run lint`는 기존 `.claude/skill/gstack` 및 기존 React hook lint 이슈를 함께 검사해 실패합니다. 이번 변경 파일 대상 ESLint는 통과했습니다.
