### PR TITLE
release: v1.1.2

### DIFF
--- a/src/pages/work-schedules/__tests__/WorkSchedules.test.tsx
+++ b/src/pages/work-schedules/__tests__/WorkSchedules.test.tsx
@@ -7,6 +7,7 @@ const mockGetWorkScheduleEvents = vi.fn()
 const mockGetTeamWorkScheduleEvents = vi.fn()
 const mockGetAllWorkScheduleEvents = vi.fn()
 const mockCreateWorkScheduleEvent = vi.fn()
+const mockDeleteWorkScheduleEvent = vi.fn()
 let capturedEvents: Array<Record<string, unknown>> = []
 
 let mockState = {
@@ -22,7 +23,11 @@ let mockState = {
 }
 
 vi.mock('@fullcalendar/react', () => ({
-  default: (props: { events?: unknown[]; dateClick?: (arg: { dateStr: string }) => void }) => (
+  default: (props: {
+    events?: unknown[]
+    dateClick?: (arg: { dateStr: string }) => void
+    eventClick?: (arg: { event: { extendedProps?: unknown } }) => void
+  }) => (
     (() => {
       capturedEvents = (props.events as Array<Record<string, unknown>> | undefined) ?? []
       return (
@@ -30,6 +35,25 @@ vi.mock('@fullcalendar/react', () => ({
           <button type="button" onClick={() => props.dateClick?.({ dateStr: '2026-03-30' })}>
             날짜 클릭
           </button>
+          {capturedEvents.map((event, index) => {
+            const meta = event.extendedProps as {
+              kind?: string
+              date?: string
+              item?: { date?: string; eventType?: string }
+            } | undefined
+            const date = meta?.date ?? meta?.item?.date ?? ''
+            const eventType = meta?.item?.eventType ?? ''
+            return (
+              <button
+                key={`${String(event.id)}-${index}`}
+                type="button"
+                aria-label={`이벤트 ${index} ${String(event.title)} ${meta?.kind ?? ''} ${eventType} ${date}`}
+                onClick={() => props.eventClick?.({ event: { extendedProps: event.extendedProps } })}
+              >
+                이벤트 {index}
+              </button>
+            )
+          })}
           <span>events:{props.events?.length ?? 0}</span>
         </div>
       )
@@ -57,7 +81,7 @@ vi.mock('../../../shared/api/attendanceApi', () => ({
   getAllWorkScheduleEvents: (...args: unknown[]) => mockGetAllWorkScheduleEvents(...args),
   createWorkScheduleEvent: (...args: unknown[]) => mockCreateWorkScheduleEvent(...args),
   updateWorkScheduleEvent: vi.fn(),
-  deleteWorkScheduleEvent: vi.fn(),
+  deleteWorkScheduleEvent: (...args: unknown[]) => mockDeleteWorkScheduleEvent(...args),
 }))
 
 import { WorkSchedules } from '../index'
@@ -106,6 +130,7 @@ describe('WorkSchedules 페이지', () => {
       {
         id: 100,
         date: '2026-03-30',
+        eventType: 'WORKING',
         startTime: '09:00:00',
         endTime: '18:00:00',
         endsNextDay: false,
@@ -118,6 +143,7 @@ describe('WorkSchedules 페이지', () => {
       {
         id: 101,
         date: '2026-03-30',
+        eventType: 'WORKING',
         startTime: '13:00:00',
         endTime: '18:00:00',
         endsNextDay: false,
@@ -130,6 +156,7 @@ describe('WorkSchedules 페이지', () => {
       {
         id: 100,
         date: '2026-03-30',
+        eventType: 'WORKING',
         startTime: '09:00:00',
         endTime: '18:00:00',
         endsNextDay: false,
@@ -140,6 +167,7 @@ describe('WorkSchedules 페이지', () => {
       {
         id: 101,
         date: '2026-03-30',
+        eventType: 'WORKING',
         startTime: '13:00:00',
         endTime: '18:00:00',
         endsNextDay: false,
@@ -151,6 +179,7 @@ describe('WorkSchedules 페이지', () => {
     mockCreateWorkScheduleEvent.mockResolvedValue({
       id: 999,
       date: '2026-03-30',
+      eventType: 'WORKING',
       startTime: '09:00:00',
       endTime: '18:00:00',
       endsNextDay: false,
@@ -158,6 +187,7 @@ describe('WorkSchedules 페이지', () => {
       memberName: '관리자',
       teamName: '1팀',
     })
+    mockDeleteWorkScheduleEvent.mockResolvedValue(null)
   })
 
   it('관리자는 전체, 팀별, 개인 필터와 캘린더를 본다', async () => {
@@ -222,6 +252,92 @@ describe('WorkSchedules 페이지', () => {
     await waitFor(() => {
       expect(mockGetTeamWorkSchedules).toHaveBeenCalled()
       expect(mockGetTeamWorkScheduleEvents).toHaveBeenCalledWith(1, expect.any(String), expect.any(String))
+    })
+  })
+
+  it('DAY_OFF 날짜별 이벤트는 같은 날짜의 반복 일정을 가리고 휴무 이벤트를 보여준다', async () => {
+    mockGetAllWorkScheduleEvents.mockResolvedValue([
+      {
+        id: 200,
+        date: '2026-05-04',
+        eventType: 'DAY_OFF',
+        startTime: null,
+        endTime: null,
+        endsNextDay: false,
+        memberId: 1,
+        memberName: '관리자',
+        teamName: '1팀',
+      },
+    ])
+
+    render(<WorkSchedules />)
+
+    await waitFor(() => {
+      expect(mockGetAllWorkScheduleEvents).toHaveBeenCalled()
+      expect(screen.getByTestId('mock-calendar')).toBeInTheDocument()
+    })
+
+    expect(
+      capturedEvents.some((event) => {
+        const meta = event.extendedProps as { kind?: string; memberId?: number; date?: string } | undefined
+        return meta?.kind === 'recurring' && meta.memberId === 1 && meta.date === '2026-05-04'
+      }),
+    ).toBe(false)
+    expect(
+      capturedEvents.some((event) => {
+        const meta = event.extendedProps as { kind?: string; item?: { eventType?: string; date?: string } } | undefined
+        return meta?.kind === 'date-event' && meta.item?.eventType === 'DAY_OFF' && meta.item.date === '2026-05-04'
+      }),
+    ).toBe(true)
+  })
+
+  it('본인 반복 일정 상세에서 해당 날짜만 휴무 처리할 수 있다', async () => {
+    render(<WorkSchedules />)
+
+    const recurringButtons = await screen.findAllByRole('button', {
+      name: /이벤트 .*관리자 recurring .*2026-05-/,
+    })
+    fireEvent.click(recurringButtons[0])
+
+    fireEvent.click(screen.getByRole('button', { name: '이 날짜만 휴무' }))
+
+    await waitFor(() => {
+      expect(mockCreateWorkScheduleEvent).toHaveBeenCalledWith({
+        date: expect.stringMatching(/^2026-05-/),
+        eventType: 'DAY_OFF',
+        startTime: null,
+        endTime: null,
+        endsNextDay: false,
+        reason: '반복 근무 일정 취소',
+      })
+    })
+  })
+
+  it('DAY_OFF 이벤트를 삭제하면 반복 일정 휴무를 취소한다', async () => {
+    mockGetAllWorkScheduleEvents.mockResolvedValue([
+      {
+        id: 200,
+        date: '2026-05-04',
+        eventType: 'DAY_OFF',
+        startTime: null,
+        endTime: null,
+        endsNextDay: false,
+        memberId: 1,
+        memberName: '관리자',
+        teamName: '1팀',
+      },
+    ])
+
+    render(<WorkSchedules />)
+
+    const dayOffButton = await screen.findByRole('button', {
+      name: /이벤트 .*관리자 휴무 date-event DAY_OFF 2026-05-04/,
+    })
+    fireEvent.click(dayOffButton)
+    fireEvent.click(screen.getByRole('button', { name: '휴무 취소' }))
+
+    await waitFor(() => {
+      expect(mockDeleteWorkScheduleEvent).toHaveBeenCalledWith(200)
     })
   })
 

--- a/src/pages/work-schedules/index.tsx
+++ b/src/pages/work-schedules/index.tsx
@@ -22,6 +22,7 @@ import {
   type MemberWorkScheduleItem,
   type WeekPattern,
   type WorkScheduleEventItem,
+  type WorkScheduleEventType,
 } from '../../shared/api/attendanceApi'
 import { formatScheduleRangeLabel } from '../../shared/lib/attendanceSchedule'
 import { formatTeamName, getTeamOptions, sortUsersByTeamAndName } from '../../shared/lib/team'
@@ -65,11 +66,14 @@ interface ScheduleModalState {
   startTime: string
   endTime: string
   endsNextDay: boolean
+  eventType: WorkScheduleEventType
+  reason: string
   item: WorkScheduleCalendarMeta | null
 }
 
 const DEFAULT_START_TIME = '09:00'
 const DEFAULT_END_TIME = '18:00'
+const DAY_OFF_REASON = '반복 근무 일정 취소'
 const WEEK_PATTERN_LABELS: Record<WeekPattern, string> = {
   EVERY: '매주',
   FIRST: '1주차',
@@ -131,6 +135,18 @@ function formatTimeLabel(time: string) {
   return time.slice(0, 5)
 }
 
+function getWorkScheduleEventType(item: WorkScheduleEventItem): WorkScheduleEventType {
+  return item.eventType ?? 'WORKING'
+}
+
+function isDayOffEvent(item: WorkScheduleEventItem) {
+  return getWorkScheduleEventType(item) === 'DAY_OFF'
+}
+
+function getOverrideKey(memberId: number, date: string) {
+  return `${memberId}:${date}`
+}
+
 function getEndDate(date: string, endsNextDay: boolean) {
   if (!endsNextDay) return date
   return toIsoDate(addDays(new Date(`${date}T12:00:00`), 1))
@@ -144,7 +160,21 @@ function formatDateLabel(date: string) {
   }).format(new Date(`${date}T12:00:00`))
 }
 
-function getEventColors(kind: 'recurring' | 'date-event', isMine: boolean) {
+function getEventColors(kind: 'recurring' | 'date-event' | 'day-off', isMine: boolean) {
+  if (kind === 'day-off') {
+    return isMine
+      ? {
+          backgroundColor: 'rgba(244, 63, 94, 0.18)',
+          borderColor: 'rgba(244, 63, 94, 0.46)',
+          textColor: 'var(--text-primary)',
+        }
+      : {
+          backgroundColor: 'rgba(148, 163, 184, 0.16)',
+          borderColor: 'rgba(148, 163, 184, 0.34)',
+          textColor: 'var(--text-primary)',
+        }
+  }
+
   if (kind === 'date-event') {
     return isMine
       ? {
@@ -176,11 +206,13 @@ function expandRecurringSchedules(
   schedules: MemberWorkScheduleItem[],
   range: CalendarRange | null,
   currentUserId: string,
+  overrides: WorkScheduleEventItem[],
 ): EventInput[] {
   if (!range) return []
 
   const start = new Date(`${range.start}T00:00:00`)
   const endExclusive = new Date(`${range.end}T00:00:00`)
+  const overriddenDates = new Set(overrides.map((item) => getOverrideKey(item.memberId, item.date)))
   const events: EventInput[] = []
 
   for (const member of schedules) {
@@ -193,6 +225,8 @@ function expandRecurringSchedules(
       if (!schedule) continue
 
       const isoDate = toIsoDate(cursor)
+      if (overriddenDates.has(getOverrideKey(member.memberId, isoDate))) continue
+
       const isMine = String(member.memberId) === currentUserId
       const colors = getEventColors('recurring', isMine)
       const startTime = formatTimeLabel(schedule.startTime)
@@ -227,11 +261,30 @@ function expandRecurringSchedules(
 }
 
 function toDateEvents(items: WorkScheduleEventItem[], currentUserId: string): EventInput[] {
-  return items.map((item) => {
+  return items.flatMap<EventInput>((item) => {
     const isMine = String(item.memberId) === currentUserId
+    if (isDayOffEvent(item)) {
+      const colors = getEventColors('day-off', isMine)
+      return [{
+        id: `date-event-${item.id}`,
+        title: `${item.memberName} 휴무`,
+        start: item.date,
+        allDay: true,
+        editable: false,
+        ...colors,
+        extendedProps: {
+          kind: 'date-event',
+          item,
+          isEditable: isMine,
+        } satisfies CalendarDateEventMeta,
+      }]
+    }
+
+    if (!item.startTime || !item.endTime) return []
+
     const colors = getEventColors('date-event', isMine)
     const endDate = item.endsNextDay ? toIsoDate(addDays(new Date(`${item.date}T12:00:00`), 1)) : item.date
-    return {
+    return [{
       id: `date-event-${item.id}`,
       title: item.memberName,
       start: `${item.date}T${item.startTime}`,
@@ -244,7 +297,7 @@ function toDateEvents(items: WorkScheduleEventItem[], currentUserId: string): Ev
         item,
         isEditable: isMine,
       } satisfies CalendarDateEventMeta,
-    }
+    }]
   })
 }
 
@@ -455,7 +508,7 @@ export function WorkSchedules() {
 
   const calendarEvents = useMemo(
     () => [
-      ...expandRecurringSchedules(recurringSchedules, calendarRange, currentUserId),
+      ...expandRecurringSchedules(recurringSchedules, calendarRange, currentUserId, filteredDateEvents),
       ...toDateEvents(filteredDateEvents, currentUserId),
     ],
     [calendarRange, currentUserId, filteredDateEvents, recurringSchedules],
@@ -468,6 +521,8 @@ export function WorkSchedules() {
       startTime: DEFAULT_START_TIME,
       endTime: DEFAULT_END_TIME,
       endsNextDay: false,
+      eventType: 'WORKING',
+      reason: '',
       item: null,
     })
   }, [])
@@ -481,12 +536,16 @@ export function WorkSchedules() {
     if (!meta) return
 
     if (meta.kind === 'date-event') {
+      const eventType = getWorkScheduleEventType(meta.item)
+      const isDayOff = eventType === 'DAY_OFF'
       setModalState({
         mode: meta.isEditable ? 'edit' : 'detail',
         date: meta.item.date,
-        startTime: formatTimeLabel(meta.item.startTime),
-        endTime: formatTimeLabel(meta.item.endTime),
-        endsNextDay: Boolean(meta.item.endsNextDay),
+        startTime: isDayOff || !meta.item.startTime ? DEFAULT_START_TIME : formatTimeLabel(meta.item.startTime),
+        endTime: isDayOff || !meta.item.endTime ? DEFAULT_END_TIME : formatTimeLabel(meta.item.endTime),
+        endsNextDay: isDayOff ? false : Boolean(meta.item.endsNextDay),
+        eventType,
+        reason: meta.item.reason ?? '',
         item: meta,
       })
       return
@@ -498,6 +557,8 @@ export function WorkSchedules() {
       startTime: meta.startTime,
       endTime: meta.endTime,
       endsNextDay: meta.endsNextDay,
+      eventType: 'WORKING',
+      reason: '',
       item: meta,
     })
   }, [])
@@ -507,12 +568,23 @@ export function WorkSchedules() {
 
     setIsModalSaving(true)
     try {
-      const payload = {
-        date: modalState.date,
-        startTime: `${modalState.startTime}:00`,
-        endTime: `${modalState.endTime}:00`,
-        endsNextDay: modalState.endsNextDay,
-      }
+      const payload = modalState.eventType === 'DAY_OFF'
+        ? {
+            date: modalState.date,
+            eventType: 'DAY_OFF' as const,
+            startTime: null,
+            endTime: null,
+            endsNextDay: false,
+            reason: modalState.reason || DAY_OFF_REASON,
+          }
+        : {
+            date: modalState.date,
+            eventType: 'WORKING' as const,
+            startTime: `${modalState.startTime}:00`,
+            endTime: `${modalState.endTime}:00`,
+            endsNextDay: modalState.endsNextDay,
+            reason: null,
+          }
 
       if (modalState.mode === 'create') {
         await createWorkScheduleEvent(payload)
@@ -524,6 +596,29 @@ export function WorkSchedules() {
       await loadCalendarData()
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : '날짜별 근무 일정 저장에 실패했습니다')
+    } finally {
+      setIsModalSaving(false)
+    }
+  }
+
+  const handleCreateDayOffFromRecurring = async () => {
+    if (!modalState || modalState.item?.kind !== 'recurring') return
+    if (String(modalState.item.memberId) !== currentUserId) return
+
+    setIsModalSaving(true)
+    try {
+      await createWorkScheduleEvent({
+        date: modalState.item.date,
+        eventType: 'DAY_OFF',
+        startTime: null,
+        endTime: null,
+        endsNextDay: false,
+        reason: DAY_OFF_REASON,
+      })
+      setModalState(null)
+      await loadCalendarData()
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : '반복 일정 휴무 처리에 실패했습니다')
     } finally {
       setIsModalSaving(false)
     }
@@ -547,6 +642,7 @@ export function WorkSchedules() {
   const modalTitle = useMemo(() => {
     if (!modalState) return ''
     if (modalState.mode === 'create') return '날짜별 근무 일정 추가'
+    if (modalState.eventType === 'DAY_OFF') return '반복 일정 휴무'
     if (modalState.item?.kind === 'date-event') return '날짜별 근무 일정'
     return '근무 일정 상세'
   }, [modalState])
@@ -559,9 +655,12 @@ export function WorkSchedules() {
   const modalDateRangeLabel = useMemo(() => {
     if (!modalState) return ''
     const startDateLabel = formatDateLabel(modalState.date)
+    if (modalState.eventType === 'DAY_OFF') return `${startDateLabel} 휴무`
     if (!modalState.endsNextDay) return `${startDateLabel} 하루 일정`
     return `${startDateLabel} ~ ${formatDateLabel(modalEndDate)}`
   }, [modalEndDate, modalState])
+
+  const isModalDayOff = modalState?.eventType === 'DAY_OFF'
 
   return (
     <div className="work-schedules-page">
@@ -658,6 +757,7 @@ export function WorkSchedules() {
               <span className="legend-chip recurring-team">공유 반복 일정</span>
               <span className="legend-chip date-own">날짜별 추가 일정</span>
               <span className="legend-chip date-team">팀 공유 일정</span>
+              <span className="legend-chip day-off">반복 일정 휴무</span>
             </div>
             <button
               type="button"
@@ -740,33 +840,50 @@ export function WorkSchedules() {
             </div>
 
             {modalState.mode === 'detail' && modalState.item?.kind === 'recurring' && (
-              <div className="work-schedules-detail-list">
-                <div className="work-schedules-detail-item">
-                  <strong>멤버</strong>
-                  <span>{modalState.item.memberName}</span>
+              <>
+                <div className="work-schedules-detail-list">
+                  <div className="work-schedules-detail-item">
+                    <strong>멤버</strong>
+                    <span>{modalState.item.memberName}</span>
+                  </div>
+                  <div className="work-schedules-detail-item">
+                    <strong>팀</strong>
+                    <span>{formatTeamName(modalState.item.teamName)}</span>
+                  </div>
+                  <div className="work-schedules-detail-item">
+                    <strong>시간</strong>
+                    <span>
+                      {formatScheduleRangeLabel({
+                        startTime: modalState.startTime,
+                        endTime: modalState.endTime,
+                        endsNextDay: modalState.endsNextDay,
+                      })}
+                    </span>
+                  </div>
+                  <div className="work-schedules-detail-item">
+                    <strong>반복 주차</strong>
+                    <span>{WEEK_PATTERN_LABELS[modalState.item.weekPattern]}</span>
+                  </div>
                 </div>
-                <div className="work-schedules-detail-item">
-                  <strong>팀</strong>
-                  <span>{formatTeamName(modalState.item.teamName)}</span>
-                </div>
-                <div className="work-schedules-detail-item">
-                  <strong>시간</strong>
-                  <span>
-                    {formatScheduleRangeLabel({
-                      startTime: modalState.startTime,
-                      endTime: modalState.endTime,
-                      endsNextDay: modalState.endsNextDay,
-                    })}
-                  </span>
-                </div>
-                <div className="work-schedules-detail-item">
-                  <strong>반복 주차</strong>
-                  <span>{WEEK_PATTERN_LABELS[modalState.item.weekPattern]}</span>
-                </div>
-              </div>
+
+                {String(modalState.item.memberId) === currentUserId && (
+                  <div className="work-schedules-day-off-callout">
+                    <strong>이 반복 일정만 쉬어야 하나요?</strong>
+                    <span>반복 설정은 유지하고, 선택한 날짜만 휴무로 덮어씁니다.</span>
+                    <button
+                      type="button"
+                      className="danger-btn"
+                      onClick={handleCreateDayOffFromRecurring}
+                      disabled={isModalSaving}
+                    >
+                      {isModalSaving ? '처리 중...' : '이 날짜만 휴무'}
+                    </button>
+                  </div>
+                )}
+              </>
             )}
 
-            {modalState.mode === 'detail' && modalState.item?.kind === 'date-event' && (
+            {(modalState.mode === 'detail' || isModalDayOff) && modalState.item?.kind === 'date-event' && (
               <div className="work-schedules-detail-list">
                 <div className="work-schedules-detail-item">
                   <strong>멤버</strong>
@@ -777,19 +894,40 @@ export function WorkSchedules() {
                   <span>{formatTeamName(modalState.item.item.teamName)}</span>
                 </div>
                 <div className="work-schedules-detail-item">
-                  <strong>시간</strong>
-                  <span>
-                    {formatScheduleRangeLabel({
-                      startTime: modalState.startTime,
-                      endTime: modalState.endTime,
-                      endsNextDay: modalState.endsNextDay,
-                    })}
-                  </span>
+                  <strong>{isModalDayOff ? '상태' : '시간'}</strong>
+                  {isModalDayOff ? (
+                    <span>반복 일정에서 이 날짜만 휴무 처리됨</span>
+                  ) : (
+                    <span>
+                      {formatScheduleRangeLabel({
+                        startTime: modalState.startTime,
+                        endTime: modalState.endTime,
+                        endsNextDay: modalState.endsNextDay,
+                      })}
+                    </span>
+                  )}
                 </div>
               </div>
             )}
 
-            {modalState.mode !== 'detail' && (
+            {modalState.mode === 'edit' && isModalDayOff && (
+              <div className="work-schedules-modal-actions">
+                <button
+                  type="button"
+                  className="danger-btn"
+                  onClick={handleDeleteEvent}
+                  disabled={isModalSaving}
+                >
+                  <Trash2 size={16} />
+                  휴무 취소
+                </button>
+                <button type="button" className="secondary-btn" onClick={() => setModalState(null)}>
+                  닫기
+                </button>
+              </div>
+            )}
+
+            {modalState.mode !== 'detail' && !isModalDayOff && (
               <>
                 <div className="work-schedules-modal-form">
                   <div

--- a/src/pages/work-schedules/work-schedules.css
+++ b/src/pages/work-schedules/work-schedules.css
@@ -164,6 +164,10 @@
   background: rgba(14, 165, 233, 0.14);
 }
 
+.legend-chip.day-off {
+  background: rgba(244, 63, 94, 0.14);
+}
+
 .quick-add-btn,
 .primary-btn,
 .secondary-btn,
@@ -194,6 +198,25 @@
 .danger-btn {
   background: color-mix(in srgb, var(--error) 12%, var(--surface));
   color: var(--error);
+}
+
+.work-schedules-day-off-callout {
+  display: grid;
+  gap: 8px;
+  margin-top: 18px;
+  padding: 16px;
+  border: 1px solid color-mix(in srgb, var(--error) 28%, var(--border-color));
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--error) 8%, var(--surface));
+}
+
+.work-schedules-day-off-callout span {
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+}
+
+.work-schedules-day-off-callout .danger-btn {
+  justify-self: start;
 }
 
 .work-schedules-loading {

--- a/src/shared/api/__tests__/attendanceApi.test.ts
+++ b/src/shared/api/__tests__/attendanceApi.test.ts
@@ -32,6 +32,7 @@ const WORK_SCHEDULE_EVENTS = [
   {
     id: 101,
     date: '2026-03-31',
+    eventType: 'WORKING',
     startTime: '13:00:00',
     endTime: '18:00:00',
     endsNextDay: false,
@@ -42,12 +43,24 @@ const WORK_SCHEDULE_EVENTS = [
   {
     id: 102,
     date: '2026-03-28',
+    eventType: 'WORKING',
     startTime: '22:00:00',
     endTime: '06:00:00',
     endsNextDay: true,
     memberId: 2,
     memberName: '박팀장',
     teamName: '2팀',
+  },
+  {
+    id: 103,
+    date: '2026-03-29',
+    eventType: 'DAY_OFF',
+    startTime: null,
+    endTime: null,
+    endsNextDay: false,
+    memberId: 1,
+    memberName: '김리더',
+    teamName: '1팀',
   },
 ]
 
@@ -107,7 +120,7 @@ const server = setupServer(
     HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: WORK_SCHEDULE_EVENTS }),
   ),
   http.post('/api/v1/work-schedule-events', async ({ request }) => {
-    const body = await request.json() as Record<string, string>
+    const body = await request.json() as Record<string, string | boolean | null>
     return HttpResponse.json({
       code: 'SUCCESS',
       message: 'ok',
@@ -115,7 +128,7 @@ const server = setupServer(
     })
   }),
   http.put('/api/v1/work-schedule-events/:eventId', async ({ request, params }) => {
-    const body = await request.json() as Record<string, string>
+    const body = await request.json() as Record<string, string | boolean | null>
     return HttpResponse.json({
       code: 'SUCCESS',
       message: 'ok',
@@ -243,8 +256,9 @@ describe('workScheduleApi', () => {
 
   it('getWorkScheduleEvents() 날짜 범위의 근무 일정 이벤트를 반환한다', async () => {
     const events = await getWorkScheduleEvents('2026-03-01', '2026-03-31')
-    expect(events).toHaveLength(1)
+    expect(events).toHaveLength(2)
     expect(events[0]).toMatchObject({ memberName: '김리더', date: '2026-03-31' })
+    expect(events[1]).toMatchObject({ eventType: 'DAY_OFF', startTime: null, endTime: null })
   })
 
   it('getTeamWorkScheduleEvents() 팀 날짜별 근무 일정 이벤트를 반환한다', async () => {
@@ -255,24 +269,45 @@ describe('workScheduleApi', () => {
 
   it('getAllWorkScheduleEvents() 전체 날짜별 근무 일정 이벤트를 반환한다', async () => {
     const events = await getAllWorkScheduleEvents('2026-03-01', '2026-03-31')
-    expect(events).toHaveLength(2)
-    expect(events.map((item) => item.memberName)).toEqual(['김리더', '박팀장'])
+    expect(events).toHaveLength(3)
+    expect(events.map((item) => item.memberName)).toEqual(['김리더', '박팀장', '김리더'])
   })
 
   it('createWorkScheduleEvent() 날짜별 근무 일정을 생성한다', async () => {
     const result = await createWorkScheduleEvent({
       date: '2026-03-30',
+      eventType: 'WORKING',
       startTime: '09:00:00',
       endTime: '18:00:00',
       endsNextDay: false,
     })
 
-    expect(result).toMatchObject({ id: 999, date: '2026-03-30', memberName: '김리더' })
+    expect(result).toMatchObject({ id: 999, date: '2026-03-30', eventType: 'WORKING', memberName: '김리더' })
+  })
+
+  it('createWorkScheduleEvent() 반복 일정 특정 날짜 휴무를 생성한다', async () => {
+    const result = await createWorkScheduleEvent({
+      date: '2026-03-29',
+      eventType: 'DAY_OFF',
+      startTime: null,
+      endTime: null,
+      endsNextDay: false,
+      reason: '반복 근무 일정 취소',
+    })
+
+    expect(result).toMatchObject({
+      id: 999,
+      date: '2026-03-29',
+      eventType: 'DAY_OFF',
+      startTime: null,
+      endTime: null,
+    })
   })
 
   it('updateWorkScheduleEvent() 날짜별 근무 일정을 수정한다', async () => {
     const result = await updateWorkScheduleEvent(101, {
       date: '2026-03-31',
+      eventType: 'WORKING',
       startTime: '10:00:00',
       endTime: '19:00:00',
       endsNextDay: false,

--- a/src/shared/api/attendanceApi.ts
+++ b/src/shared/api/attendanceApi.ts
@@ -33,6 +33,7 @@ export const resetMyAttendance = (date?: string) =>
 
 export type DayOfWeek = 'MONDAY' | 'TUESDAY' | 'WEDNESDAY' | 'THURSDAY' | 'FRIDAY' | 'SATURDAY' | 'SUNDAY'
 export type WeekPattern = 'EVERY' | 'FIRST' | 'SECOND' | 'THIRD' | 'FOURTH' | 'LAST'
+export type WorkScheduleEventType = 'WORKING' | 'DAY_OFF'
 
 export interface WorkScheduleItem {
   id: number
@@ -61,9 +62,11 @@ export interface MemberWorkScheduleItem {
 export interface WorkScheduleEventItem {
   id: number
   date: string
-  startTime: string
-  endTime: string
+  eventType?: WorkScheduleEventType
+  startTime: string | null
+  endTime: string | null
   endsNextDay?: boolean
+  reason?: string | null
   memberId: number
   memberName: string
   teamName: string
@@ -71,9 +74,11 @@ export interface WorkScheduleEventItem {
 
 export interface WorkScheduleEventPayload {
   date: string
-  startTime: string
-  endTime: string
+  eventType?: WorkScheduleEventType
+  startTime: string | null
+  endTime: string | null
   endsNextDay?: boolean
+  reason?: string | null
 }
 
 interface RawMemberWorkScheduleItem {

--- a/src/shared/api/mock/handlers/attendance.ts
+++ b/src/shared/api/mock/handlers/attendance.ts
@@ -87,6 +87,7 @@ let workScheduleEvents: WorkScheduleEventItem[] = [
   {
     id: 101,
     date: '2026-03-31',
+    eventType: 'WORKING',
     startTime: '13:00:00',
     endTime: '18:00:00',
     memberId: 1,
@@ -96,6 +97,7 @@ let workScheduleEvents: WorkScheduleEventItem[] = [
   {
     id: 102,
     date: '2026-04-02',
+    eventType: 'WORKING',
     startTime: '22:00:00',
     endTime: '06:00:00',
     endsNextDay: true,
@@ -232,13 +234,23 @@ export const attendanceHandlers = [
   }),
 
   http.post('/api/v1/work-schedule-events', async ({ request }) => {
-    const body = await request.json() as { date: string; startTime: string; endTime: string; endsNextDay?: boolean }
+    const body = await request.json() as {
+      date: string
+      eventType?: 'WORKING' | 'DAY_OFF'
+      startTime: string | null
+      endTime: string | null
+      endsNextDay?: boolean
+      reason?: string | null
+    }
+    const eventType = body.eventType ?? 'WORKING'
     const created: WorkScheduleEventItem = {
       id: Date.now(),
       date: body.date,
-      startTime: body.startTime,
-      endTime: body.endTime,
-      endsNextDay: Boolean(body.endsNextDay),
+      eventType,
+      startTime: eventType === 'DAY_OFF' ? null : body.startTime,
+      endTime: eventType === 'DAY_OFF' ? null : body.endTime,
+      endsNextDay: eventType === 'DAY_OFF' ? false : Boolean(body.endsNextDay),
+      reason: body.reason ?? null,
       memberId: 1,
       memberName: '김리더',
       teamName: '1팀',
@@ -250,7 +262,14 @@ export const attendanceHandlers = [
 
   http.put('/api/v1/work-schedule-events/:eventId', async ({ params, request }) => {
     const eventId = Number(params.eventId)
-    const body = await request.json() as { date: string; startTime: string; endTime: string; endsNextDay?: boolean }
+    const body = await request.json() as {
+      date: string
+      eventType?: 'WORKING' | 'DAY_OFF'
+      startTime: string | null
+      endTime: string | null
+      endsNextDay?: boolean
+      reason?: string | null
+    }
     const existing = workScheduleEvents.find((item) => item.id === eventId)
 
     if (!existing) {
@@ -260,12 +279,15 @@ export const attendanceHandlers = [
       )
     }
 
+    const eventType = body.eventType ?? 'WORKING'
     const updated: WorkScheduleEventItem = {
       ...existing,
       date: body.date,
-      startTime: body.startTime,
-      endTime: body.endTime,
-      endsNextDay: Boolean(body.endsNextDay),
+      eventType,
+      startTime: eventType === 'DAY_OFF' ? null : body.startTime,
+      endTime: eventType === 'DAY_OFF' ? null : body.endTime,
+      endsNextDay: eventType === 'DAY_OFF' ? false : Boolean(body.endsNextDay),
+      reason: body.reason ?? null,
     }
 
     workScheduleEvents = workScheduleEvents.map((item) => (item.id === eventId ? updated : item))


### PR DESCRIPTION
## 작업 내용
- develop 브랜치의 최신 변경 사항을 main에 반영하는 `v1.1.2` 배포 PR입니다.
- 이번 배포에는 백엔드의 반복 근무 특정 날짜 휴무(`WorkScheduleEventType.DAY_OFF`) 계약을 프론트 근무 일정 캘린더에 반영한 변경이 포함됩니다.
- 반복 근무 전체를 해제하지 않고, 선택한 날짜만 휴무 처리하거나 휴무 취소할 수 있도록 운영 흐름을 보강했습니다.

## 변경 이유
- 반복 근무 설정으로 출근일을 지정한 뒤 특정 날짜만 쉬어야 할 때, 기존 프론트는 반복 일정 전체를 해제하고 다시 설정하는 우회 흐름에 가까웠습니다.
- 백엔드에서 `DAY_OFF` 날짜별 이벤트가 반복 일정보다 우선 적용되도록 지원하므로, 프론트도 같은 날짜의 반복 일정을 숨기고 휴무 이벤트를 명확히 보여줘야 합니다.
- 총무/팀장/개인이 캘린더에서 실제 예외 판정 기준과 같은 화면을 보지 못하면 출근일 수정/삭제 혼선이 계속 생길 수 있습니다.

## 상세 변경 사항
### 주요 변경
- [x] 날짜별 근무 일정 API 타입에 `eventType`, nullable `startTime/endTime`, `reason` 계약 반영
- [x] `DAY_OFF` 날짜별 이벤트가 같은 날짜의 반복 근무 일정을 덮어쓰도록 캘린더 합성 로직 수정
- [x] 본인 반복 일정 상세에서 “이 날짜만 휴무” 단건 휴무 생성 액션 추가
- [x] 휴무 이벤트를 별도 색상/범례로 표시하고 “휴무 취소” 삭제 흐름 추가
- [x] MSW mock에 `DAY_OFF` 생성/수정 계약 반영
- [x] API/화면 테스트에 휴무 생성, 반복 일정 덮어쓰기, 휴무 취소 회귀 추가

### 백엔드 계약
- `WorkScheduleEventRequest.eventType`: `WORKING | DAY_OFF`
- `DAY_OFF` 요청: `{ date, eventType: "DAY_OFF", startTime: null, endTime: null, endsNextDay: false, reason }`
- `DAY_OFF` 응답은 반복 일정의 특정 날짜 취소로 해석하며, 같은 멤버/날짜의 반복 일정보다 우선합니다.

### 포함 PR
- #390 feat: 반복 근무 특정 날짜 휴무 처리 연동

### 추가 메모
- develop 머지는 사용자 지침에 따라 CI 대기 없이 완료했고, main PR은 머지하지 않고 열어둡니다.

## 테스트
- [x] `npm test -- src/shared/api/__tests__/attendanceApi.test.ts src/pages/work-schedules/__tests__/WorkSchedules.test.tsx`
- [x] `npm run test:run`
- [x] `npx eslint src/shared/api/attendanceApi.ts src/shared/api/__tests__/attendanceApi.test.ts src/shared/api/mock/handlers/attendance.ts src/pages/work-schedules/index.tsx src/pages/work-schedules/__tests__/WorkSchedules.test.tsx`
- [x] `npm run build`

## 참고
- `npm run test:run` 실행 중 Vitest/Node의 `--localstorage-file` 경고와 jsdom navigation 미구현 경고가 출력되지만 테스트는 전부 통과했습니다.
- `npm run build`는 기존과 동일하게 500kB 이상 chunk 경고를 출력하지만 빌드는 성공했습니다.

## 리뷰 포인트
- 반복 일정 상세에서 “이 날짜만 휴무” 흐름이 사용자가 기대하는 부분 취소 UX와 맞는지 확인 부탁드립니다.
- `DAY_OFF` 이벤트가 캘린더에서 과하지 않지만 충분히 눈에 띄게 구분되는지 봐주세요.
- 반복 일정과 날짜별 근무/휴무 이벤트가 같은 날짜에 있을 때, 백엔드 예외 판정 우선순위와 화면 표현이 어긋나지 않는지 확인 부탁드립니다.

## 관련 이슈
- closes #389