### PR TITLE
[Feat] #417 - GA4 분석 연동

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ VITE_API_BASE_URL=http://localhost:8080
 
 # MSW Mock 활성화 (true: mock 사용, false 또는 미설정: 실제 API 사용)
 VITE_USE_MOCK=true
+
+# Google Analytics 4 Measurement ID
+VITE_GA_MEASUREMENT_ID=G-JGZ8JFGKPW

--- a/README.md
+++ b/README.md
@@ -191,6 +191,9 @@ VITE_AI_API_URL=<your-ollama-api-url>
 
 # 사용할 AI 모델명
 VITE_AI_API_MODEL=llama3.1
+
+# Google Analytics 4 Measurement ID
+VITE_GA_MEASUREMENT_ID=G-JGZ8JFGKPW
 ```
 
 > **백엔드 API 연동**  

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { GoogleAnalytics } from '../features/analytics/ui/GoogleAnalytics'
 import { Layout } from '../widgets/Layout'
 import { PrivateRoute } from '../shared/ui/PrivateRoute'
 import { AdminRoute } from '../shared/ui/AdminRoute'
@@ -21,6 +22,7 @@ import { TeamManagement } from '../pages/team-management'
 export function AppRouter() {
   return (
     <BrowserRouter>
+      <GoogleAnalytics />
       <Routes>
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />

--- a/src/features/analytics/model/__tests__/googleAnalytics.test.ts
+++ b/src/features/analytics/model/__tests__/googleAnalytics.test.ts
@@ -35,11 +35,10 @@ describe('createGoogleAnalyticsClient', () => {
       'id=G-TEST123',
     )
     expect(window.dataLayer).toHaveLength(2)
-    expect(Array.from(window.dataLayer?.[1] ?? [])).toEqual([
-      'config',
-      'G-TEST123',
-      { send_page_view: false },
-    ])
+    const configCommand = window.dataLayer?.[1]
+    expect(configCommand?.[0]).toBe('config')
+    expect(configCommand?.[1]).toBe('G-TEST123')
+    expect(configCommand?.[2]).toEqual({ send_page_view: false })
   })
 
   it('Given a configured client, When the same route is reported twice, Then it sends one page view per route', () => {

--- a/src/features/analytics/model/__tests__/googleAnalytics.test.ts
+++ b/src/features/analytics/model/__tests__/googleAnalytics.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  createGoogleAnalyticsClient,
+  getGoogleAnalyticsMeasurementId,
+  type GoogleAnalyticsClient,
+} from '../googleAnalytics'
+
+const environment = { window, document } as const
+
+afterEach(() => {
+  document.querySelectorAll('script[data-yanus-ga4]').forEach((script) => script.remove())
+  window.dataLayer = undefined
+  window.gtag = undefined
+})
+
+describe('getGoogleAnalyticsMeasurementId', () => {
+  it('Given a trimmed GA4 measurement ID, When parsed, Then it returns the normalized ID', () => {
+    expect(getGoogleAnalyticsMeasurementId('  G-JGZ8JFGKPW  ')).toBe('G-JGZ8JFGKPW')
+  })
+
+  it('Given a missing or non-GA4 ID, When parsed, Then it disables analytics', () => {
+    expect(getGoogleAnalyticsMeasurementId(undefined)).toBeNull()
+    expect(getGoogleAnalyticsMeasurementId('UA-123456')).toBeNull()
+  })
+})
+
+describe('createGoogleAnalyticsClient', () => {
+  it('Given a valid ID, When initialized, Then it queues the GA4 config without an automatic page view', () => {
+    const client = createGoogleAnalyticsClient('G-TEST123', environment)
+
+    client.initialize()
+
+    expect(document.querySelector('script[data-yanus-ga4]')).not.toBeNull()
+    expect(document.querySelector<HTMLScriptElement>('script[data-yanus-ga4]')?.src).toContain(
+      'id=G-TEST123',
+    )
+    expect(window.dataLayer).toHaveLength(2)
+    expect(Array.from(window.dataLayer?.[1] ?? [])).toEqual([
+      'config',
+      'G-TEST123',
+      { send_page_view: false },
+    ])
+  })
+
+  it('Given a configured client, When the same route is reported twice, Then it sends one page view per route', () => {
+    const client = createGoogleAnalyticsClient('G-TEST123', environment)
+
+    client.pageView({ path: '/calendar', title: '캘린더', location: 'https://yanus.test/calendar' })
+    client.pageView({ path: '/calendar', title: '캘린더', location: 'https://yanus.test/calendar' })
+    client.pageView({ path: '/chat', title: '채팅', location: 'https://yanus.test/chat' })
+
+    expect(window.dataLayer?.filter((command) => String(command[0]) === 'event')).toHaveLength(2)
+  })
+
+  it('Given no measurement ID, When analytics is initialized, Then it does not add a script or data layer', () => {
+    const client = createGoogleAnalyticsClient(null, environment)
+
+    client.initialize()
+    client.pageView({ path: '/', title: '홈', location: 'https://yanus.test/' })
+
+    expect(document.querySelector('script[data-yanus-ga4]')).toBeNull()
+    expect(window.dataLayer).toBeUndefined()
+  })
+})
+
+describe('GoogleAnalyticsClient contract', () => {
+  it('describes the client methods used by the route tracker', () => {
+    const client: GoogleAnalyticsClient = {
+      initialize: vi.fn(),
+      pageView: vi.fn(),
+    }
+
+    client.initialize()
+    client.pageView({ path: '/', title: '홈', location: 'https://yanus.test/' })
+
+    expect(client.initialize).toHaveBeenCalledOnce()
+    expect(client.pageView).toHaveBeenCalledOnce()
+  })
+})

--- a/src/features/analytics/model/googleAnalytics.ts
+++ b/src/features/analytics/model/googleAnalytics.ts
@@ -1,0 +1,98 @@
+export type GoogleAnalyticsPageView = Readonly<{
+  path: string
+  title: string
+  location: string
+}>
+
+export type GoogleAnalyticsClient = Readonly<{
+  initialize: () => void
+  pageView: (page: GoogleAnalyticsPageView) => void
+}>
+
+type GoogleAnalyticsConfig = Readonly<{
+  send_page_view: false
+}>
+
+type GoogleAnalyticsPageViewParameters = Readonly<{
+  page_title: string
+  page_location: string
+  page_path: string
+}>
+
+type GoogleAnalyticsCommand =
+  | readonly ['js', Date]
+  | readonly ['config', string, GoogleAnalyticsConfig]
+  | readonly ['event', 'page_view', GoogleAnalyticsPageViewParameters]
+
+type GoogleAnalyticsEnvironment = Readonly<{
+  window: Window
+  document: Document
+}>
+
+declare global {
+  interface Window {
+    dataLayer?: GoogleAnalyticsCommand[]
+    gtag?: (...command: GoogleAnalyticsCommand) => void
+  }
+}
+
+const GA4_MEASUREMENT_ID_PATTERN = /^G-[A-Z0-9]+$/i
+const GOOGLE_ANALYTICS_SCRIPT_SELECTOR = 'script[data-yanus-ga4]'
+const GOOGLE_ANALYTICS_SCRIPT_ATTRIBUTE = 'data-yanus-ga4'
+
+export function getGoogleAnalyticsMeasurementId(rawMeasurementId: unknown): string | null {
+  if (typeof rawMeasurementId !== 'string') {
+    return null
+  }
+
+  const measurementId = rawMeasurementId.trim()
+  return GA4_MEASUREMENT_ID_PATTERN.test(measurementId) ? measurementId : null
+}
+
+export function createGoogleAnalyticsClient(
+  measurementId: string | null,
+  environment: GoogleAnalyticsEnvironment,
+): GoogleAnalyticsClient {
+  let isInitialized = false
+  let lastPagePath: string | null = null
+
+  const initialize = (): void => {
+    if (!measurementId || isInitialized) {
+      return
+    }
+
+    environment.window.dataLayer ??= []
+    environment.window.gtag ??= (...command: GoogleAnalyticsCommand): void => {
+      environment.window.dataLayer?.push(command)
+    }
+
+    if (!environment.document.querySelector(GOOGLE_ANALYTICS_SCRIPT_SELECTOR)) {
+      const script = environment.document.createElement('script')
+      script.async = true
+      script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(measurementId)}`
+      script.setAttribute(GOOGLE_ANALYTICS_SCRIPT_ATTRIBUTE, measurementId)
+      environment.document.head.appendChild(script)
+    }
+
+    environment.window.gtag?.('js', new Date())
+    environment.window.gtag?.('config', measurementId, { send_page_view: false })
+    isInitialized = true
+  }
+
+  const pageView = (page: GoogleAnalyticsPageView): void => {
+    initialize()
+
+    if (!measurementId || lastPagePath === page.path) {
+      return
+    }
+
+    environment.window.gtag?.('event', 'page_view', {
+      page_title: page.title,
+      page_location: page.location,
+      page_path: page.path,
+    })
+    lastPagePath = page.path
+  }
+
+  return { initialize, pageView }
+}

--- a/src/features/analytics/ui/GoogleAnalytics.tsx
+++ b/src/features/analytics/ui/GoogleAnalytics.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+import {
+  createGoogleAnalyticsClient,
+  getGoogleAnalyticsMeasurementId,
+  type GoogleAnalyticsClient,
+} from '../model/googleAnalytics'
+
+const measurementId = getGoogleAnalyticsMeasurementId(import.meta.env.VITE_GA_MEASUREMENT_ID)
+const defaultClient = createGoogleAnalyticsClient(measurementId, { window, document })
+
+type GoogleAnalyticsProps = Readonly<{
+  client?: GoogleAnalyticsClient
+}>
+
+export function GoogleAnalytics({ client = defaultClient }: GoogleAnalyticsProps) {
+  const location = useLocation()
+  const pagePath = location.pathname
+  const pageLocation = `${window.location.origin}${pagePath}`
+
+  useEffect(() => {
+    client.initialize()
+  }, [client])
+
+  useEffect(() => {
+    client.pageView({
+      path: pagePath,
+      title: document.title,
+      location: pageLocation,
+    })
+  }, [client, pageLocation, pagePath])
+
+  return null
+}

--- a/src/features/analytics/ui/__tests__/GoogleAnalytics.test.tsx
+++ b/src/features/analytics/ui/__tests__/GoogleAnalytics.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes, Link } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+import { GoogleAnalytics } from '../GoogleAnalytics'
+import type { GoogleAnalyticsClient } from '../../model/googleAnalytics'
+
+describe('GoogleAnalytics route tracker', () => {
+  it('tracks the initial route and each SPA navigation', async () => {
+    const user = userEvent.setup()
+    const client: GoogleAnalyticsClient = {
+      initialize: vi.fn(),
+      pageView: vi.fn(),
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <GoogleAnalytics client={client} />
+        <Routes>
+          <Route path="*" element={<Link to="/calendar">캘린더</Link>} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(client.initialize).toHaveBeenCalledOnce()
+    expect(client.pageView).toHaveBeenCalledWith(expect.objectContaining({ path: '/' }))
+
+    await user.click(screen.getByRole('link', { name: '캘린더' }))
+
+    expect(client.pageView).toHaveBeenLastCalledWith(expect.objectContaining({ path: '/calendar' }))
+  })
+})


### PR DESCRIPTION
## 작업 내용

- Google Analytics 4 Google tag를 `VITE_GA_MEASUREMENT_ID` 환경변수로 연결했습니다.
- React Router 기반 SPA에서 초기 진입과 경로 변경마다 `page_view`를 전송합니다.
- `send_page_view: false`로 자동 history page view를 끄고, 앱 라우터가 한 번씩만 수동 전송하도록 구성했습니다.
- 기존 API, 인증, 권한, Vercel Analytics, 사용자 입력 흐름은 변경하지 않았습니다.

## 변경 이유

- yANUs Groupware의 실제 화면 사용 흐름을 GA4에서 확인할 수 있어야 합니다.
- Measurement ID와 analytics 스크립트를 코드에 하드코딩하지 않고 배포 환경에서 주입합니다.
- 페이지 경로·제목·origin만 전송하고 입력값, 토큰, API 응답 데이터는 이벤트 파라미터에 포함하지 않습니다.

## 상세 변경 사항

- [x] GA4 Measurement ID 형식 파싱 및 미설정 fallback
- [x] Google tag script 지연 로드와 dataLayer 초기화
- [x] 초기 `page_view` 및 React Router SPA 이동 추적
- [x] 동일 경로 중복 `page_view` 방지
- [x] `G-...` Measurement ID 환경변수 예시를 `.env.example`와 README에 문서화
- [x] RED → GREEN 테스트와 route tracker 테스트 추가
- [ ] Vercel Production/Preview 환경에 `VITE_GA_MEASUREMENT_ID` 등록

범위 밖:
- GA4 속성 생성, 보고서/이벤트 설정, 개인정보처리방침·동의 배너는 이번 코드 변경 범위에 포함하지 않았습니다.
- Vercel CLI 인증 토큰 만료로 원격 환경변수 등록은 아직 수행하지 못했습니다.

## 테스트

- [x] `npm run test:run`: 64개 파일, 463개 테스트 통과
- [x] `npm run build` 통과
- [x] 변경 파일 대상 `npx eslint` 통과
- [ ] 전체 `npm run lint`: 기존 baseline 오류 24개와 경고 4개
- [x] Chromium smoke: GA script 1개, `/login → /register` page_view 2건, document width 1280
- [x] Measurement ID 주입 환경에서 dataLayer config와 page_view payload 확인

## 리뷰 포인트

- `send_page_view: false`와 React Router 수동 추적의 중복 방지
- StrictMode에서도 초기 page_view가 한 번만 기록되는 client dedupe
- 환경변수 미설정 시 외부 script가 로드되지 않는 fallback
- page_location/page_path에 사용자 입력·토큰이 유입되지 않는지 확인
- Vercel Production/Preview 환경변수 등록 후 Tag Assistant 또는 GA4 Realtime 검증

## 관련 이슈

closes #417

develop 머지 후 이슈는 검증 코멘트와 함께 완료 처리합니다. 기존 release PR #416은 develop 반영 후 GA4 커밋을 포함하도록 갱신됩니다.