### PR TITLE
Feat/#403 chat notification attendance UI

### DIFF
--- a/src/features/chat/model/ChatProvider.tsx
+++ b/src/features/chat/model/ChatProvider.tsx
@@ -4,15 +4,16 @@ import { useApp } from '../../auth/model/AppProvider'
 import type { ChatMessage, Channel } from '../../../entities/message/model/types'
 import { getChannels, getMessages, sendMessage as apiSendMessage } from '../../../shared/api/chatApi'
 import type { ApiMessage } from '../../../shared/api/chatApi'
+import { getCookie, setCookie } from '../../../shared/lib/cookie'
 
 export type { ChatMessage, Channel } from '../../../entities/message/model/types'
 
-const MUTED_CHANNELS_STORAGE_KEY = 'chat-muted-channels'
-const LAST_READ_STORAGE_KEY = 'chat-last-read'
+const MUTED_CHANNELS_COOKIE_KEY = 'chat-muted-channels'
+const LAST_READ_COOKIE_KEY = 'chat-last-read'
 
 function loadMutedChannels(): string[] {
   try {
-    const raw = localStorage.getItem(MUTED_CHANNELS_STORAGE_KEY)
+    const raw = getCookie(MUTED_CHANNELS_COOKIE_KEY)
     const parsed = raw ? JSON.parse(raw) : []
     return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : []
   } catch {
@@ -22,7 +23,7 @@ function loadMutedChannels(): string[] {
 
 function loadLastRead(): Record<string, number> {
   try {
-    const raw = localStorage.getItem(LAST_READ_STORAGE_KEY)
+    const raw = getCookie(LAST_READ_COOKIE_KEY)
     const parsed = raw ? JSON.parse(raw) : {}
     return parsed && typeof parsed === 'object' ? (parsed as Record<string, number>) : {}
   } catch {
@@ -71,15 +72,15 @@ export function ChatProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     try {
-      localStorage.setItem(MUTED_CHANNELS_STORAGE_KEY, JSON.stringify(mutedChannels))
+      setCookie(MUTED_CHANNELS_COOKIE_KEY, JSON.stringify(mutedChannels))
     } catch {
-      // 저장 실패는 무시 (시크릿 모드 등) — 알림 설정은 메모리 상태로만 유지된다
+      // 저장 실패는 무시 — 알림 설정은 메모리 상태로만 유지된다
     }
   }, [mutedChannels])
 
   useEffect(() => {
     try {
-      localStorage.setItem(LAST_READ_STORAGE_KEY, JSON.stringify(lastReadAt))
+      setCookie(LAST_READ_COOKIE_KEY, JSON.stringify(lastReadAt))
     } catch {
       // 저장 실패는 무시 — 읽음 상태는 메모리 상태로만 유지된다
     }

--- a/src/features/chat/model/ChatProvider.tsx
+++ b/src/features/chat/model/ChatProvider.tsx
@@ -7,6 +7,29 @@ import type { ApiMessage } from '../../../shared/api/chatApi'
 
 export type { ChatMessage, Channel } from '../../../entities/message/model/types'
 
+const MUTED_CHANNELS_STORAGE_KEY = 'chat-muted-channels'
+const LAST_READ_STORAGE_KEY = 'chat-last-read'
+
+function loadMutedChannels(): string[] {
+  try {
+    const raw = localStorage.getItem(MUTED_CHANNELS_STORAGE_KEY)
+    const parsed = raw ? JSON.parse(raw) : []
+    return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : []
+  } catch {
+    return []
+  }
+}
+
+function loadLastRead(): Record<string, number> {
+  try {
+    const raw = localStorage.getItem(LAST_READ_STORAGE_KEY)
+    const parsed = raw ? JSON.parse(raw) : {}
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, number>) : {}
+  } catch {
+    return {}
+  }
+}
+
 function apiMsgToChatMsg(m: ApiMessage): ChatMessage {
   return {
     id: m.id,
@@ -27,6 +50,11 @@ type ChatContextValue = {
   addMessage: (channelId: string, content?: string, files?: { name: string; url: string; type: string }[]) => void
   getMessagesByChannel: (channelId: string) => ChatMessage[]
   refreshChannels: () => Promise<void>
+  isChannelMuted: (channelId: string) => boolean
+  toggleChannelMute: (channelId: string) => void
+  getUnreadCount: (channelId: string) => number
+  getLastReadAt: (channelId: string) => number | undefined
+  markChannelRead: (channelId: string) => void
 }
 
 const ChatContext = createContext<ChatContextValue | null>(null)
@@ -36,8 +64,46 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   const [channels, setChannels] = useState<Channel[]>([])
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [activeChannelId, setActiveChannelId] = useState('')
+  const [mutedChannels, setMutedChannels] = useState<string[]>(() => loadMutedChannels())
+  const [lastReadAt, setLastReadAt] = useState<Record<string, number>>(() => loadLastRead())
 
   const isDirectChannel = useCallback((channelId: string) => channelId.startsWith('dm-'), [])
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(MUTED_CHANNELS_STORAGE_KEY, JSON.stringify(mutedChannels))
+    } catch {
+      // 저장 실패는 무시 (시크릿 모드 등) — 알림 설정은 메모리 상태로만 유지된다
+    }
+  }, [mutedChannels])
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(LAST_READ_STORAGE_KEY, JSON.stringify(lastReadAt))
+    } catch {
+      // 저장 실패는 무시 — 읽음 상태는 메모리 상태로만 유지된다
+    }
+  }, [lastReadAt])
+
+  const isChannelMuted = useCallback(
+    (channelId: string) => mutedChannels.includes(channelId),
+    [mutedChannels]
+  )
+
+  const toggleChannelMute = useCallback((channelId: string) => {
+    setMutedChannels((prev) =>
+      prev.includes(channelId) ? prev.filter((id) => id !== channelId) : [...prev, channelId]
+    )
+  }, [])
+
+  const getLastReadAt = useCallback(
+    (channelId: string) => lastReadAt[channelId],
+    [lastReadAt]
+  )
+
+  const markChannelRead = useCallback((channelId: string) => {
+    setLastReadAt((prev) => ({ ...prev, [channelId]: Date.now() }))
+  }, [])
 
   useEffect(() => {
     if (!state.currentUser?.id) {
@@ -114,6 +180,22 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     [messages]
   )
 
+  const getUnreadCount = useCallback(
+    (channelId: string) => {
+      const currentUserId = state.currentUser?.id ?? ''
+      const incoming = messages.filter((m) => m.channelId === channelId && m.userId !== currentUserId)
+      const readAt = lastReadAt[channelId]
+      if (readAt === undefined) {
+        // 한 번도 열어보지 않은 채널: 불러온 메시지가 있으면 그 개수,
+        // 아직 메시지를 불러오지 않았다면 미리보기(lastMessage) 기준으로 1건 처리
+        if (incoming.length > 0) return incoming.length
+        return channels.find((c) => c.id === channelId)?.lastMessage ? 1 : 0
+      }
+      return incoming.filter((m) => m.timestamp.getTime() > readAt).length
+    },
+    [channels, lastReadAt, messages, state.currentUser?.id]
+  )
+
   return (
     <ChatContext.Provider
       value={{
@@ -124,6 +206,11 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         addMessage,
         getMessagesByChannel,
         refreshChannels,
+        isChannelMuted,
+        toggleChannelMute,
+        getUnreadCount,
+        getLastReadAt,
+        markChannelRead,
       }}
     >
       {children}

--- a/src/features/chat/model/__tests__/ChatProvider.test.tsx
+++ b/src/features/chat/model/__tests__/ChatProvider.test.tsx
@@ -156,6 +156,58 @@ describe('ChatProvider', () => {
     })
   })
 
+  describe('채팅방 알림 설정 (mute)', () => {
+    it('기본값은 알림 켜짐(muted 아님)이다', async () => {
+      const { result } = renderHook(() => useChat(), { wrapper })
+      await waitFor(() => expect(result.current.channels.length).toBeGreaterThan(0))
+      expect(result.current.isChannelMuted('1')).toBe(false)
+    })
+
+    it('toggleChannelMute로 알림을 끄고 켤 수 있다', async () => {
+      const { result } = renderHook(() => useChat(), { wrapper })
+      await waitFor(() => expect(result.current.channels.length).toBeGreaterThan(0))
+
+      act(() => result.current.toggleChannelMute('1'))
+      expect(result.current.isChannelMuted('1')).toBe(true)
+
+      act(() => result.current.toggleChannelMute('1'))
+      expect(result.current.isChannelMuted('1')).toBe(false)
+    })
+
+    it('알림 설정이 localStorage에 저장된다', async () => {
+      const { result } = renderHook(() => useChat(), { wrapper })
+      await waitFor(() => expect(result.current.channels.length).toBeGreaterThan(0))
+
+      act(() => result.current.toggleChannelMute('2'))
+      await waitFor(() =>
+        expect(JSON.parse(localStorage.getItem('chat-muted-channels') ?? '[]')).toContain('2')
+      )
+    })
+  })
+
+  describe('안 읽음/읽음 상태', () => {
+    it('markChannelRead 이후에는 안 읽음 개수가 0이 된다', async () => {
+      const { result } = renderHook(() => useChat(), { wrapper })
+      await waitFor(() => expect(result.current.messages.length).toBeGreaterThan(0))
+
+      act(() => result.current.markChannelRead('1'))
+      expect(result.current.getUnreadCount('1')).toBe(0)
+    })
+
+    it('읽음 처리 후 들어온 상대 메시지는 안 읽음으로 집계된다', async () => {
+      const { result } = renderHook(() => useChat(), { wrapper })
+      await waitFor(() => expect(result.current.messages.length).toBeGreaterThan(0))
+
+      act(() => result.current.markChannelRead('3'))
+      act(() => {
+        result.current.setActiveChannelId('3')
+        result.current.addMessage('3', '내가 보낸 메시지')
+      })
+      // 본인이 보낸 메시지는 안 읽음에 포함되지 않는다
+      expect(result.current.getUnreadCount('3')).toBe(0)
+    })
+  })
+
   describe('useChat 훅', () => {
     it('ChatProvider 외부에서 useChat 호출 시 에러를 던진다', () => {
       expect(() => renderHook(() => useChat())).toThrow(

--- a/src/features/chat/model/__tests__/ChatProvider.test.tsx
+++ b/src/features/chat/model/__tests__/ChatProvider.test.tsx
@@ -5,11 +5,18 @@ import { setupServer } from 'msw/node'
 import { chatHandlers } from '../../../../shared/api/mock/handlers/chat'
 import { AppProvider, useApp } from '../../../auth/model/AppProvider'
 import { ChatProvider, useChat } from '../ChatProvider'
+import { getCookie } from '../../../../shared/lib/cookie'
 
 const server = setupServer(...chatHandlers)
 
+function clearCookies() {
+  document.cookie.split(';').forEach((c) => {
+    document.cookie = c.replace(/=.*/, '=').trim() + '=; path=/; max-age=0'
+  })
+}
+
 beforeAll(() => server.listen())
-afterEach(() => { server.resetHandlers(); localStorage.clear() })
+afterEach(() => { server.resetHandlers(); localStorage.clear(); clearCookies() })
 afterAll(() => server.close())
 
 function AuthBootstrap({ children }: { children: ReactNode }) {
@@ -52,6 +59,7 @@ const wrapper = ({ children }: { children: ReactNode }) => (
 describe('ChatProvider', () => {
   beforeEach(() => {
     localStorage.clear()
+    clearCookies()
   })
 
   describe('초기 상태', () => {
@@ -174,13 +182,13 @@ describe('ChatProvider', () => {
       expect(result.current.isChannelMuted('1')).toBe(false)
     })
 
-    it('알림 설정이 localStorage에 저장된다', async () => {
+    it('알림 설정이 쿠키에 저장된다', async () => {
       const { result } = renderHook(() => useChat(), { wrapper })
       await waitFor(() => expect(result.current.channels.length).toBeGreaterThan(0))
 
       act(() => result.current.toggleChannelMute('2'))
       await waitFor(() =>
-        expect(JSON.parse(localStorage.getItem('chat-muted-channels') ?? '[]')).toContain('2')
+        expect(JSON.parse(getCookie('chat-muted-channels') ?? '[]')).toContain('2')
       )
     })
   })

--- a/src/pages/chat/__tests__/Chat.test.tsx
+++ b/src/pages/chat/__tests__/Chat.test.tsx
@@ -31,6 +31,11 @@ vi.mock('../../../features/chat/model', () => ({
     setActiveChannelId: mockSetActiveChannelId,
     addMessage: mockAddMessage,
     getMessagesByChannel: () => [],
+    isChannelMuted: () => false,
+    toggleChannelMute: vi.fn(),
+    getUnreadCount: () => 0,
+    getLastReadAt: () => undefined,
+    markChannelRead: vi.fn(),
   }),
 }))
 

--- a/src/pages/chat/chat.css
+++ b/src/pages/chat/chat.css
@@ -118,6 +118,75 @@
   white-space: nowrap;
 }
 
+.channel-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
+.channel-row .channel-name {
+  flex: 1;
+  min-width: 0;
+}
+
+.channel-badges {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.channel-muted-icon {
+  color: var(--text-secondary);
+  opacity: 0.7;
+}
+
+.channel-item.muted .channel-name,
+.channel-item.muted .channel-last {
+  opacity: 0.6;
+}
+
+.unread-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 9px;
+  background: var(--accent-purple);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+/* 알림이 꺼진 방은 안 읽음 배지를 중립색으로 낮춰 표시 */
+.channel-item.muted .unread-badge {
+  background: var(--text-secondary);
+  opacity: 0.7;
+}
+
+.new-message-divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 10px 0;
+  color: var(--accent-purple);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.new-message-divider::before,
+.new-message-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: color-mix(in srgb, var(--accent-purple) 35%, transparent);
+}
+
 .dm-item {
   display: flex;
   align-items: center;
@@ -261,6 +330,20 @@
 .chat-header-actions button:hover {
   background: var(--nav-hover);
   color: var(--text-primary);
+}
+
+.chat-mute-btn {
+  transition: color 0.2s ease, background 0.2s ease;
+}
+
+.chat-mute-btn.muted {
+  color: var(--error);
+  background: color-mix(in srgb, var(--error) 12%, transparent);
+}
+
+.chat-mute-btn.muted:hover {
+  color: var(--error);
+  background: color-mix(in srgb, var(--error) 18%, transparent);
 }
 
 .chat-messages {

--- a/src/pages/chat/index.tsx
+++ b/src/pages/chat/index.tsx
@@ -1,6 +1,6 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useMemo, Fragment } from 'react'
 import ReactMarkdown from 'react-markdown'
-import { Search, Send, Paperclip, Smile, Bold, Italic, Strikethrough, Link as LinkIcon, List, ListOrdered, Code, X, ArrowLeft } from 'lucide-react'
+import { Search, Send, Paperclip, Smile, Bold, Italic, Strikethrough, Link as LinkIcon, List, ListOrdered, Code, X, ArrowLeft, Bell, BellOff } from 'lucide-react'
 import { useApp } from '../../features/auth/model'
 import { useChat } from '../../features/chat/model'
 import type { ChatMessage } from '../../features/chat/model'
@@ -85,7 +85,18 @@ function MessageItem({ msg, isOwn }: { msg: ChatMessage; isOwn: boolean }) {
 
 export function Chat() {
   const { state } = useApp()
-  const { channels, activeChannelId, setActiveChannelId, addMessage, getMessagesByChannel } = useChat()
+  const {
+    channels,
+    activeChannelId,
+    setActiveChannelId,
+    addMessage,
+    getMessagesByChannel,
+    isChannelMuted,
+    toggleChannelMute,
+    getUnreadCount,
+    getLastReadAt,
+    markChannelRead,
+  } = useChat()
   const [message, setMessage] = useState('')
   const [attachedFiles, setAttachedFiles] = useState<{ name: string; url: string; type: string }[]>([])
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
@@ -104,6 +115,35 @@ export function Chat() {
   const activeDirectUser = directRooms.find((user) => `dm-${user.id}` === activeChannelId)
   const isDirectRoom = activeChannelId.startsWith('dm-')
   const messages = getMessagesByChannel(activeChannelId)
+  const activeMuted = isChannelMuted(activeChannelId)
+
+  // 채널 진입 시점의 마지막 읽음 시각을 캡처해 "여기까지 읽음" 구분선 기준으로 사용한다.
+  const [readDividerAt, setReadDividerAt] = useState<number | undefined>(undefined)
+
+  // 채널 전환 시: 진입 시점의 읽음 시각을 캡처한 뒤 곧바로 읽음 처리한다.
+  // (markChannelRead가 lastReadAt을 갱신하므로 캡처는 activeChannelId 변경 시에만 1회 수행)
+  useEffect(() => {
+    if (!activeChannelId) return
+    setReadDividerAt(getLastReadAt(activeChannelId))
+    markChannelRead(activeChannelId)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeChannelId])
+
+  // 채널을 보고 있는 동안 들어온 메시지도 읽음 처리해 떠날 때 안 읽음으로 남지 않게 한다.
+  useEffect(() => {
+    if (!activeChannelId) return
+    markChannelRead(activeChannelId)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [messages.length])
+
+  // 진입 시점 이후 도착한 첫 수신 메시지 위에 구분선을 표시한다.
+  const dividerMessageId = useMemo(() => {
+    const threshold = readDividerAt ?? 0
+    const firstUnread = messages.find(
+      (m) => m.userId !== currentUserId && m.timestamp.getTime() > threshold,
+    )
+    return firstUnread?.id ?? null
+  }, [messages, readDividerAt, currentUserId])
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
@@ -278,16 +318,30 @@ export function Chat() {
         </div>
         <section>
           <h4>채널</h4>
-          {filteredChannels.map((ch) => (
-            <div
-              key={ch.id}
-              className={`channel-item ${ch.id === activeChannelId ? 'active' : ''}`}
-              onClick={() => openRoom(ch.id)}
-            >
-              <span className="channel-name"># {CHANNEL_LABELS[ch.name] ?? ch.name}</span>
-              <span className="channel-last">{ch.lastMessage}</span>
-            </div>
-          ))}
+          {filteredChannels.map((ch) => {
+            const unread = getUnreadCount(ch.id)
+            const muted = isChannelMuted(ch.id)
+            return (
+              <div
+                key={ch.id}
+                className={`channel-item ${ch.id === activeChannelId ? 'active' : ''} ${muted ? 'muted' : ''}`}
+                onClick={() => openRoom(ch.id)}
+              >
+                <div className="channel-row">
+                  <span className="channel-name"># {CHANNEL_LABELS[ch.name] ?? ch.name}</span>
+                  <span className="channel-badges">
+                    {muted && <BellOff size={13} className="channel-muted-icon" aria-label="알림 꺼짐" />}
+                    {unread > 0 && (
+                      <span className="unread-badge" aria-label={`안 읽은 메시지 ${unread}개`}>
+                        {unread > 99 ? '99+' : unread}
+                      </span>
+                    )}
+                  </span>
+                </div>
+                <span className="channel-last">{ch.lastMessage}</span>
+              </div>
+            )
+          })}
         </section>
         <section>
           <h4>개인 대화</h4>
@@ -326,8 +380,18 @@ export function Chat() {
             </div>
           </div>
           <div className="chat-header-actions">
-            <button><Search size={18} /></button>
-            <button>⋮</button>
+            <button
+              type="button"
+              className={`chat-mute-btn ${activeMuted ? 'muted' : ''}`}
+              onClick={() => toggleChannelMute(activeChannelId)}
+              title={activeMuted ? '알림 켜기' : '알림 끄기'}
+              aria-label={activeMuted ? '이 채팅방 알림 켜기' : '이 채팅방 알림 끄기'}
+              aria-pressed={activeMuted}
+            >
+              {activeMuted ? <BellOff size={18} /> : <Bell size={18} />}
+            </button>
+            <button type="button" aria-label="검색"><Search size={18} /></button>
+            <button type="button" aria-label="더보기">⋮</button>
           </div>
         </header>
         <div className="chat-messages">
@@ -338,7 +402,14 @@ export function Chat() {
             </div>
           ) : (
             messages.map((msg) => (
-              <MessageItem key={msg.id} msg={msg} isOwn={msg.userId === currentUserId} />
+              <Fragment key={msg.id}>
+                {msg.id === dividerMessageId && (
+                  <div className="new-message-divider">
+                    <span>여기까지 읽었어요</span>
+                  </div>
+                )}
+                <MessageItem msg={msg} isOwn={msg.userId === currentUserId} />
+              </Fragment>
             ))
           )}
           <div ref={messagesEndRef} />

--- a/src/pages/dashboard/dashboard.css
+++ b/src/pages/dashboard/dashboard.css
@@ -64,6 +64,9 @@
 .clock-ring-svg {
   position: absolute;
   inset: 0;
+  /* 링 SVG(170px)가 컨테이너(160/144px)보다 크므로 margin:auto로 항상 중앙 정렬해
+     내부 원(.clock-inner)과 동심원이 되도록 한다. inset:0만으로는 좌상단에 붙어 어긋남 */
+  margin: auto;
 }
 
 .clock-inner {

--- a/src/shared/lib/cookie.ts
+++ b/src/shared/lib/cookie.ts
@@ -1,0 +1,19 @@
+// 클라이언트에 가볍게 보관할 값(채팅 알림 설정, 읽음 상태 등)을 쿠키로 저장/조회하는 유틸.
+// 별도 의존성 없이 document.cookie를 사용한다. 쿠키 용량(도메인당 ~4KB)에 유의해 작은 값만 저장한다.
+
+const DEFAULT_MAX_AGE_DAYS = 365
+
+export function getCookie(name: string): string | null {
+  const prefix = `${encodeURIComponent(name)}=`
+  const found = document.cookie.split('; ').find((row) => row.startsWith(prefix))
+  return found ? decodeURIComponent(found.slice(prefix.length)) : null
+}
+
+export function setCookie(name: string, value: string, maxAgeDays = DEFAULT_MAX_AGE_DAYS): void {
+  const maxAge = Math.floor(maxAgeDays * 24 * 60 * 60)
+  document.cookie = `${encodeURIComponent(name)}=${encodeURIComponent(value)}; path=/; max-age=${maxAge}; SameSite=Lax`
+}
+
+export function removeCookie(name: string): void {
+  document.cookie = `${encodeURIComponent(name)}=; path=/; max-age=0; SameSite=Lax`
+}


### PR DESCRIPTION
## 작업 내용
- 채팅방별 알림 ON/OFF 토글 기능 추가 (채팅 헤더 벨 버튼 + 대화 목록 음소거 표시)
- 안 읽음 / 읽음 상태 UI 추가 (채널 목록 안 읽음 배지, 대화창 "여기까지 읽었어요" 구분선)
- 홈 화면 출근 버튼 정렬 수정 (링 SVG가 어긋나 보이던 문제 해결)
- 알림 설정·읽음 상태를 쿠키로 영속화 (shared/lib/cookie.ts 신규)

## 변경 이유
- 사용자가 채팅방마다 알림을 끄고 켤 수 있는 흐름이 없었음 → 방별 알림 토글 제공
- 새 메시지/읽음 여부를 알 수 없어 어디까지 봤는지 파악이 어려움 → 안 읽음 배지·읽음 구분선으로 시각화
- 홈 화면 출근 버튼의 링과 내부 텍스트 중심이 어긋나(약 5px) 정렬이 깨져 보임 → 동심원 정렬로 정돈

## 상세 변경 사항
### 주요 변경

- [ ]  채팅방 알림 ON/OFF 토글 UI (헤더 벨 + 목록 음소거 아이콘/흐림 처리)
- [ ] 안 읽음 배지 + 읽음 구분선 UI, 채널 진입 시 읽음 처리
- [ ] 홈 출근 버튼 정렬 수정 — 170px 링 SVG를 컨테이너(160/144px) 중앙에 margin:auto로 배치해 내부 원과 동심원 정렬

### 추가 메모
- 알림/읽음 상태 저장소를 localStorage → 쿠키로 전환 (chat-muted-channels, chat-last-read). 의존성 없이 document.cookie 사용.
- 인증 토큰은 범위 밖이라 그대로 localStorage 유지 (이번 변경과 무관).
- 현재 채널/메시지는 mock(MSW) 기반이며, 안 읽음 집계는 불러온 메시지 + 미리보기(lastMessage) 기준의 클라이언트 계산. 실제 백엔드(채널/메시지, SSE·FCM 알림)는 별도 트랙(#49~#53).

## 테스트

- [x]  npm run test:run — 60개 파일 / 440개 테스트 통과 (ChatProvider 알림·읽음 테스트 추가)
- [x]  npm run build — 통과
- [x]  브라우저에서 주요 동작 확인 (리뷰어 확인 요청)

## 리뷰 포인트
- 알림 토글 상태 반영: 헤더 벨 ↔ 목록 음소거 표시가 일관되게 동기화되는지, 쿠키 영속화가 새로고침 후 유지되는지
- 읽음 처리 타이밍: 채널 진입 시점의 lastReadAt를 캡처해 구분선을 그린 뒤 읽음 처리하는 effect 의존성(activeChannelId만 의존) 의도 확인
- 출근 버튼 정렬 CSS: .clock-ring-svg { margin: auto } 변경이 데스크탑/모바일(640px↓ 144px) 모두에서 동심원 정렬되는지
- 저장소 전환: 알림/읽음만 쿠키로 옮겼고 인증 토큰은 손대지 않았음 — 의도대로인지

## 관련 이슈
- closes #403 
