### PR TITLE
fix: 특정 날짜 반복 일정 제외 표시 정리

### DIFF
--- a/src/pages/work-schedules/__tests__/WorkSchedules.test.tsx
+++ b/src/pages/work-schedules/__tests__/WorkSchedules.test.tsx
@@ -35,6 +35,9 @@ vi.mock('@fullcalendar/react', () => ({
           <button type="button" onClick={() => props.dateClick?.({ dateStr: '2026-03-30' })}>
             날짜 클릭
           </button>
+          <button type="button" onClick={() => props.dateClick?.({ dateStr: '2026-05-04' })}>
+            날짜 클릭 2026-05-04
+          </button>
           {capturedEvents.map((event, index) => {
             const meta = event.extendedProps as {
               kind?: string
@@ -255,7 +258,7 @@ describe('WorkSchedules 페이지', () => {
     })
   })
 
-  it('DAY_OFF 날짜별 이벤트는 같은 날짜의 반복 일정을 가리고 휴무 이벤트를 보여준다', async () => {
+  it('DAY_OFF 날짜별 이벤트는 같은 날짜의 반복 일정을 가리고 캘린더에서는 숨긴다', async () => {
     mockGetAllWorkScheduleEvents.mockResolvedValue([
       {
         id: 200,
@@ -288,7 +291,7 @@ describe('WorkSchedules 페이지', () => {
         const meta = event.extendedProps as { kind?: string; item?: { eventType?: string; date?: string } } | undefined
         return meta?.kind === 'date-event' && meta.item?.eventType === 'DAY_OFF' && meta.item.date === '2026-05-04'
       }),
-    ).toBe(true)
+    ).toBe(false)
   })
 
   it('본인 반복 일정 상세에서 해당 날짜만 휴무 처리할 수 있다', async () => {
@@ -299,7 +302,7 @@ describe('WorkSchedules 페이지', () => {
     })
     fireEvent.click(recurringButtons[0])
 
-    fireEvent.click(screen.getByRole('button', { name: '이 날짜만 휴무' }))
+    fireEvent.click(screen.getByRole('button', { name: '이 날짜만 제외' }))
 
     await waitFor(() => {
       expect(mockCreateWorkScheduleEvent).toHaveBeenCalledWith({
@@ -313,7 +316,7 @@ describe('WorkSchedules 페이지', () => {
     })
   })
 
-  it('DAY_OFF 이벤트를 삭제하면 반복 일정 휴무를 취소한다', async () => {
+  it('DAY_OFF가 숨겨진 날짜를 클릭하면 반복 일정 제외를 취소할 수 있다', async () => {
     mockGetAllWorkScheduleEvents.mockResolvedValue([
       {
         id: 200,
@@ -330,11 +333,12 @@ describe('WorkSchedules 페이지', () => {
 
     render(<WorkSchedules />)
 
-    const dayOffButton = await screen.findByRole('button', {
-      name: /이벤트 .*관리자 휴무 date-event DAY_OFF 2026-05-04/,
+    await waitFor(() => {
+      expect(mockGetAllWorkScheduleEvents).toHaveBeenCalled()
     })
-    fireEvent.click(dayOffButton)
-    fireEvent.click(screen.getByRole('button', { name: '휴무 취소' }))
+
+    fireEvent.click(screen.getByRole('button', { name: '날짜 클릭 2026-05-04' }))
+    fireEvent.click(screen.getByRole('button', { name: '제외 취소' }))
 
     await waitFor(() => {
       expect(mockDeleteWorkScheduleEvent).toHaveBeenCalledWith(200)

--- a/src/pages/work-schedules/index.tsx
+++ b/src/pages/work-schedules/index.tsx
@@ -160,21 +160,7 @@ function formatDateLabel(date: string) {
   }).format(new Date(`${date}T12:00:00`))
 }
 
-function getEventColors(kind: 'recurring' | 'date-event' | 'day-off', isMine: boolean) {
-  if (kind === 'day-off') {
-    return isMine
-      ? {
-          backgroundColor: 'rgba(244, 63, 94, 0.18)',
-          borderColor: 'rgba(244, 63, 94, 0.46)',
-          textColor: 'var(--text-primary)',
-        }
-      : {
-          backgroundColor: 'rgba(148, 163, 184, 0.16)',
-          borderColor: 'rgba(148, 163, 184, 0.34)',
-          textColor: 'var(--text-primary)',
-        }
-  }
-
+function getEventColors(kind: 'recurring' | 'date-event', isMine: boolean) {
   if (kind === 'date-event') {
     return isMine
       ? {
@@ -264,20 +250,7 @@ function toDateEvents(items: WorkScheduleEventItem[], currentUserId: string): Ev
   return items.flatMap<EventInput>((item) => {
     const isMine = String(item.memberId) === currentUserId
     if (isDayOffEvent(item)) {
-      const colors = getEventColors('day-off', isMine)
-      return [{
-        id: `date-event-${item.id}`,
-        title: `${item.memberName} 휴무`,
-        start: item.date,
-        allDay: true,
-        editable: false,
-        ...colors,
-        extendedProps: {
-          kind: 'date-event',
-          item,
-          isEditable: isMine,
-        } satisfies CalendarDateEventMeta,
-      }]
+      return []
     }
 
     if (!item.startTime || !item.endTime) return []
@@ -527,9 +500,36 @@ export function WorkSchedules() {
     })
   }, [])
 
+  const openDayOffModal = useCallback((item: WorkScheduleEventItem) => {
+    setModalState({
+      mode: 'edit',
+      date: item.date,
+      startTime: DEFAULT_START_TIME,
+      endTime: DEFAULT_END_TIME,
+      endsNextDay: false,
+      eventType: 'DAY_OFF',
+      reason: item.reason ?? '',
+      item: {
+        kind: 'date-event',
+        item,
+        isEditable: true,
+      },
+    })
+  }, [])
+
   const handleDateClick = useCallback((arg: DateClickArg) => {
-    openCreateModal(arg.dateStr.slice(0, 10))
-  }, [openCreateModal])
+    const date = arg.dateStr.slice(0, 10)
+    const dayOffOverride = filteredDateEvents.find(
+      (item) => isDayOffEvent(item) && item.date === date && String(item.memberId) === currentUserId,
+    )
+
+    if (dayOffOverride) {
+      openDayOffModal(dayOffOverride)
+      return
+    }
+
+    openCreateModal(date)
+  }, [currentUserId, filteredDateEvents, openCreateModal, openDayOffModal])
 
   const handleEventClick = useCallback((arg: EventClickArg) => {
     const meta = arg.event.extendedProps as WorkScheduleCalendarMeta | undefined
@@ -642,7 +642,7 @@ export function WorkSchedules() {
   const modalTitle = useMemo(() => {
     if (!modalState) return ''
     if (modalState.mode === 'create') return '날짜별 근무 일정 추가'
-    if (modalState.eventType === 'DAY_OFF') return '반복 일정 휴무'
+    if (modalState.eventType === 'DAY_OFF') return '근무 일정 제외'
     if (modalState.item?.kind === 'date-event') return '날짜별 근무 일정'
     return '근무 일정 상세'
   }, [modalState])
@@ -655,7 +655,7 @@ export function WorkSchedules() {
   const modalDateRangeLabel = useMemo(() => {
     if (!modalState) return ''
     const startDateLabel = formatDateLabel(modalState.date)
-    if (modalState.eventType === 'DAY_OFF') return `${startDateLabel} 휴무`
+    if (modalState.eventType === 'DAY_OFF') return `${startDateLabel} 일정 제외`
     if (!modalState.endsNextDay) return `${startDateLabel} 하루 일정`
     return `${startDateLabel} ~ ${formatDateLabel(modalEndDate)}`
   }, [modalEndDate, modalState])
@@ -757,7 +757,6 @@ export function WorkSchedules() {
               <span className="legend-chip recurring-team">공유 반복 일정</span>
               <span className="legend-chip date-own">날짜별 추가 일정</span>
               <span className="legend-chip date-team">팀 공유 일정</span>
-              <span className="legend-chip day-off">반복 일정 휴무</span>
             </div>
             <button
               type="button"
@@ -868,15 +867,15 @@ export function WorkSchedules() {
 
                 {String(modalState.item.memberId) === currentUserId && (
                   <div className="work-schedules-day-off-callout">
-                    <strong>이 반복 일정만 쉬어야 하나요?</strong>
-                    <span>반복 설정은 유지하고, 선택한 날짜만 휴무로 덮어씁니다.</span>
+                    <strong>이 날짜만 일정에서 제외할까요?</strong>
+                    <span>반복 설정은 유지하고, 선택한 날짜의 근무 일정만 캘린더에서 제외합니다.</span>
                     <button
                       type="button"
                       className="danger-btn"
                       onClick={handleCreateDayOffFromRecurring}
                       disabled={isModalSaving}
                     >
-                      {isModalSaving ? '처리 중...' : '이 날짜만 휴무'}
+                      {isModalSaving ? '처리 중...' : '이 날짜만 제외'}
                     </button>
                   </div>
                 )}
@@ -896,7 +895,7 @@ export function WorkSchedules() {
                 <div className="work-schedules-detail-item">
                   <strong>{isModalDayOff ? '상태' : '시간'}</strong>
                   {isModalDayOff ? (
-                    <span>반복 일정에서 이 날짜만 휴무 처리됨</span>
+                    <span>반복 일정에서 이 날짜만 제외됨</span>
                   ) : (
                     <span>
                       {formatScheduleRangeLabel({
@@ -919,7 +918,7 @@ export function WorkSchedules() {
                   disabled={isModalSaving}
                 >
                   <Trash2 size={16} />
-                  휴무 취소
+                  제외 취소
                 </button>
                 <button type="button" className="secondary-btn" onClick={() => setModalState(null)}>
                   닫기

--- a/src/pages/work-schedules/work-schedules.css
+++ b/src/pages/work-schedules/work-schedules.css
@@ -164,10 +164,6 @@
   background: rgba(14, 165, 233, 0.14);
 }
 
-.legend-chip.day-off {
-  background: rgba(244, 63, 94, 0.14);
-}
-
 .quick-add-btn,
 .primary-btn,
 .secondary-btn,


### PR DESCRIPTION
## 관련 이슈
closes #392

## 작업 내용
- `DAY_OFF` 날짜별 이벤트를 캘린더 메인 이벤트로 표시하지 않도록 변경했습니다.
- `DAY_OFF`는 같은 멤버/날짜의 반복 일정을 막는 숨은 제외 기록으로만 사용합니다.
- 본인 제외 날짜를 다시 클릭하면 “근무 일정 제외” 모달을 열어 제외 취소를 할 수 있게 했습니다.
- 반복 일정 상세 CTA와 모달 문구를 “휴무 표시”가 아니라 “일정 제외” 기준으로 정리했습니다.
- 더 이상 보이지 않는 `DAY_OFF` 범례 색상을 제거했습니다.

## 검증
- `npm test -- src/pages/work-schedules/__tests__/WorkSchedules.test.tsx`
- `npm test -- src/shared/api/__tests__/attendanceApi.test.ts src/pages/work-schedules/__tests__/WorkSchedules.test.tsx`
- `npm run test:run`
- `npx eslint src/pages/work-schedules/index.tsx src/pages/work-schedules/__tests__/WorkSchedules.test.tsx`
- `npm run build`

## 참고
- `npm run test:run` 실행 중 Vitest/Node의 `--localstorage-file` 경고와 jsdom navigation 미구현 경고가 출력되지만 테스트는 전부 통과했습니다.
- CSS 파일은 현재 ESLint 설정상 검사 대상이 아니라 CSS를 직접 넣으면 “ignored” 경고만 발생합니다.
- `npm run build`는 기존과 동일한 500kB 이상 chunk 경고를 출력하지만 빌드는 성공했습니다.

## 리뷰 포인트
- 반복 일정 중 제외된 날짜가 캘린더에서 실제로 비어 보이는지 확인 부탁드립니다.
- 빈 날짜 클릭으로 제외 취소를 제공하는 흐름이 운영자가 복구할 수 있을 만큼 충분한지 봐주세요.