### PR TITLE
feat: 채팅방 설정 및 권한 관리 (목록 개선·팀방 진입/전환·나가기)

### DIFF
--- a/src/entities/message/model/types.ts
+++ b/src/entities/message/model/types.ts
@@ -9,8 +9,12 @@ export interface ChatMessage {
   timestamp: Date
 }
 
+export type ChannelType = 'GENERAL' | 'TEAM' | 'DIRECT'
+
 export interface Channel {
   id: string
   name: string
+  type?: ChannelType
+  memberCount?: number
   lastMessage?: string
 }

--- a/src/features/chat/model/ChatProvider.tsx
+++ b/src/features/chat/model/ChatProvider.tsx
@@ -10,15 +10,20 @@ export type { ChatMessage, Channel } from '../../../entities/message/model/types
 
 const MUTED_CHANNELS_COOKIE_KEY = 'chat-muted-channels'
 const LAST_READ_COOKIE_KEY = 'chat-last-read'
+const LEFT_CHANNELS_COOKIE_KEY = 'chat-left-channels'
 
-function loadMutedChannels(): string[] {
+function loadStringList(cookieKey: string): string[] {
   try {
-    const raw = getCookie(MUTED_CHANNELS_COOKIE_KEY)
+    const raw = getCookie(cookieKey)
     const parsed = raw ? JSON.parse(raw) : []
     return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : []
   } catch {
     return []
   }
+}
+
+function loadMutedChannels(): string[] {
+  return loadStringList(MUTED_CHANNELS_COOKIE_KEY)
 }
 
 function loadLastRead(): Record<string, number> {
@@ -56,6 +61,9 @@ type ChatContextValue = {
   getUnreadCount: (channelId: string) => number
   getLastReadAt: (channelId: string) => number | undefined
   markChannelRead: (channelId: string) => void
+  visibleChannels: Channel[]
+  isChannelLeft: (channelId: string) => boolean
+  leaveChannel: (channelId: string) => void
 }
 
 const ChatContext = createContext<ChatContextValue | null>(null)
@@ -67,6 +75,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   const [activeChannelId, setActiveChannelId] = useState('')
   const [mutedChannels, setMutedChannels] = useState<string[]>(() => loadMutedChannels())
   const [lastReadAt, setLastReadAt] = useState<Record<string, number>>(() => loadLastRead())
+  const [leftChannels, setLeftChannels] = useState<string[]>(() => loadStringList(LEFT_CHANNELS_COOKIE_KEY))
 
   const isDirectChannel = useCallback((channelId: string) => channelId.startsWith('dm-'), [])
 
@@ -105,6 +114,34 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   const markChannelRead = useCallback((channelId: string) => {
     setLastReadAt((prev) => ({ ...prev, [channelId]: Date.now() }))
   }, [])
+
+  useEffect(() => {
+    try {
+      setCookie(LEFT_CHANNELS_COOKIE_KEY, JSON.stringify(leftChannels))
+    } catch {
+      // 저장 실패는 무시 — 나간 채팅방 목록은 메모리 상태로만 유지된다
+    }
+  }, [leftChannels])
+
+  const isChannelLeft = useCallback(
+    (channelId: string) => leftChannels.includes(channelId),
+    [leftChannels]
+  )
+
+  const leaveChannel = useCallback(
+    (channelId: string) => {
+      setLeftChannels((prev) => (prev.includes(channelId) ? prev : [...prev, channelId]))
+      // 나간 방이 현재 보고 있던 방이면 남아있는 첫 번째 방으로 전환한다.
+      setActiveChannelId((prev) => {
+        if (prev !== channelId) return prev
+        const next = channels.find((c) => c.id !== channelId && !leftChannels.includes(c.id))
+        return next?.id ?? ''
+      })
+    },
+    [channels, leftChannels]
+  )
+
+  const visibleChannels = channels.filter((c) => !leftChannels.includes(c.id))
 
   useEffect(() => {
     if (!state.currentUser?.id) {
@@ -212,6 +249,9 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         getUnreadCount,
         getLastReadAt,
         markChannelRead,
+        visibleChannels,
+        isChannelLeft,
+        leaveChannel,
       }}
     >
       {children}

--- a/src/features/chat/model/__tests__/ChatProvider.test.tsx
+++ b/src/features/chat/model/__tests__/ChatProvider.test.tsx
@@ -216,6 +216,42 @@ describe('ChatProvider', () => {
     })
   })
 
+  describe('채팅방 나가기 (leave)', () => {
+    it('나간 채널은 visibleChannels에서 제외된다', async () => {
+      const { result } = renderHook(() => useChat(), { wrapper })
+      await waitFor(() => expect(result.current.channels.length).toBeGreaterThan(0))
+
+      act(() => result.current.leaveChannel('2'))
+
+      expect(result.current.isChannelLeft('2')).toBe(true)
+      expect(result.current.visibleChannels.some((c) => c.id === '2')).toBe(false)
+      // 전체 채널 목록에는 그대로 남아 있다
+      expect(result.current.channels.some((c) => c.id === '2')).toBe(true)
+    })
+
+    it('현재 보고 있던 방을 나가면 남은 방으로 전환된다', async () => {
+      const { result } = renderHook(() => useChat(), { wrapper })
+      await waitFor(() => expect(result.current.channels.length).toBeGreaterThan(0))
+
+      act(() => result.current.setActiveChannelId('2'))
+      expect(result.current.activeChannelId).toBe('2')
+
+      act(() => result.current.leaveChannel('2'))
+      expect(result.current.activeChannelId).not.toBe('2')
+      expect(result.current.isChannelLeft(result.current.activeChannelId)).toBe(false)
+    })
+
+    it('나간 방 목록이 쿠키에 저장된다', async () => {
+      const { result } = renderHook(() => useChat(), { wrapper })
+      await waitFor(() => expect(result.current.channels.length).toBeGreaterThan(0))
+
+      act(() => result.current.leaveChannel('3'))
+      await waitFor(() =>
+        expect(JSON.parse(getCookie('chat-left-channels') ?? '[]')).toContain('3')
+      )
+    })
+  })
+
   describe('useChat 훅', () => {
     it('ChatProvider 외부에서 useChat 호출 시 에러를 던진다', () => {
       expect(() => renderHook(() => useChat())).toThrow(

--- a/src/pages/chat/__tests__/Chat.test.tsx
+++ b/src/pages/chat/__tests__/Chat.test.tsx
@@ -22,21 +22,27 @@ vi.mock('../../../features/auth/model', () => ({
 }))
 
 vi.mock('../../../features/chat/model', () => ({
-  useChat: () => ({
-    channels: [
-      { id: '1', name: 'General', lastMessage: '안녕하세요!' },
-      { id: '2', name: 'Design Team', lastMessage: '디자인 피드백 부탁드려요' },
-    ],
-    activeChannelId: '1',
-    setActiveChannelId: mockSetActiveChannelId,
-    addMessage: mockAddMessage,
-    getMessagesByChannel: () => [],
-    isChannelMuted: () => false,
-    toggleChannelMute: vi.fn(),
-    getUnreadCount: () => 0,
-    getLastReadAt: () => undefined,
-    markChannelRead: vi.fn(),
-  }),
+  useChat: () => {
+    const channels = [
+      { id: '1', name: 'General', type: 'GENERAL', memberCount: 23, lastMessage: '안녕하세요!' },
+      { id: '2', name: 'Design Team', type: 'TEAM', memberCount: 6, lastMessage: '디자인 피드백 부탁드려요' },
+    ]
+    return {
+      channels,
+      activeChannelId: '1',
+      setActiveChannelId: mockSetActiveChannelId,
+      addMessage: mockAddMessage,
+      getMessagesByChannel: () => [],
+      isChannelMuted: () => false,
+      toggleChannelMute: vi.fn(),
+      getUnreadCount: () => 0,
+      getLastReadAt: () => undefined,
+      markChannelRead: vi.fn(),
+      visibleChannels: channels,
+      isChannelLeft: () => false,
+      leaveChannel: vi.fn(),
+    }
+  },
 }))
 
 vi.mock('../../../shared/api/membersApi', () => ({

--- a/src/pages/chat/chat.css
+++ b/src/pages/chat/chat.css
@@ -101,8 +101,19 @@
 }
 
 .channel-name {
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: 6px;
   font-weight: 500;
+  min-width: 0;
+}
+
+.channel-kind-icon {
+  flex-shrink: 0;
+  color: var(--text-secondary);
+}
+
+.channel-name-text {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -746,6 +757,23 @@
   color: var(--text-on-accent);
 }
 
+.link-modal-actions button.danger {
+  background: var(--error);
+  border: none;
+  color: #fff;
+}
+
+.leave-modal-desc {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin: 4px 0 4px;
+}
+
+.leave-modal-desc strong {
+  color: var(--text-primary);
+}
+
 .send-btn {
   display: flex;
   align-items: center;
@@ -932,4 +960,82 @@
   .send-btn {
     width: 100%;
   }
+}
+
+/* ===== #404 팀 채팅방 구분 / 멤버수 / 방 메뉴 ===== */
+.channel-item.team-room.active {
+  background: var(--nav-active);
+}
+
+.channel-item.team-room .channel-kind-icon {
+  color: var(--accent-purple);
+}
+
+.channel-member-count {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+}
+
+/* 상세(헤더)에서 팀 채팅방 구분 배지 */
+.room-type-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-left: 8px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  vertical-align: middle;
+  color: var(--accent-purple);
+  background: color-mix(in srgb, var(--accent-purple) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-purple) 24%, transparent);
+}
+
+/* 방 메뉴(⋮) 드롭다운 */
+.chat-room-menu {
+  position: relative;
+}
+
+.chat-room-menu-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 20;
+  min-width: 168px;
+  padding: 6px;
+  border-radius: 12px;
+  background: var(--bg-card-solid);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.chat-room-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 9px 10px;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  background: transparent;
+  text-align: left;
+}
+
+.chat-room-menu-item:hover {
+  background: var(--nav-hover);
+}
+
+.chat-room-menu-item.danger {
+  color: var(--error);
+}
+
+.chat-room-menu-item.danger:hover {
+  background: color-mix(in srgb, var(--error) 12%, transparent);
 }

--- a/src/pages/chat/index.tsx
+++ b/src/pages/chat/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useMemo, Fragment } from 'react'
 import ReactMarkdown from 'react-markdown'
-import { Search, Send, Paperclip, Smile, Bold, Italic, Strikethrough, Link as LinkIcon, List, ListOrdered, Code, X, ArrowLeft, Bell, BellOff } from 'lucide-react'
+import { Search, Send, Paperclip, Smile, Bold, Italic, Strikethrough, Link as LinkIcon, List, ListOrdered, Code, X, ArrowLeft, Bell, BellOff, Users, LogOut, MoreVertical, Hash } from 'lucide-react'
 import { useApp } from '../../features/auth/model'
 import { useChat } from '../../features/chat/model'
 import type { ChatMessage } from '../../features/chat/model'
@@ -12,6 +12,8 @@ const CHANNEL_LABELS: Record<string, string> = {
   General: '전체 공지',
   'Design Team': '디자인팀',
   'Dev Team': '개발팀',
+  'Marketing Team': '마케팅팀',
+  'Product Team': '프로덕트팀',
 }
 function formatTime(date: Date): string {
   const now = new Date()
@@ -96,6 +98,8 @@ export function Chat() {
     getUnreadCount,
     getLastReadAt,
     markChannelRead,
+    visibleChannels,
+    leaveChannel,
   } = useChat()
   const [message, setMessage] = useState('')
   const [attachedFiles, setAttachedFiles] = useState<{ name: string; url: string; type: string }[]>([])
@@ -116,6 +120,11 @@ export function Chat() {
   const isDirectRoom = activeChannelId.startsWith('dm-')
   const messages = getMessagesByChannel(activeChannelId)
   const activeMuted = isChannelMuted(activeChannelId)
+  const isTeamRoom = activeChannel?.type === 'TEAM'
+
+  const [showRoomMenu, setShowRoomMenu] = useState(false)
+  const [showLeaveModal, setShowLeaveModal] = useState(false)
+  const roomMenuRef = useRef<HTMLDivElement>(null)
 
   // 채널 진입 시점의 마지막 읽음 시각을 캡처해 "여기까지 읽음" 구분선 기준으로 사용한다.
   const [readDividerAt, setReadDividerAt] = useState<number | undefined>(undefined)
@@ -180,6 +189,27 @@ export function Chat() {
     document.addEventListener('click', onOutside)
     return () => document.removeEventListener('click', onOutside)
   }, [showEmojiPicker])
+
+  useEffect(() => {
+    if (!showRoomMenu) return
+    const onOutside = (e: MouseEvent) => {
+      if (roomMenuRef.current?.contains(e.target as Node)) return
+      setShowRoomMenu(false)
+    }
+    document.addEventListener('click', onOutside)
+    return () => document.removeEventListener('click', onOutside)
+  }, [showRoomMenu])
+
+  // 채널을 전환하면 열려 있던 방 메뉴를 닫는다.
+  useEffect(() => {
+    setShowRoomMenu(false)
+  }, [activeChannelId])
+
+  const handleLeaveChannel = () => {
+    leaveChannel(activeChannelId)
+    setShowLeaveModal(false)
+    setShowRoomMenu(false)
+  }
 
   const handleSend = () => {
     const trimmed = message.trim()
@@ -276,10 +306,12 @@ export function Chat() {
     })
   }
 
-  const filteredChannels = channels.filter((channel) =>
+  const filteredChannels = visibleChannels.filter((channel) =>
     channel.name.toLowerCase().includes(roomQuery.toLowerCase()) ||
     (channel.lastMessage ?? '').toLowerCase().includes(roomQuery.toLowerCase()),
   )
+  const generalChannels = filteredChannels.filter((channel) => channel.type !== 'TEAM')
+  const teamChannels = filteredChannels.filter((channel) => channel.type === 'TEAM')
 
   const filteredDirectRooms = directRooms.filter((user) =>
     user.name.toLowerCase().includes(roomQuery.toLowerCase()) ||
@@ -293,13 +325,45 @@ export function Chat() {
     }
   }
 
+  const renderChannelItem = (ch: (typeof filteredChannels)[number], team: boolean) => {
+    const unread = getUnreadCount(ch.id)
+    const muted = isChannelMuted(ch.id)
+    const label = CHANNEL_LABELS[ch.name] ?? ch.name
+    return (
+      <div
+        key={ch.id}
+        className={`channel-item ${team ? 'team-room' : ''} ${ch.id === activeChannelId ? 'active' : ''} ${muted ? 'muted' : ''}`}
+        onClick={() => openRoom(ch.id)}
+      >
+        <div className="channel-row">
+          <span className="channel-name">
+            {team ? <Users size={15} className="channel-kind-icon" /> : <Hash size={15} className="channel-kind-icon" />}
+            <span className="channel-name-text">{label}</span>
+          </span>
+          <span className="channel-badges">
+            {muted && <BellOff size={13} className="channel-muted-icon" aria-label="알림 꺼짐" />}
+            {unread > 0 && (
+              <span className="unread-badge" aria-label={`안 읽은 메시지 ${unread}개`}>
+                {unread > 99 ? '99+' : unread}
+              </span>
+            )}
+          </span>
+        </div>
+        <span className="channel-last">{ch.lastMessage}</span>
+        {team && ch.memberCount != null && (
+          <span className="channel-member-count">멤버 {ch.memberCount}명</span>
+        )}
+      </div>
+    )
+  }
+
   const roomTitle = isDirectRoom
     ? activeDirectUser?.name ?? '대화방'
     : `# ${CHANNEL_LABELS[activeChannel?.name ?? ''] ?? activeChannel?.name ?? '디자인팀'}`
 
   const roomMeta = isDirectRoom
     ? `${formatTeamName(activeDirectUser?.team)} · ${activeDirectUser?.online ? '대화 가능' : '현재 자리 비움'}`
-    : '23명 참여 중'
+    : `${activeChannel?.memberCount ?? 0}명 참여 중`
 
   return (
     <div className={`chat-page ${isMobileRoomOpen ? 'room-open-mobile' : 'list-open-mobile'}`}>
@@ -316,32 +380,19 @@ export function Chat() {
             onChange={(e) => setRoomQuery(e.target.value)}
           />
         </div>
+        {generalChannels.length > 0 && (
+          <section>
+            <h4>채널</h4>
+            {generalChannels.map((ch) => renderChannelItem(ch, false))}
+          </section>
+        )}
         <section>
-          <h4>채널</h4>
-          {filteredChannels.map((ch) => {
-            const unread = getUnreadCount(ch.id)
-            const muted = isChannelMuted(ch.id)
-            return (
-              <div
-                key={ch.id}
-                className={`channel-item ${ch.id === activeChannelId ? 'active' : ''} ${muted ? 'muted' : ''}`}
-                onClick={() => openRoom(ch.id)}
-              >
-                <div className="channel-row">
-                  <span className="channel-name"># {CHANNEL_LABELS[ch.name] ?? ch.name}</span>
-                  <span className="channel-badges">
-                    {muted && <BellOff size={13} className="channel-muted-icon" aria-label="알림 꺼짐" />}
-                    {unread > 0 && (
-                      <span className="unread-badge" aria-label={`안 읽은 메시지 ${unread}개`}>
-                        {unread > 99 ? '99+' : unread}
-                      </span>
-                    )}
-                  </span>
-                </div>
-                <span className="channel-last">{ch.lastMessage}</span>
-              </div>
-            )
-          })}
+          <h4>팀 채팅방</h4>
+          {teamChannels.length > 0
+            ? teamChannels.map((ch) => renderChannelItem(ch, true))
+            : !roomQuery && (
+                <div className="chat-empty-search">참여 중인 팀 채팅방이 없습니다.</div>
+              )}
         </section>
         <section>
           <h4>개인 대화</h4>
@@ -375,7 +426,14 @@ export function Chat() {
               </button>
             )}
             <div>
-              <h3>{roomTitle}</h3>
+              <h3>
+                {roomTitle}
+                {isTeamRoom && (
+                  <span className="room-type-badge">
+                    <Users size={12} />팀
+                  </span>
+                )}
+              </h3>
               <span className="members-count">{roomMeta}</span>
             </div>
           </div>
@@ -391,7 +449,48 @@ export function Chat() {
               {activeMuted ? <BellOff size={18} /> : <Bell size={18} />}
             </button>
             <button type="button" aria-label="검색"><Search size={18} /></button>
-            <button type="button" aria-label="더보기">⋮</button>
+            <div className="chat-room-menu" ref={roomMenuRef}>
+              <button
+                type="button"
+                className="chat-room-menu-btn"
+                aria-label="채팅방 메뉴"
+                aria-haspopup="menu"
+                aria-expanded={showRoomMenu}
+                onClick={() => setShowRoomMenu((v) => !v)}
+              >
+                <MoreVertical size={18} />
+              </button>
+              {showRoomMenu && (
+                <div className="chat-room-menu-dropdown" role="menu">
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="chat-room-menu-item"
+                    onClick={() => {
+                      toggleChannelMute(activeChannelId)
+                      setShowRoomMenu(false)
+                    }}
+                  >
+                    {activeMuted ? <Bell size={15} /> : <BellOff size={15} />}
+                    {activeMuted ? '알림 켜기' : '알림 끄기'}
+                  </button>
+                  {isTeamRoom && (
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className="chat-room-menu-item danger"
+                      onClick={() => {
+                        setShowRoomMenu(false)
+                        setShowLeaveModal(true)
+                      }}
+                    >
+                      <LogOut size={15} />
+                      채팅방 나가기
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
           </div>
         </header>
         <div className="chat-messages">
@@ -498,6 +597,22 @@ export function Chat() {
             <div className="link-modal-actions">
               <button onClick={() => setShowLinkModal(false)}>취소</button>
               <button className="primary" onClick={handleLink}>확인</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showLeaveModal && (
+        <div className="link-modal-overlay" onClick={() => setShowLeaveModal(false)}>
+          <div className="link-modal glass leave-modal" onClick={(e) => e.stopPropagation()}>
+            <h4>채팅방을 나가시겠어요?</h4>
+            <p className="leave-modal-desc">
+              <strong># {CHANNEL_LABELS[activeChannel?.name ?? ''] ?? activeChannel?.name}</strong> 채팅방에서 나갑니다.
+              나가면 목록에서 사라지고 새 메시지 알림을 받지 않습니다.
+            </p>
+            <div className="link-modal-actions">
+              <button onClick={() => setShowLeaveModal(false)}>취소</button>
+              <button className="danger" onClick={handleLeaveChannel}>나가기</button>
             </div>
           </div>
         </div>

--- a/src/shared/api/__tests__/chatApi.test.ts
+++ b/src/shared/api/__tests__/chatApi.test.ts
@@ -12,8 +12,8 @@ afterAll(() => server.close())
 describe('chatApi', () => {
   it('getChannels() 채널 목록을 반환한다', async () => {
     const channels = await getChannels()
-    expect(channels).toHaveLength(3)
-    expect(channels[0]).toMatchObject({ id: '1', name: 'General' })
+    expect(channels).toHaveLength(5)
+    expect(channels[0]).toMatchObject({ id: '1', name: 'General', type: 'GENERAL' })
   })
 
   it('getMessages() 채널 메시지 목록을 반환한다', async () => {

--- a/src/shared/api/chatApi.ts
+++ b/src/shared/api/chatApi.ts
@@ -3,6 +3,8 @@ import { baseClient } from './baseClient'
 export interface ApiChannel {
   id: string
   name: string
+  type?: 'GENERAL' | 'TEAM' | 'DIRECT'
+  memberCount?: number
   lastMessage?: string
 }
 

--- a/src/shared/api/mock/handlers/chat.ts
+++ b/src/shared/api/mock/handlers/chat.ts
@@ -1,9 +1,11 @@
 import { http, HttpResponse } from 'msw'
 
 const mockChannels = [
-  { id: '1', name: 'General', lastMessage: '안녕하세요!' },
-  { id: '2', name: 'Design Team', lastMessage: '디자인 피드백 부탁드려요' },
-  { id: '3', name: 'Dev Team', lastMessage: 'PR 리뷰 요청드립니다' },
+  { id: '1', name: 'General', type: 'GENERAL', memberCount: 23, lastMessage: '안녕하세요!' },
+  { id: '2', name: 'Design Team', type: 'TEAM', memberCount: 6, lastMessage: '디자인 피드백 부탁드려요' },
+  { id: '3', name: 'Dev Team', type: 'TEAM', memberCount: 8, lastMessage: 'PR 리뷰 요청드립니다' },
+  { id: '4', name: 'Marketing Team', type: 'TEAM', memberCount: 5, lastMessage: '캠페인 일정 공유합니다' },
+  { id: '5', name: 'Product Team', type: 'TEAM', memberCount: 4, lastMessage: '로드맵 업데이트했어요' },
 ]
 
 const mockMessages: Record<string, { id: string; channelId: string; userId: string; userName: string; content: string; type: string; timestamp: string }[]> = {


### PR DESCRIPTION
## 작업 내용
- 채팅방 목록 UI를 채널 / 팀 채팅방 / 개인 대화 3개 섹션으로 재구성
- 팀 채팅방 진입·전환 흐름 구현 (목록·상세에서 팀방을 명확히 구분)
- 채팅방 나가기 기능 추가 (헤더 ⋮ 메뉴 + 확인 모달)
- Channel 모델에 type(GENERAL/TEAM/DIRECT)·memberCount 추가, mock 채널 보강

## 변경 이유
- 기존 채팅 화면은 메시지 송수신 중심이라 팀 채팅방/채널 전환 경험이 제한적이었음
- 채팅방 나가기와 방별 상태 관리 UI가 없어, 사용자가 참여 방을 정리할 수 없었음
- 목적: 팀 채팅방을 한눈에 구분해 진입/전환하고, 나가기 동작을 UI에서 제공

## 상세 변경 사항
### 주요 변경
- [ ]  채팅방 목록 UI 개선 — 섹션 분리(채널/ 팀 채팅방/ 개인 대화), 채널 종류 아이콘(# Hash / Users), 팀방 멤버 수 표시
- [ ]  팀 채팅방 진입/전환 UI — Channel.type·memberCount 추가, 목록에서 보라색 팀 아이콘으로 구분 + 상세 헤더 "팀" 배지, 클릭 시 진입/전환
- [ ]  채팅방 나가기 버튼 및 확인 UI — 헤더 ⋮ 드롭다운(알림 켜기·끄기 / 채팅방 나가기) + 나가기 확인 모달, 나간 방은 목록에서 제외되고 남은 방으로 자동 전환

### 추가 메모
- 나가기는 팀 채팅방에만 노출 (전체 공지 채널·DM은 나가기 불가).
- 나간 방 목록은 #403 방침대로 쿠키(chat-left-channels)에 영속화. 전체 채널 목록(API 응답)에는 그대로 두고 visibleChannels에서만 필터링 → 백엔드 join/leave API 연동 시 교체 용이.
- Channel.type은 백엔드(#49~#53, GENERAL/TEAM/DIRECT)와 동일하게 맞춰 forward-compatible. 현재는 mock(MSW) 기반이라 mock 채널에 type/memberCount 부여 + 팀 채널 2개(마케팅/프로덕트) 추가.
- 이 브랜치는 feat/#403-... 위에 스택되어 있음 → #403 머지 후 리베이스 권장 (단독 머지 시 #403 변경분이 함께 들어감).

## 테스트

-  npm run test:run — 60개 파일 / 443개 테스트 통과 (ChatProvider 나가기 테스트 추가, chatApi/Chat 테스트 갱신)
-  npm run build — 통과
-  브라우저에서 주요 동작 확인 (리뷰어 확인 요청: 팀방 진입/전환, 나가기 후 자동 전환, 새로고침 후 나간 방 유지)

## 리뷰 포인트
- 나가기 후 활성 방 전환 로직 — 현재 보던 방을 나갈 때 leaveChannel이 남은 방 중 첫 번째로 전환하는 동작([ChatProvider.tsx](vscode-webview://03u1b68fpr0fup2cjp5louob1mju9onkvm4of378jbpvb65h0bms/new-yanus-fe/src/features/chat/model/ChatProvider.tsx))
- 방 구분 기준 — type === 'TEAM' 기준으로 목록 섹션/배지/나가기 노출을 분기. type 미지정 채널은 일반 채널로 처리
- 영속화 위치 — 나간 방을 쿠키에 저장하고 visibleChannels에서 필터링하는 방식이 이후 백엔드 연동과 호환되는지
- 드롭다운 UX — ⋮ 메뉴의 외부 클릭 닫힘 / 채널 전환 시 닫힘 처리

## 관련 이슈
- closes #404 
