### PR TITLE
release: v1.1.4

### DIFF
--- a/src/features/attendance/model/__tests__/useWorkSchedule.test.ts
+++ b/src/features/attendance/model/__tests__/useWorkSchedule.test.ts
@@ -4,6 +4,10 @@ import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
 import { useWorkSchedule } from '../useWorkSchedule'
 
+const TODAY = new Date().toISOString().slice(0, 10)
+const TODAY_INDEX = (new Date(`${TODAY}T12:00:00`).getDay() + 6) % 7
+const INDEX_TO_DOW = ['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY', 'SUNDAY'] as const
+
 const DEFAULT_SCHEDULES = [
   { id: 1, dayOfWeek: 'MONDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'EVERY', endsNextDay: false },
   { id: 2, dayOfWeek: 'TUESDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'EVERY', endsNextDay: false },
@@ -15,6 +19,9 @@ const DEFAULT_SCHEDULES = [
 const server = setupServer(
   http.get('/api/v1/work-schedules/me', () =>
     HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: DEFAULT_SCHEDULES }),
+  ),
+  http.get('/api/v1/work-schedule-events', () =>
+    HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: [] }),
   ),
   http.put('/api/v1/work-schedules', async ({ request }) => {
     const body = await request.json() as Record<string, string>
@@ -80,6 +87,90 @@ describe('useWorkSchedule', () => {
       expect(result.current.workDays.slice(0, 5)).toEqual([true, true, true, true, true])
       expect(result.current.workDays[5]).toBe(false)
       expect(result.current.workDays[6]).toBe(false)
+    })
+
+    it('오늘 날짜별 DAY_OFF가 있으면 반복 일정은 유지하되 오늘 적용 일정만 휴무로 본다', async () => {
+      server.use(
+        http.get('/api/v1/work-schedules/me', () =>
+          HttpResponse.json({
+            code: 'SUCCESS',
+            message: 'ok',
+            data: [
+              {
+                id: 100,
+                dayOfWeek: INDEX_TO_DOW[TODAY_INDEX],
+                startTime: '09:00:00',
+                endTime: '18:00:00',
+                weekPattern: 'EVERY',
+                endsNextDay: false,
+              },
+            ],
+          }),
+        ),
+        http.get('/api/v1/work-schedule-events', () =>
+          HttpResponse.json({
+            code: 'SUCCESS',
+            message: 'ok',
+            data: [
+              {
+                id: 200,
+                date: TODAY,
+                eventType: 'DAY_OFF',
+                startTime: null,
+                endTime: null,
+                endsNextDay: false,
+                memberId: 1,
+                memberName: '김리더',
+                teamName: '1팀',
+              },
+            ],
+          }),
+        ),
+      )
+
+      const { result } = await mountHook()
+
+      expect(result.current.workDays[TODAY_INDEX]).toBe(true)
+      expect(result.current.todayWorkEnabled).toBe(false)
+      expect(result.current.todayScheduleSource).toBe('DAY_OFF')
+    })
+
+    it('오늘 날짜별 WORKING이 있으면 반복 일정이 없어도 오늘 적용 일정으로 본다', async () => {
+      server.use(
+        http.get('/api/v1/work-schedules/me', () =>
+          HttpResponse.json({ code: 'SUCCESS', message: 'ok', data: [] }),
+        ),
+        http.get('/api/v1/work-schedule-events', () =>
+          HttpResponse.json({
+            code: 'SUCCESS',
+            message: 'ok',
+            data: [
+              {
+                id: 201,
+                date: TODAY,
+                eventType: 'WORKING',
+                startTime: '13:00:00',
+                endTime: '18:30:00',
+                endsNextDay: false,
+                memberId: 1,
+                memberName: '김리더',
+                teamName: '1팀',
+              },
+            ],
+          }),
+        ),
+      )
+
+      const { result } = await mountHook()
+
+      expect(result.current.workDays[TODAY_INDEX]).toBe(false)
+      expect(result.current.todayWorkEnabled).toBe(true)
+      expect(result.current.todayWorkSchedule).toMatchObject({
+        checkInTime: '13:00',
+        checkOutTime: '18:30',
+        endsNextDay: false,
+      })
+      expect(result.current.todayScheduleSource).toBe('DATE_EVENT')
     })
   })
 

--- a/src/features/attendance/model/useWorkSchedule.ts
+++ b/src/features/attendance/model/useWorkSchedule.ts
@@ -1,13 +1,21 @@
 import { useState, useEffect } from 'react'
-import { deleteWorkScheduleDay, getMyWorkSchedule, upsertWorkScheduleDay } from '../../../shared/api/attendanceApi'
-import type { DayOfWeek, WeekPattern } from '../../../shared/api/attendanceApi'
+import {
+  deleteWorkScheduleDay,
+  getMyWorkSchedule,
+  getWorkScheduleEvents,
+  upsertWorkScheduleDay,
+} from '../../../shared/api/attendanceApi'
+import type { DayOfWeek, WeekPattern, WorkScheduleEventItem } from '../../../shared/api/attendanceApi'
 import { ApiError } from '../../../shared/api/baseClient'
+import { getTodayStr } from '../../../shared/lib/date'
 
 export interface DaySchedule {
   checkInTime: string   // "HH:mm"
   checkOutTime: string  // "HH:mm"
   endsNextDay: boolean
 }
+
+export type TodayScheduleSource = 'RECURRING' | 'DATE_EVENT' | 'DAY_OFF' | 'NONE'
 
 export type { WeekPattern } from '../../../shared/api/attendanceApi'
 
@@ -28,12 +36,28 @@ function makeDefaultDaySchedules(checkIn: string, checkOut: string): DaySchedule
   return Array.from({ length: 7 }, () => ({ checkInTime: checkIn, checkOutTime: checkOut, endsNextDay: false }))
 }
 
+function getEventType(event: WorkScheduleEventItem) {
+  return event.eventType ?? 'WORKING'
+}
+
+function toDaySchedule(event: WorkScheduleEventItem): DaySchedule | null {
+  if (!event.startTime || !event.endTime) return null
+
+  return {
+    checkInTime: event.startTime.slice(0, 5),
+    checkOutTime: event.endTime.slice(0, 5),
+    endsNextDay: Boolean(event.endsNextDay),
+  }
+}
+
 export function useWorkSchedule() {
+  const [today] = useState(() => getTodayStr())
   const [workDays, setWorkDays] = useState<boolean[]>(DEFAULT_WORK_DAYS)
   const [daySchedules, setDaySchedules] = useState<DaySchedule[]>(
     makeDefaultDaySchedules(DEFAULT_CHECK_IN, DEFAULT_CHECK_OUT),
   )
   const [weekPatterns, setWeekPatterns] = useState<WeekPattern[]>(DEFAULT_WEEK_PATTERNS)
+  const [todayOverride, setTodayOverride] = useState<WorkScheduleEventItem | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -48,7 +72,9 @@ export function useWorkSchedule() {
         if (Array.isArray(parsed) && parsed.length === 7) {
           parsedStoredDays = parsed
         }
-      } catch {}
+      } catch {
+        // Ignore malformed localStorage and prefer the API response.
+      }
     }
 
     // localStorage에서 근무 요일 토글 상태는 API 조회 실패 시에만 fallback으로 사용
@@ -57,7 +83,9 @@ export function useWorkSchedule() {
       try {
         const parsed = JSON.parse(storedWeekPatterns) as WeekPattern[]
         if (Array.isArray(parsed) && parsed.length === 7) setWeekPatterns(parsed)
-      } catch {}
+      } catch {
+        // Ignore malformed localStorage and keep the default recurrence pattern.
+      }
     }
 
     const storedEndsNextDay = localStorage.getItem(WORK_ENDS_NEXT_DAY_STORAGE_KEY)
@@ -69,11 +97,21 @@ export function useWorkSchedule() {
             prev.map((schedule, index) => ({ ...schedule, endsNextDay: parsed[index] ?? false })),
           )
         }
-      } catch {}
+      } catch {
+        // Ignore malformed localStorage and keep same-day end defaults.
+      }
     }
 
+    const loadTodayOverride = getWorkScheduleEvents(today, today)
+      .then((items) => {
+        setTodayOverride(items.find((item) => item.date === today) ?? null)
+      })
+      .catch(() => {
+        setTodayOverride(null)
+      })
+
     // API에서 요일별 근무 시간 불러오기
-    getMyWorkSchedule()
+    const loadRecurringSchedule = getMyWorkSchedule()
       .then((items) => {
         const activeDays = INDEX_TO_DOW.map((dow) =>
           items.some((item) => item.dayOfWeek === dow),
@@ -114,8 +152,9 @@ export function useWorkSchedule() {
           setSavedWorkDays(parsedStoredDays)
         }
       })
-      .finally(() => setIsLoading(false))
-  }, [])
+
+    Promise.allSettled([loadRecurringSchedule, loadTodayOverride]).finally(() => setIsLoading(false))
+  }, [today])
 
   const toggleDay = (index: number) => {
     setWorkDays((prev) => prev.map((v, i) => (i === index ? !v : v)))
@@ -180,10 +219,34 @@ export function useWorkSchedule() {
     return saved
   }
 
+  const todayIndex = (new Date(`${today}T12:00:00`).getDay() + 6) % 7
+  const todayRecurringEnabled = workDays[todayIndex]
+  const todayRecurringSchedule = daySchedules[todayIndex]
+  const todayOverrideType = todayOverride ? getEventType(todayOverride) : null
+  const todayOverrideSchedule = todayOverride && todayOverrideType === 'WORKING'
+    ? toDaySchedule(todayOverride)
+    : null
+  const todayWorkEnabled = todayOverrideType === 'DAY_OFF'
+    ? false
+    : todayOverrideSchedule
+      ? true
+      : todayRecurringEnabled
+  const todayWorkSchedule = todayOverrideSchedule ?? todayRecurringSchedule
+  const todayScheduleSource: TodayScheduleSource = todayOverrideType === 'DAY_OFF'
+    ? 'DAY_OFF'
+    : todayOverrideSchedule
+      ? 'DATE_EVENT'
+      : todayRecurringEnabled
+        ? 'RECURRING'
+        : 'NONE'
+
   return {
     workDays,
     daySchedules,
     weekPatterns,
+    todayWorkEnabled,
+    todayWorkSchedule,
+    todayScheduleSource,
     isLoading,
     isSaving,
     error,

--- a/src/pages/dashboard/__tests__/Dashboard.test.tsx
+++ b/src/pages/dashboard/__tests__/Dashboard.test.tsx
@@ -53,6 +53,27 @@ vi.mock('../../../shared/lib/date', () => ({
   getTodayStr: () => '2026-03-23',
 }))
 
+const DEFAULT_DAY_SCHEDULES = [
+  { checkInTime: '09:00', checkOutTime: '18:00' },
+  { checkInTime: '09:00', checkOutTime: '18:00' },
+  { checkInTime: '09:00', checkOutTime: '18:00' },
+  { checkInTime: '09:00', checkOutTime: '18:00' },
+  { checkInTime: '09:00', checkOutTime: '18:00' },
+  { checkInTime: '09:00', checkOutTime: '18:00' },
+  { checkInTime: '09:00', checkOutTime: '18:00' },
+]
+
+function makeWorkScheduleState(overrides: Record<string, unknown> = {}) {
+  return {
+    workDays: [true, false, false, false, false, false, false],
+    daySchedules: DEFAULT_DAY_SCHEDULES,
+    todayWorkEnabled: true,
+    todayWorkSchedule: DEFAULT_DAY_SCHEDULES[0],
+    todayScheduleSource: 'RECURRING',
+    ...overrides,
+  }
+}
+
 describe('Dashboard 페이지', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -66,18 +87,7 @@ describe('Dashboard 페이지', () => {
       clearError: vi.fn(),
       isLoading: false,
     })
-    mockUseWorkSchedule.mockReturnValue({
-      workDays: [true, false, false, false, false, false, false],
-      daySchedules: [
-        { checkInTime: '09:00', checkOutTime: '18:00' },
-        { checkInTime: '09:00', checkOutTime: '18:00' },
-        { checkInTime: '09:00', checkOutTime: '18:00' },
-        { checkInTime: '09:00', checkOutTime: '18:00' },
-        { checkInTime: '09:00', checkOutTime: '18:00' },
-        { checkInTime: '09:00', checkOutTime: '18:00' },
-        { checkInTime: '09:00', checkOutTime: '18:00' },
-      ],
-    })
+    mockUseWorkSchedule.mockReturnValue(makeWorkScheduleState())
   })
 
   it('대시보드 페이지가 렌더링된다', () => {
@@ -118,18 +128,11 @@ describe('Dashboard 페이지', () => {
 
   it('근무 일정이 없는 날에는 출근 버튼 클릭 시 경고 모달이 열린다', async () => {
     const user = userEvent.setup()
-    mockUseWorkSchedule.mockReturnValue({
+    mockUseWorkSchedule.mockReturnValue(makeWorkScheduleState({
       workDays: [false, false, false, false, false, false, false],
-      daySchedules: [
-        { checkInTime: '09:00', checkOutTime: '18:00' },
-        { checkInTime: '09:00', checkOutTime: '18:00' },
-        { checkInTime: '09:00', checkOutTime: '18:00' },
-        { checkInTime: '09:00', checkOutTime: '18:00' },
-        { checkInTime: '09:00', checkOutTime: '18:00' },
-        { checkInTime: '09:00', checkOutTime: '18:00' },
-        { checkInTime: '09:00', checkOutTime: '18:00' },
-      ],
-    })
+      todayWorkEnabled: false,
+      todayScheduleSource: 'NONE',
+    }))
 
     render(
       <MemoryRouter>
@@ -147,18 +150,11 @@ describe('Dashboard 페이지', () => {
 
   it('근무 일정 경고 모달에서 계속하기를 누르면 출근 처리한다', async () => {
     const user = userEvent.setup()
-    mockUseWorkSchedule.mockReturnValue({
+    mockUseWorkSchedule.mockReturnValue(makeWorkScheduleState({
       workDays: [false, false, false, false, false, false, false],
-      daySchedules: [
-        { checkInTime: '09:00', checkOutTime: '18:00' },
-        { checkInTime: '09:00', checkOutTime: '18:00' },
-        { checkInTime: '09:00', checkOutTime: '18:00' },
-        { checkInTime: '09:00', checkOutTime: '18:00' },
-        { checkInTime: '09:00', checkOutTime: '18:00' },
-        { checkInTime: '09:00', checkOutTime: '18:00' },
-        { checkInTime: '09:00', checkOutTime: '18:00' },
-      ],
-    })
+      todayWorkEnabled: false,
+      todayScheduleSource: 'NONE',
+    }))
 
     render(
       <MemoryRouter>
@@ -170,6 +166,44 @@ describe('Dashboard 페이지', () => {
     await user.click(screen.getByRole('button', { name: '계속하기' }))
 
     expect(mockHandleClockClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('오늘 날짜별 DAY_OFF가 적용되면 휴무로 표시하고 출근 전 확인 모달을 연다', async () => {
+    const user = userEvent.setup()
+    mockUseWorkSchedule.mockReturnValue(makeWorkScheduleState({
+      todayWorkEnabled: false,
+      todayScheduleSource: 'DAY_OFF',
+    }))
+
+    render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('오늘은 휴무입니다')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: '출근하기' }))
+
+    expect(screen.getByText('근무 일정을 등록하셨나요?')).toBeInTheDocument()
+    expect(mockHandleClockClick).not.toHaveBeenCalled()
+  })
+
+  it('오늘 날짜별 WORKING이 적용되면 반복 일정 없이도 근무 예정 시간을 표시한다', () => {
+    mockUseWorkSchedule.mockReturnValue(makeWorkScheduleState({
+      workDays: [false, false, false, false, false, false, false],
+      todayWorkEnabled: true,
+      todayWorkSchedule: { checkInTime: '13:00', checkOutTime: '18:30', endsNextDay: false },
+      todayScheduleSource: 'DATE_EVENT',
+    }))
+
+    render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('오늘 근무 예정 13:00 - 18:30')).toBeInTheDocument()
   })
 
   it('퇴근 완료 상태에서 출근 내역 초기화 버튼 클릭 시 확인 모달이 열린다', async () => {

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -78,7 +78,7 @@ export function Dashboard() {
     clearError,
     isLoading,
   } = useWorkSession()
-  const { workDays, daySchedules } = useWorkSchedule()
+  const { todayWorkEnabled, todayWorkSchedule } = useWorkSchedule()
   const { getEventsByDate, updateEvent, deleteEvent } = useEvents()
   const { channels, getMessagesByChannel, activeChannelId } = useChat()
   const { getTasksByDate, toggleTaskDone } = useTasks()
@@ -88,9 +88,6 @@ export function Dashboard() {
   const recentMessages = getMessagesByChannel(activeChannelId).slice(-3)
   const todayTasks = getTasksByDate(today)
   const activeChannel = channels.find((channel) => channel.id === activeChannelId)
-  const todayIndex = (new Date().getDay() + 6) % 7
-  const todayWorkEnabled = workDays[todayIndex]
-  const todayWorkSchedule = daySchedules[todayIndex]
   const nowMinutes = (now.getHours() * 60) + now.getMinutes()
 
   useEffect(() => {


### PR DESCRIPTION
## 작업 내용
- develop 브랜치의 최신 변경 사항을 main에 반영하는 `v1.1.4` 배포 PR입니다.
- 이번 배포에는 대시보드 출근 카드가 날짜별 근무 일정(`WorkScheduleEvent`) 우선순위를 반영하도록 수정한 내용이 포함됩니다.
- 반복 일정 편집 상태는 유지하면서, 오늘 실제 적용 일정만 별도로 합성해 출근 가능 여부와 예정 시간을 표시합니다.

## 변경 이유
- 백엔드는 날짜별 근무 일정이 반복 일정보다 우선 적용되도록 수정됐지만, 프론트 출근 카드는 반복 요일 배열만 보고 있었습니다.
- 그 결과 특정 날짜를 `DAY_OFF`로 제외해도 오늘 휴무 표시/출근 전 확인 흐름이 어긋날 수 있었습니다.
- 반대로 반복 일정이 없는 날에 날짜별 `WORKING` 일정을 추가해도 대시보드가 오늘 근무 예정 시간으로 표시하지 못했습니다.

## 상세 변경 사항
### 주요 변경
- [x] `useWorkSchedule()`에서 오늘 날짜의 `/api/v1/work-schedule-events` 조회 추가
- [x] 반복 근무 편집용 `workDays/daySchedules`와 대시보드용 `todayWorkEnabled/todayWorkSchedule` 분리
- [x] 오늘 `DAY_OFF`가 있으면 출근 카드에서 휴무로 판단
- [x] 오늘 `WORKING`이 있으면 반복 일정이 없어도 출근 카드에서 근무 예정으로 판단
- [x] 대시보드가 반복 요일 배열 대신 오늘 적용 일정 값을 사용하도록 변경
- [x] hook/dashboard 회귀 테스트 추가

### 포함 PR
- #396 fix: 출근 카드에 날짜별 근무 일정 반영

### 추가 메모
- develop 머지는 사용자 지침에 따라 CI 대기 없이 완료했고, main PR은 머지하지 않고 열어둡니다.

## 테스트
- [x] `npm test -- src/features/attendance/model/__tests__/useWorkSchedule.test.ts`
- [x] `npm test -- src/features/attendance/model/__tests__/useWorkSchedule.test.ts src/pages/dashboard/__tests__/Dashboard.test.tsx`
- [x] `npm run test:run`
- [x] `npx eslint src/features/attendance/model/useWorkSchedule.ts src/features/attendance/model/__tests__/useWorkSchedule.test.ts src/pages/dashboard/index.tsx src/pages/dashboard/__tests__/Dashboard.test.tsx`
- [x] `npm run build`

## 참고
- `npm run test:run` 실행 중 Vitest/Node의 `--localstorage-file` 경고와 jsdom navigation 미구현 경고가 출력되지만 테스트는 전부 통과했습니다.
- `npm run build`는 기존과 동일하게 500kB 이상 chunk 경고를 출력하지만 빌드는 성공했습니다.

## 리뷰 포인트
- 오늘 `DAY_OFF`가 적용됐을 때 출근 카드가 “오늘은 휴무입니다”로 표시되는지 확인 부탁드립니다.
- 오늘 날짜별 `WORKING` 추가 일정이 반복 일정이 없는 날에도 출근 카드 예정 시간으로 표시되는지 봐주세요.
- 반복 근무 편집기의 요일 토글 상태가 날짜별 이벤트 때문에 바뀌지 않는지 확인 부탁드립니다.

## 관련 이슈
- closes #395