### PR TITLE
release: v1.1.5

### DIFF
--- a/src/features/attendance/model/__tests__/useWorkSchedule.test.ts
+++ b/src/features/attendance/model/__tests__/useWorkSchedule.test.ts
@@ -3,6 +3,8 @@ import { renderHook, act } from '@testing-library/react'
 import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
 import { useWorkSchedule } from '../useWorkSchedule'
+import type { WeekPattern } from '../../../../shared/api/attendanceApi'
+import { matchesWeekPattern } from '../../../../shared/lib/attendanceSchedule'
 
 const TODAY = new Date().toISOString().slice(0, 10)
 const TODAY_INDEX = (new Date(`${TODAY}T12:00:00`).getDay() + 6) % 7
@@ -15,6 +17,13 @@ const DEFAULT_SCHEDULES = [
   { id: 4, dayOfWeek: 'THURSDAY', startTime: '09:00:00', endTime: '18:00:00', weekPattern: 'EVERY', endsNextDay: false },
   { id: 5, dayOfWeek: 'FRIDAY', startTime: '22:00:00', endTime: '06:00:00', weekPattern: 'LAST', endsNextDay: true },
 ]
+
+function getNonMatchingPattern(dateStr: string): Exclude<WeekPattern, 'EVERY'> {
+  const date = new Date(`${dateStr}T12:00:00`)
+  return (['FIRST', 'SECOND', 'THIRD', 'FOURTH', 'LAST'] as const).find(
+    (pattern) => !matchesWeekPattern(date, pattern),
+  ) ?? 'FIRST'
+}
 
 const server = setupServer(
   http.get('/api/v1/work-schedules/me', () =>
@@ -171,6 +180,34 @@ describe('useWorkSchedule', () => {
         endsNextDay: false,
       })
       expect(result.current.todayScheduleSource).toBe('DATE_EVENT')
+    })
+
+    it('오늘 요일의 반복 일정이 있어도 주차 패턴이 맞지 않으면 휴무로 본다', async () => {
+      const nonMatchingPattern = getNonMatchingPattern(TODAY)
+      server.use(
+        http.get('/api/v1/work-schedules/me', () =>
+          HttpResponse.json({
+            code: 'SUCCESS',
+            message: 'ok',
+            data: [
+              {
+                id: 300,
+                dayOfWeek: INDEX_TO_DOW[TODAY_INDEX],
+                startTime: '09:00:00',
+                endTime: '18:00:00',
+                weekPattern: nonMatchingPattern,
+                endsNextDay: false,
+              },
+            ],
+          }),
+        ),
+      )
+
+      const { result } = await mountHook()
+
+      expect(result.current.workDays[TODAY_INDEX]).toBe(true)
+      expect(result.current.todayWorkEnabled).toBe(false)
+      expect(result.current.todayScheduleSource).toBe('NONE')
     })
   })
 

--- a/src/features/attendance/model/useWorkSchedule.ts
+++ b/src/features/attendance/model/useWorkSchedule.ts
@@ -7,7 +7,8 @@ import {
 } from '../../../shared/api/attendanceApi'
 import type { DayOfWeek, WeekPattern, WorkScheduleEventItem } from '../../../shared/api/attendanceApi'
 import { ApiError } from '../../../shared/api/baseClient'
-import { getTodayStr } from '../../../shared/lib/date'
+import { getTodayStr, parseDateString } from '../../../shared/lib/date'
+import { matchesWeekPattern } from '../../../shared/lib/attendanceSchedule'
 
 export interface DaySchedule {
   checkInTime: string   // "HH:mm"
@@ -220,7 +221,8 @@ export function useWorkSchedule() {
   }
 
   const todayIndex = (new Date(`${today}T12:00:00`).getDay() + 6) % 7
-  const todayRecurringEnabled = workDays[todayIndex]
+  const todayRecurringMatchesPattern = matchesWeekPattern(parseDateString(today), weekPatterns[todayIndex])
+  const todayRecurringEnabled = workDays[todayIndex] && todayRecurringMatchesPattern
   const todayRecurringSchedule = daySchedules[todayIndex]
   const todayOverrideType = todayOverride ? getEventType(todayOverride) : null
   const todayOverrideSchedule = todayOverride && todayOverrideType === 'WORKING'

--- a/src/pages/work-schedules/__tests__/WorkSchedules.test.tsx
+++ b/src/pages/work-schedules/__tests__/WorkSchedules.test.tsx
@@ -298,7 +298,7 @@ describe('WorkSchedules 페이지', () => {
     render(<WorkSchedules />)
 
     const recurringButtons = await screen.findAllByRole('button', {
-      name: /이벤트 .*관리자 recurring .*2026-05-/,
+      name: /이벤트 .*관리자 recurring .*2026-\d{2}-/,
     })
     fireEvent.click(recurringButtons[0])
 
@@ -306,7 +306,7 @@ describe('WorkSchedules 페이지', () => {
 
     await waitFor(() => {
       expect(mockCreateWorkScheduleEvent).toHaveBeenCalledWith({
-        date: expect.stringMatching(/^2026-05-/),
+        date: expect.stringMatching(/^2026-\d{2}-\d{2}$/),
         eventType: 'DAY_OFF',
         startTime: null,
         endTime: null,

--- a/src/pages/work-schedules/index.tsx
+++ b/src/pages/work-schedules/index.tsx
@@ -24,7 +24,7 @@ import {
   type WorkScheduleEventItem,
   type WorkScheduleEventType,
 } from '../../shared/api/attendanceApi'
-import { formatScheduleRangeLabel } from '../../shared/lib/attendanceSchedule'
+import { formatScheduleRangeLabel, matchesWeekPattern } from '../../shared/lib/attendanceSchedule'
 import { formatTeamName, getTeamOptions, sortUsersByTeamAndName } from '../../shared/lib/team'
 import { canViewAllWorkSchedules, canViewTeamWorkSchedules } from '../../shared/lib/permissions'
 import { DataTableSection } from '../../shared/ui/DataTableSection'
@@ -102,27 +102,6 @@ function toIsoDate(date: Date) {
 
 function toMondayIndex(jsDay: number) {
   return (jsDay + 6) % 7
-}
-
-function getOccurrencePattern(date: Date): Exclude<WeekPattern, 'EVERY' | 'LAST'> {
-  const occurrence = Math.floor((date.getDate() - 1) / 7) + 1
-  if (occurrence === 1) return 'FIRST'
-  if (occurrence === 2) return 'SECOND'
-  if (occurrence === 3) return 'THIRD'
-  return 'FOURTH'
-}
-
-function isLastOccurrence(date: Date) {
-  const nextWeek = new Date(date)
-  nextWeek.setDate(date.getDate() + 7)
-  return nextWeek.getMonth() !== date.getMonth()
-}
-
-function matchesWeekPattern(date: Date, pattern: WeekPattern | undefined) {
-  const normalized = pattern ?? 'EVERY'
-  if (normalized === 'EVERY') return true
-  if (normalized === 'LAST') return isLastOccurrence(date)
-  return getOccurrencePattern(date) === normalized
 }
 
 function addDays(date: Date, days: number) {

--- a/src/shared/lib/__tests__/attendanceSchedule.test.ts
+++ b/src/shared/lib/__tests__/attendanceSchedule.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { matchesWeekPattern } from '../attendanceSchedule'
+
+describe('attendanceSchedule', () => {
+  describe('matchesWeekPattern', () => {
+    it('EVERY 또는 값 없음은 모든 날짜에 매칭된다', () => {
+      const date = new Date('2026-06-01T12:00:00')
+
+      expect(matchesWeekPattern(date, 'EVERY')).toBe(true)
+      expect(matchesWeekPattern(date, undefined)).toBe(true)
+    })
+
+    it('FIRST/SECOND/THIRD/FOURTH는 월 안의 같은 요일 발생 순서로 매칭된다', () => {
+      expect(matchesWeekPattern(new Date('2026-06-01T12:00:00'), 'FIRST')).toBe(true)
+      expect(matchesWeekPattern(new Date('2026-06-08T12:00:00'), 'SECOND')).toBe(true)
+      expect(matchesWeekPattern(new Date('2026-06-15T12:00:00'), 'THIRD')).toBe(true)
+      expect(matchesWeekPattern(new Date('2026-06-22T12:00:00'), 'FOURTH')).toBe(true)
+    })
+
+    it('LAST는 7일 뒤가 다음 달인 같은 요일에만 매칭된다', () => {
+      expect(matchesWeekPattern(new Date('2026-06-22T12:00:00'), 'LAST')).toBe(false)
+      expect(matchesWeekPattern(new Date('2026-06-29T12:00:00'), 'LAST')).toBe(true)
+    })
+  })
+})

--- a/src/shared/lib/attendanceSchedule.ts
+++ b/src/shared/lib/attendanceSchedule.ts
@@ -1,4 +1,5 @@
 import { parseDateString, toDateString } from './date'
+import type { WeekPattern } from '../api/attendanceApi'
 
 function sliceClock(value: string | null | undefined) {
   if (!value) return '-'
@@ -45,4 +46,25 @@ export function formatScheduleRangeLabel({
 
 export function formatDateTimeClock(value: string | null | undefined) {
   return sliceClock(value)
+}
+
+function getOccurrencePattern(date: Date): Exclude<WeekPattern, 'EVERY' | 'LAST'> {
+  const occurrence = Math.floor((date.getDate() - 1) / 7) + 1
+  if (occurrence === 1) return 'FIRST'
+  if (occurrence === 2) return 'SECOND'
+  if (occurrence === 3) return 'THIRD'
+  return 'FOURTH'
+}
+
+function isLastOccurrence(date: Date) {
+  const nextWeek = new Date(date)
+  nextWeek.setDate(date.getDate() + 7)
+  return nextWeek.getMonth() !== date.getMonth()
+}
+
+export function matchesWeekPattern(date: Date, pattern: WeekPattern | undefined) {
+  const normalized = pattern ?? 'EVERY'
+  if (normalized === 'EVERY') return true
+  if (normalized === 'LAST') return isLastOccurrence(date)
+  return getOccurrencePattern(date) === normalized
 }


### PR DESCRIPTION
## 작업 내용
- develop 브랜치의 최신 변경 사항을 main에 반영하는 `v1.1.5` 배포 PR입니다.
- 이번 배포에는 대시보드 오늘 출근일 판정이 반복 근무 일정의 주차 패턴(`FIRST/SECOND/THIRD/FOURTH/LAST`)을 반영하도록 수정한 내용이 포함됩니다.
- 근무 일정 캘린더와 대시보드가 같은 주차 패턴 판정 기준을 사용하도록 공통 로직을 정리했습니다.

## 변경 이유
- 기존 대시보드는 오늘 요일의 반복 일정 존재 여부만 보고 출근일로 판단했습니다.
- 그 결과 FIRST/SECOND/THIRD/FOURTH/LAST 패턴이 오늘 날짜와 맞지 않아도 “오늘 근무 예정”으로 표시될 수 있었습니다.
- 날짜별 WORKING/DAY_OFF 이벤트 우선순위는 유지하면서, 반복 일정 자체의 적용 여부만 정확히 판정해야 합니다.

## 상세 변경 사항
### 주요 변경
- [x] `matchesWeekPattern` 공통 함수 추가
- [x] `useWorkSchedule()` 오늘 반복 일정 판정에 weekPattern 적용
- [x] 근무 일정 캘린더의 중복 주차 패턴 판정 로직을 공통 함수로 교체
- [x] 주차 패턴 단위 테스트 및 오늘 근무 여부 회귀 테스트 추가
- [x] 날짜 의존성이 있던 WorkSchedules 테스트 안정화

### 포함 PR
- #400 fix: 오늘 출근일 주차 패턴 판정 반영

### 추가 메모
- develop 머지는 사용자 지침에 따라 CI 대기 없이 완료했고, main PR은 머지하지 않고 열어둡니다.
- 백엔드 attendance 모듈은 현재 프론트 저장소 checkout에 없어 이번 배포 범위에는 포함하지 않았습니다.

## 테스트
- [x] `npm test -- --run src/shared/lib/__tests__/attendanceSchedule.test.ts src/features/attendance/model/__tests__/useWorkSchedule.test.ts src/pages/work-schedules/__tests__/WorkSchedules.test.tsx src/pages/dashboard/__tests__/Dashboard.test.tsx`
- [x] `npx eslint src/shared/lib/attendanceSchedule.ts src/shared/lib/__tests__/attendanceSchedule.test.ts src/features/attendance/model/useWorkSchedule.ts src/features/attendance/model/__tests__/useWorkSchedule.test.ts src/pages/work-schedules/index.tsx src/pages/work-schedules/__tests__/WorkSchedules.test.tsx`
- [x] `npm run build`

## 참고
- 관련 테스트 실행 중 Vitest/Node의 `--localstorage-file` 경고가 출력되지만 테스트는 전부 통과했습니다.
- `npm run build`는 기존과 동일하게 500kB 이상 chunk 경고를 출력하지만 빌드는 성공했습니다.
- `npm run lint` 전체 실행은 기존 `.claude/skill/gstack` 및 기존 앱 lint 이슈를 함께 검사해 실패합니다. 이번 변경 파일 대상 ESLint는 통과했습니다.

## 리뷰 포인트
- 오늘 반복 일정 판정에서 weekPattern이 날짜별 이벤트보다 낮은 우선순위로 적용되는지 확인 부탁드립니다.
- 주차 패턴이 맞지 않는 오늘 날짜에 대시보드가 “오늘은 휴무입니다”로 표시되는지 봐주세요.
- 캘린더와 대시보드가 같은 주차 패턴 기준을 사용해 표시 차이가 없는지 확인 부탁드립니다.

## 관련 이슈
- closes #398
